### PR TITLE
fix: session slots empty on first launch (4 root causes)

### DIFF
--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -671,6 +671,8 @@ export async function startSession(opts: SessionOptions): Promise<void> {
       core.wsServer.broadcastExcept(cachedSlotMap, sender);
       broadcastSse(cachedSlotMap);
       core.broadcast(computeButtonState());
+      // Re-send sessions_list so slot buttons populate after plugin startup race
+      core.broadcastSessionsList().catch(() => {});
       return true;
     }
     return false;

--- a/bridge/src/session-aggregator.ts
+++ b/bridge/src/session-aggregator.ts
@@ -44,12 +44,13 @@ export async function enrichSessionsWithState(
 
 /**
  * Build an enriched sessions list for multi-session display.
+ * Always includes the own session so single-session mode (agentdeck claude) shows the active session.
  */
 export async function buildEnrichedSessionsList(
   ownSessionId: string,
   ownState: string,
 ): Promise<EnrichedSession[]> {
-  const siblings = listActiveSessions().filter(s => s.agentType !== 'daemon' && s.id !== ownSessionId);
-  const enriched = await enrichSessionsWithState(siblings, ownSessionId, ownState);
+  const all = listActiveSessions().filter(s => s.agentType !== 'daemon');
+  const enriched = await enrichSessionsWithState(all, ownSessionId, ownState);
   return sortSessions(enriched);
 }

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -444,6 +444,8 @@ connMgr.on('display_state', (ev: { type: 'display_state'; displayOn: boolean }) 
 connMgr.on('connected', () => {
   dinfo('Plugin', `connected (agentType=${proxiedAgentType} prevState=${currentState})`);
   setDaemonConnected(true);
+  // Re-send slot map so bridge knows our layout (covers bridge-starts-after-plugin case)
+  sendSlotMap();
   // Request fresh usage data immediately on connect (covers sleep/wake recovery)
   connMgr.send({ type: 'query_usage' });
 });

--- a/shared/src/svg-renderers/agent-logos.ts
+++ b/shared/src/svg-renderers/agent-logos.ts
@@ -1,0 +1,153 @@
+/**
+ * Agent logo SVG paths for icon and watermark rendering on session buttons.
+ *
+ * Each logo is a centered path designed for a 144x144 button canvas.
+ * Two rendering modes:
+ *   agentLogoIcon()      — prominent icon at top of button (primary identification)
+ *   agentLogoWatermark()  — low-opacity background mark
+ */
+
+import type { AgentType } from '../adapter.js';
+import { dimColor, agentBrandColor } from '../state-colors.js';
+
+/**
+ * Claude Code Antigravity robot — official logo from claudecode.svg.
+ * viewBox 0 0 24 24. fill-rule: evenodd (eyes are transparent cutouts).
+ */
+export const CLAUDE_LOGO_PATH =
+  'M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z';
+
+/**
+ * OpenClaw lobster — official logo paths from openclaw.ai brand assets.
+ * Original viewBox 0 0 120 120, rendered at 1:1 inside 144x144 button.
+ * Source: Dashboard Icons (CC-BY-4.0)
+ */
+export const OC_BODY =
+  'M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z';
+export const OC_CLAW_L =
+  'M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z';
+export const OC_CLAW_R =
+  'M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z';
+const OC_ANTENNA_L = 'M45 15 Q35 5 30 8';
+const OC_ANTENNA_R = 'M75 15 Q85 5 90 8';
+
+/** Codex CLI knot/clover — official SVG from codex brand assets. viewBox 0 0 24 24. */
+export const CODEX_LOGO_PATH =
+  'M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388z';
+
+// ===== Prominent agent icon (top of button, primary identification) =====
+
+/**
+ * Render agent logo as a visible icon at top-center of button.
+ * Uses agent brand color (not state color) for consistent identification.
+ * @param agent Agent type
+ * @param size Target size in px (default 48)
+ * @param opacity Icon opacity (default 0.7)
+ */
+export function agentLogoIcon(
+  agent: AgentType,
+  size = 48,
+  opacity = 0.7,
+): string {
+  const brandColor = agentBrandColor(agent);
+  // Center icon slightly below top — can overlap with text for compact layout
+  const cy = size / 2 + 12;
+
+  if (agent === 'claude-code') {
+    const s = size / 24;
+    return `<g transform="translate(72,${cy}) scale(${s.toFixed(2)}) translate(-12,-12)" opacity="${opacity}"><path d="${CLAUDE_LOGO_PATH}" fill="${brandColor}" fill-rule="evenodd"/></g>`;
+  }
+  if (agent === 'codex-cli') {
+    const s = size / 24;
+    return [
+      `<defs><linearGradient id="cx-i" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#B1A7FF"/><stop offset="48%" stop-color="#7A9DFF"/><stop offset="100%" stop-color="${brandColor}"/></linearGradient></defs>`,
+      `<g transform="translate(72,${cy}) scale(${s.toFixed(2)}) translate(-12,-12)" opacity="${opacity}"><path d="${CODEX_LOGO_PATH}" fill="url(#cx-i)"/></g>`,
+    ].join('');
+  }
+  if (agent === 'opencode') {
+    // Smaller icon for OpenCode (geometric squares are visually heavier)
+    const ocSize = Math.round(size * 0.75);
+    const half = ocSize / 2;
+    const ring = ocSize * 0.18;
+    const inner = ocSize * 0.5;
+    return [
+      `<g opacity="${opacity}">`,
+      `<rect x="${72 - half}" y="${cy - half}" width="${ocSize}" height="${ocSize}" rx="4" fill="${dimColor(brandColor, 0.3)}"/>`,
+      `<rect x="${72 - half + ring}" y="${cy - half + ring}" width="${ocSize - ring * 2}" height="${ocSize - ring * 2}" rx="2" fill="${dimColor('#4B4646', 0.2)}"/>`,
+      `<rect x="${72 - inner / 2}" y="${cy - inner / 2}" width="${inner}" height="${inner}" rx="2" fill="${dimColor('#4B4646', 0.2)}"/>`,
+      `</g>`,
+    ].join('');
+  }
+  // OpenClaw lobster
+  const ocScale = size / 120;
+  return [
+    `<defs><linearGradient id="oc-i" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="${brandColor}"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs>`,
+    `<g transform="translate(${72 - 60 * ocScale},${cy - 60 * ocScale}) scale(${ocScale.toFixed(3)})" opacity="${opacity}">`,
+    `<path d="${OC_BODY}" fill="url(#oc-i)"/>`,
+    `<path d="${OC_CLAW_L}" fill="url(#oc-i)"/>`,
+    `<path d="${OC_CLAW_R}" fill="url(#oc-i)"/>`,
+    `<path d="${OC_ANTENNA_L}" stroke="${brandColor}" stroke-width="3" stroke-linecap="round" fill="none"/>`,
+    `<path d="${OC_ANTENNA_R}" stroke="${brandColor}" stroke-width="3" stroke-linecap="round" fill="none"/>`,
+    `<circle cx="45" cy="35" r="6" fill="#0a0a14"/>`,
+    `<circle cx="75" cy="35" r="6" fill="#0a0a14"/>`,
+    `<circle cx="46" cy="34" r="2.5" fill="#00e5cc" opacity="0.7"/>`,
+    `<circle cx="76" cy="34" r="2.5" fill="#00e5cc" opacity="0.7"/>`,
+    `</g>`,
+  ].join('');
+}
+
+// ===== Low-opacity watermark (background mark) =====
+
+/**
+ * Render agent logo as a background watermark.
+ * Uses brand color dimmed for subtle identification.
+ */
+export function agentLogoWatermark(
+  agent: AgentType,
+  _color?: string,
+  opacity = 0.12,
+): string {
+  const brandColor = agentBrandColor(agent);
+  const markOpacity = Math.min(opacity * 4, 0.9);
+  const fill = dimColor(brandColor, 0.5);
+
+  if (agent === 'claude-code') {
+    return `<g transform="translate(72,72) scale(3) translate(-12,-12)" opacity="${markOpacity}"><path d="${CLAUDE_LOGO_PATH}" fill="${fill}" fill-rule="evenodd"/></g>`;
+  }
+  if (agent === 'codex-cli') {
+    return [
+      `<defs><linearGradient id="cx-g" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="${dimColor('#B1A7FF', 0.5)}"/><stop offset="48%" stop-color="${dimColor('#7A9DFF', 0.5)}"/><stop offset="100%" stop-color="${dimColor('#3941FF', 0.5)}"/></linearGradient></defs>`,
+      `<g transform="translate(72,72) scale(3) translate(-12,-12)" opacity="${markOpacity}"><path d="${CODEX_LOGO_PATH}" fill="url(#cx-g)"/></g>`,
+    ].join('');
+  }
+  if (agent === 'opencode') {
+    const s = 72;
+    const half = s / 2;
+    const ring = s * 0.18;
+    const inner = s * 0.5;
+    return [
+      `<g opacity="${markOpacity}">`,
+      `<rect x="${72 - half}" y="${72 - half}" width="${s}" height="${s}" fill="${dimColor('#F1ECEC', 0.6)}"/>`,
+      `<rect x="${72 - half + ring}" y="${72 - half + ring}" width="${s - ring * 2}" height="${s - ring * 2}" fill="${dimColor('#4B4646', 0.5)}"/>`,
+      `<rect x="${72 - inner / 2}" y="${72 - inner / 2}" width="${inner}" height="${inner}" fill="${dimColor('#4B4646', 0.5)}"/>`,
+      `</g>`,
+    ].join('');
+  }
+  // OpenClaw lobster
+  const ocFill1 = dimColor('#ff4d4d', 0.4);
+  const ocFill2 = dimColor('#991b1b', 0.4);
+  return [
+    `<defs><linearGradient id="oc-g" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="${ocFill1}"/><stop offset="100%" stop-color="${ocFill2}"/></linearGradient></defs>`,
+    `<g transform="translate(36,36) scale(0.6)" opacity="${markOpacity}">`,
+    `<path d="${OC_BODY}" fill="url(#oc-g)"/>`,
+    `<path d="${OC_CLAW_L}" fill="url(#oc-g)"/>`,
+    `<path d="${OC_CLAW_R}" fill="url(#oc-g)"/>`,
+    `<path d="${OC_ANTENNA_L}" stroke="${ocFill1}" stroke-width="3" stroke-linecap="round" fill="none"/>`,
+    `<path d="${OC_ANTENNA_R}" stroke="${ocFill1}" stroke-width="3" stroke-linecap="round" fill="none"/>`,
+    `<circle cx="45" cy="35" r="6" fill="#0a0a14"/>`,
+    `<circle cx="75" cy="35" r="6" fill="#0a0a14"/>`,
+    `<circle cx="46" cy="34" r="2.5" fill="${dimColor('#00e5cc', 0.3)}"/>`,
+    `<circle cx="76" cy="34" r="2.5" fill="${dimColor('#00e5cc', 0.3)}"/>`,
+    `</g>`,
+  ].join('');
+}

--- a/shared/src/svg-renderers/index.ts
+++ b/shared/src/svg-renderers/index.ts
@@ -1,0 +1,3 @@
+export * from './text-utils.js';
+export * from './agent-logos.js';
+export * from './session-slot-renderer.js';

--- a/shared/src/svg-renderers/session-slot-renderer.ts
+++ b/shared/src/svg-renderers/session-slot-renderer.ts
@@ -1,0 +1,268 @@
+/**
+ * Session slot button SVG renderer for v4 dynamic layout.
+ *
+ * Renders: session list buttons, detail view info/options/nav buttons.
+ * 144x144 canvas matching SD+ button spec.
+ *
+ * Agent identification: creature icon (agentLogoIcon) at top of button.
+ * State colors: unified palette from shared/state-colors (no agent overrides).
+ */
+import type { SessionInfo } from '../protocol.js';
+import type { PromptOption } from '../states.js';
+import type { AgentType } from '../adapter.js';
+import { State } from '../states.js';
+import { stateColor } from '../state-colors.js';
+import { agentLogoIcon } from './agent-logos.js';
+import { wrapTextByWidth } from './text-utils.js';
+
+const SIZE = 144;
+const MAX_TEXT_PX = 124; // 144 - 10px padding each side
+
+function stateLabel(state?: string, agentType?: AgentType): string {
+  if (!state) return 'OFFLINE';
+  // OpenClaw-specific labels
+  if (agentType === 'openclaw') {
+    if (state === 'idle') return 'STANDBY';
+    if (state === 'processing') return 'ROUTING';
+  }
+  switch (state) {
+    case 'idle': return 'IDLE';
+    case 'processing': return 'WORKING';
+    case 'awaiting_option':
+    case 'awaiting_permission':
+    case 'awaiting_diff':
+      return 'AWAITING';
+    default: return state.toUpperCase();
+  }
+}
+
+function escXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '\u2026';
+}
+
+// ---- Session List Button ----
+
+export function renderSessionSlot(
+  session: SessionInfo,
+  isActive: boolean,
+  animFrame: number,
+  displayName?: string,
+): string {
+  const isAwaiting = session.state?.startsWith('awaiting') ?? false;
+  const agent = (session.agentType as AgentType) || 'claude-code';
+  const sColor = stateColor(session.state);
+  const bgColor = isActive ? '#1e3a5f' : (isAwaiting ? '#2d1810' : '#1a1a2e');
+
+  const nameForDisplay = displayName ?? session.projectName;
+
+  // Project name (main text, bold)
+  const projectName = truncate(nameForDisplay, 16);
+  const projFontSize = projectName.length > 10 ? 16 : 20;
+
+  // Model name
+  const modelText = session.modelName ? truncate(session.modelName, 16) : '';
+
+  // State indicator
+  const stateLbl = stateLabel(session.state, agent);
+
+  // Agent creature icon — primary identification element
+  const icon = agentLogoIcon(agent, 48, 0.7);
+
+  // AWAITING pulse glow border
+  let glowBorder = '';
+  if (isAwaiting) {
+    const pulseOpacity = 0.4 + 0.5 * Math.abs(Math.sin(animFrame * 0.15));
+    glowBorder = [
+      `<defs><filter id="pg" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur in="SourceGraphic" stdDeviation="2"/></filter></defs>`,
+      `<rect x="2" y="2" width="140" height="140" rx="11" fill="none" stroke="${sColor}" stroke-width="2.5" opacity="${pulseOpacity.toFixed(2)}" filter="url(#pg)"/>`,
+      `<rect x="2" y="2" width="140" height="140" rx="11" fill="none" stroke="${sColor}" stroke-width="1.5" opacity="${(pulseOpacity * 0.8).toFixed(2)}"/>`,
+    ].join('');
+  }
+
+  // Active indicator (thin left border)
+  const activeBorder = isActive
+    ? `<rect x="0" y="16" width="3" height="112" rx="1.5" fill="#3b82f6" opacity="0.8"/>`
+    : '';
+
+  // Layout (144px canvas):
+  //   y=4~52:   Agent creature icon (48px, brand-colored)
+  //   y=68:     Project name (bold, white)
+  //   y=86:     Model name (slate)
+  //   y=112:    State dot + label (state-colored)
+  const elements = [
+    icon,
+    glowBorder,
+    activeBorder,
+    // Project name
+    `<text x="72" y="68" text-anchor="middle" font-family="Arial,sans-serif" font-size="${projFontSize}" font-weight="bold" fill="#ffffff">${escXml(projectName)}</text>`,
+    // Model name
+    modelText ? `<text x="72" y="86" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8">${escXml(modelText)}</text>` : '',
+    // State dot + label (centered, bottom)
+    `<text x="72" y="112" text-anchor="middle" font-family="Arial,sans-serif" font-size="14" font-weight="600" fill="${sColor}">\u25CF ${escXml(stateLbl)}</text>`,
+  ].join('');
+
+  return svgFrame(bgColor, elements);
+}
+
+// ---- Empty Slot ----
+
+export function renderEmptySlot(): string {
+  const label = `<text x="72" y="76" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="#333333">Empty</text>`;
+  return svgFrame('#111111', label);
+}
+
+export function renderNoDaemonSlot(slot: number): string {
+  if (slot === 0) {
+    // START button — launches macOS app
+    const elements = [
+      `<text x="72" y="56" text-anchor="middle" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">AgentDeck</text>`,
+      `<text x="72" y="96" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#22c55e">\u25B6 START</text>`,
+    ].join('');
+    return svgFrame('#0f1a0f', elements);
+  }
+  return svgFrame('#111111', '');
+}
+
+// ---- Navigation Buttons ----
+
+export function renderBackButton(): string {
+  const arrow = `<text x="72" y="76" text-anchor="middle" font-family="Arial,sans-serif" font-size="32" fill="#94a3b8">\u2190</text>`;
+  const label = `<text x="72" y="108" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="600" fill="#94a3b8">BACK</text>`;
+  return svgFrame('#1a1a1a', arrow + label);
+}
+
+export function renderNextPageButton(pageLabel: string): string {
+  const arrow = `<text x="72" y="64" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" fill="#60a5fa">\u25B6</text>`;
+  const label = `<text x="72" y="92" text-anchor="middle" font-family="Arial,sans-serif" font-size="14" font-weight="600" fill="#60a5fa">NEXT</text>`;
+  const page = `<text x="72" y="114" text-anchor="middle" font-family="Arial,sans-serif" font-size="11" fill="#64748b">${escXml(pageLabel)}</text>`;
+  return svgFrame('#1a1a2e', arrow + label + page);
+}
+
+export function renderEscButton(active = true): string {
+  const c = active ? '#f97316' : '#a0855a';
+  const bg = active ? '#2d1810' : '#1a1308';
+  const op = active ? '' : ' opacity="0.45"';
+  const elements = [
+    `<text x="72" y="62" text-anchor="middle" font-family="Arial,sans-serif" font-size="32" fill="${c}"${op}>\u2716</text>`,
+    `<text x="72" y="100" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="${c}"${op}>ESC</text>`,
+  ].join('');
+  return svgFrame(bg, elements);
+}
+
+export function renderStopButton(active = true): string {
+  const c = active ? '#ef4444' : '#666666';
+  const bg = active ? '#2d1010' : '#1a0a0a';
+  const op = active ? '' : ' opacity="0.4"';
+  const elements = [
+    `<text x="72" y="62" text-anchor="middle" font-family="Arial,sans-serif" font-size="32" fill="${c}"${op}>\u25A0</text>`,
+    `<text x="72" y="100" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="${c}"${op}>STOP</text>`,
+  ].join('');
+  return svgFrame(bg, elements);
+}
+
+// ---- Detail View: Session Info ----
+
+export function renderDetailInfo(session: SessionInfo | undefined, state: State, tool?: string, modelName?: string, mode?: string, displayName?: string): string {
+  if (!session) return renderEmptySlot();
+
+  const agent = (session.agentType as AgentType) || 'claude-code';
+  const sColor = stateColor(session.state);
+  const stateLbl = stateLabel(session.state, agent);
+  const isOpenClaw = agent === 'openclaw';
+  const nameForDisplay = displayName ?? session.projectName;
+
+  // Detail info layout (144px canvas):
+  //   y=top:    Agent creature icon (small, brand-colored)
+  //   y=50:     project name (bold, white)
+  //   y=72:     model (slate, skip for OpenClaw)
+  //   y=90:     mode (purple, skip for OpenClaw)
+  //   y=106:    tool (yellow)
+  //   y=132:    state dot + label (state-colored)
+  const detailIcon = agentLogoIcon(agent, 36, 0.5);
+
+  const elements = [
+    detailIcon,
+    // Project name (bold, large)
+    `<text x="72" y="50" text-anchor="middle" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="#ffffff">${escXml(truncate(nameForDisplay, 12))}</text>`,
+    // Model (skip for OpenClaw)
+    modelName && !isOpenClaw ? `<text x="72" y="72" text-anchor="middle" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">${escXml(truncate(modelName, 16))}</text>` : '',
+    // Mode (skip for OpenClaw)
+    mode && mode !== 'default' && !isOpenClaw ? `<text x="72" y="90" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="#a78bfa">${escXml(mode.toUpperCase())}</text>` : '',
+    // Tool (if processing)
+    tool ? `<text x="72" y="106" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="#fbbf24">\u25B6 ${escXml(truncate(tool, 16))}</text>` : '',
+    // State (centered, bottom)
+    `<text x="72" y="132" text-anchor="middle" font-family="Arial,sans-serif" font-size="14" font-weight="600" fill="${sColor}">\u25CF ${escXml(stateLbl)}</text>`,
+  ].join('');
+
+  return svgFrame('#0f172a', elements);
+}
+
+// ---- Detail View: Option Button ----
+
+export function renderOptionButton(option: PromptOption, index: number): string {
+  const label = option.label || `Option ${index + 1}`;
+  const lines = wrapTextByWidth(label, MAX_TEXT_PX, 16);
+  const lineHeight = 20;
+  const startY = lines.length === 1 ? 76 : 76 - ((lines.length - 1) * lineHeight) / 2;
+
+  // Slot number (top-right)
+  const slotNum = `<text x="${SIZE - 10}" y="18" text-anchor="end" font-family="Arial,sans-serif" font-size="13" fill="#ffffff" opacity="0.25">${index + 1}</text>`;
+
+  const textEls = lines.slice(0, 3).map((line, i) =>
+    `<text x="72" y="${startY + i * lineHeight}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#ffffff">${escXml(line)}</text>`
+  ).join('');
+
+  // Use different bg colors for visual distinction
+  const colors = ['#1e3a5f', '#1e3a4a', '#2a1e4a', '#1e4a3a', '#3a1e2a'];
+  const bgColor = colors[index % colors.length];
+
+  return svgFrame(bgColor, slotNum + textEls);
+}
+
+// ---- Detail View: Preset Action Button ----
+
+export function renderPresetButton(label: string, iconSvg: string, color: string, textColor: string, subtitle?: string, loading?: boolean): string {
+  if (loading) {
+    return svgFrame(color, iconSvg);
+  }
+  const labelEl = `<text x="72" y="100" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="${textColor}">${escXml(label)}</text>`;
+  const subEl = subtitle
+    ? `<text x="72" y="118" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="${textColor}" opacity="0.7">${escXml(truncate(subtitle, 14))}</text>`
+    : '';
+  return svgFrame(color, iconSvg + labelEl + subEl);
+}
+
+// ---- Detail View: Info slot (tool, model/mode) ----
+
+export function renderInfoSlot(label: string, subtitle?: string): string {
+  const mainEl = `<text x="72" y="${subtitle ? 68 : 76}" text-anchor="middle" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#94a3b8">${escXml(truncate(label, 18))}</text>`;
+  const subEl = subtitle
+    ? `<text x="72" y="92" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="#64748b">${escXml(truncate(subtitle, 22))}</text>`
+    : '';
+  return svgFrame('#1a1a1a', mainEl + subEl);
+}
+
+// ---- SVG Frame ----
+
+export function svgFrame(bgColor: string, innerElements: string, slotNumber?: number): string {
+  const slotLabel = slotNumber != null
+    ? `<text x="${SIZE - 10}" y="18" text-anchor="end" font-family="Arial,sans-serif" font-size="13" fill="#ffffff" opacity="0.3">${slotNumber}</text>`
+    : '';
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${SIZE}" height="${SIZE}" viewBox="0 0 ${SIZE} ${SIZE}">`,
+    `<rect width="${SIZE}" height="${SIZE}" rx="12" fill="${bgColor}"/>`,
+    innerElements,
+    slotLabel,
+    `</svg>`,
+  ].join('');
+}

