### PR TITLE
fix: node-pty spawn-helper permissions on macOS with pnpm

### DIFF
--- a/bridge/src/voice.ts
+++ b/bridge/src/voice.ts
@@ -25,6 +25,11 @@ function findBinary(candidates: string[], fallback: string): string {
 
 /** Check if a whisper-cli binary has Metal GPU support (native arm64 + libggml-metal). */
 function detectMetal(whisperPath: string): boolean {
+  // Skip if whisper-cli doesn't exist (just a fallback name, not installed)
+  if (!existsSync(whisperPath)) {
+    debug('Voice', `whisper-cli not found, skipping Metal detection`);
+    return false;
+  }
   try {
     const otoolOut = execSync(`otool -L "${whisperPath}"`, { encoding: 'utf8' });
     const hasMetal = otoolOut.includes('libggml-metal');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "generate-icons": "node scripts/generate-icons.mjs",
     "package": "bash scripts/package-plugin.sh",
     "setup": "bash scripts/install.sh",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "bash scripts/postinstall.sh"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Fix node-pty spawn-helper permissions (pnpm doesn't preserve execute bits from prebuilds)
+
+find node_modules -path "*node-pty*/prebuilds/darwin-*/spawn-helper" 2>/dev/null | while read -r SPAWN_HELPER; do
+  if [ -n "$SPAWN_HELPER" ] && [ ! -x "$SPAWN_HELPER" ]; then
+    chmod +x "$SPAWN_HELPER"
+    echo "[postinstall] Fixed spawn-helper permissions: $SPAWN_HELPER"
+  fi
+done


### PR DESCRIPTION
pnpm doesn't preserve execute bits from node-pty prebuilds, causing posix_spawnp to fail when spawning PTY processes.

- Add postinstall script to chmod +x spawn-helper for darwin-*
- Skip otool Metal detection when whisper-cli isn't installed