--- a/shared/src/svg-renderers/text-utils.ts
+++ b/shared/src/svg-renderers/text-utils.ts
@@ -1,0 +1,86 @@
+/**
+ * CJK-aware text measurement utilities.
+ * Extracted from voice-renderer.ts for shared use across renderers.
+ */
+
+const COMBINING_RE = /\p{M}/u;
+
+/** True for CJK / fullwidth characters (Hangul, Kanji, Kana, CJK symbols). */
+export function isWide(code: number): boolean {
+  return (
+    (code >= 0x1100 && code <= 0x11FF) ||   // Hangul Jamo
+    (code >= 0x2E80 && code <= 0x9FFF) ||   // CJK radicals, symbols, ideographs
+    (code >= 0xAC00 && code <= 0xD7AF) ||   // Hangul Syllables
+    (code >= 0xF900 && code <= 0xFAFF) ||   // CJK Compatibility Ideographs
+    (code >= 0xFF00 && code <= 0xFF60) ||   // Fullwidth forms
+    (code >= 0xFFE0 && code <= 0xFFE6)      // Fullwidth signs
+  );
+}
+
+/** Pixel width of a single character at given font size (Arial approximation). */
+export function charPx(ch: string, fontSize: number): number {
+  if (COMBINING_RE.test(ch)) return 0;              // combining marks: zero width
+  if (isWide(ch.charCodeAt(0))) return fontSize;     // CJK: ~1em
+  return fontSize * 0.55;                            // Latin, etc.: ~0.55em
+}
+
+/** Estimate pixel width of a string at given font size (Arial). */
+export function measureTextWidth(text: string, fontSize: number): number {
+  let px = 0;
+  for (const ch of text) px += charPx(ch, fontSize);
+  return px;
+}
+
+/** Slice string so first part fits within maxPx. */
+export function sliceByPx(s: string, maxPx: number, fontSize: number): [string, string] {
+  let px = 0;
+  let i = 0;
+  for (const ch of s) {
+    const cw = charPx(ch, fontSize);
+    if (cw > 0 && px + cw > maxPx) break;
+    px += cw;
+    i += ch.length;
+  }
+  return [s.slice(0, i), s.slice(i)];
+}
+
+/** Word-wrap text by estimated pixel width (works for all scripts). */
+export function wrapTextByWidth(text: string, maxWidthPx: number, fontSize: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+  let currentPx = 0;
+  const spacePx = fontSize * 0.28;
+
+  for (const word of words) {
+    const wordPx = measureTextWidth(word, fontSize);
+
+    if (current && currentPx + spacePx + wordPx > maxWidthPx) {
+      lines.push(current);
+      current = '';
+      currentPx = 0;
+    }
+
+    if (wordPx > maxWidthPx) {
+      if (current) { lines.push(current); current = ''; currentPx = 0; }
+      let rem = word;
+      while (measureTextWidth(rem, fontSize) > maxWidthPx) {
+        const [chunk, rest] = sliceByPx(rem, maxWidthPx, fontSize);
+        lines.push(chunk);
+        rem = rest;
+      }
+      current = rem;
+      currentPx = measureTextWidth(rem, fontSize);
+    } else {
+      if (current) {
+        current += ' ' + word;
+        currentPx += spacePx + wordPx;
+      } else {
+        current = word;
+        currentPx = wordPx;
+      }
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}


### PR DESCRIPTION
## Summary

Session slot buttons were always showing \"Empty\" after installing the plugin and running `agentdeck claude`. Diagnosed and fixed 4 root causes:

- **Missing `shared/src/svg-renderers/`** — commit `8db82ff` added re-exports from this folder but never committed the actual files, breaking `pnpm build` with TS2307. Reconstructed the 4 missing files from the previous commit (`8cdaef6`).
- **Plugin didn't re-send `deck_slot_map` on reconnect** — `sendSlotMap()` is triggered by `onWillAppear` (~5 s after plugin load). When the bridge starts *after* the plugin the first send is dropped. The `connected` handler only sent `query_usage` and never re-sent the slot map, so the bridge had no record of the 8 button slots.
- **Bridge didn't re-broadcast `sessions_list` after receiving slot map** — even with a valid slot map, the bridge only broadcast `button_state` on `deck_slot_map`, not `sessions_list`. Session-slot buttons populate from `sessions_list`, so they stayed empty.
- **`buildEnrichedSessionsList` excluded the own session** — the aggregator filtered `s.id !== ownSessionId`, producing an empty list in single-session mode (`agentdeck claude` without a daemon). Fix: include all non-daemon sessions so single-session mode works. The daemon-server enricher is unaffected.

## Test plan

- [ ] `pnpm build` succeeds from a clean checkout
- [ ] Run `agentdeck claude` in a project directory
- [ ] Session slot button 0 shows the project name + state within a few seconds of connection
- [ ] Restart Stream Deck app while bridge is running — slots repopulate after reconnect
- [ ] Daemon multi-session mode (`agentdeck daemon start` + multiple `agentdeck claude` sessions) still shows all sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)