### PR TITLE
fix(slots): session slots empty on first launch — startup race + own-session filter

### DIFF
--- a/bridge/src/__tests__/session-aggregator.test.ts
+++ b/bridge/src/__tests__/session-aggregator.test.ts
@@ -158,7 +158,7 @@ describe('session-aggregator', () => {
     expect(sessions[0].state).toBeUndefined();
   });
 
-  it('buildEnrichedSessionsList excludes daemon and own session before enrichment', async () => {
+  it('buildEnrichedSessionsList includes own session and excludes daemon', async () => {
     mockListActive.mockReturnValue([
       makeSession({ id: 'own-session', port: 9121, projectName: 'Main' }),
       makeSession({ id: 'daemon-1', port: 9120, projectName: 'Daemon', agentType: 'daemon' }),
@@ -177,15 +177,24 @@ describe('session-aggregator', () => {
       throw new Error(`unexpected url: ${url}`);
     });
 
-    const sessions = await buildEnrichedSessionsList('own-session', 'awaiting_option');
+    const sessions = await buildEnrichedSessionsList('own-session', 'awaiting_option', 'opus-4', 'high');
 
-    expect(sessions).toHaveLength(2);
+    // Order from sortSessions: claude-code group sorted by projectName (Backend, Main)
+    // then codex-cli group (Frontend). Daemon excluded.
+    expect(sessions).toHaveLength(3);
     expect(sessions).toEqual([
       expect.objectContaining({
         id: 'sibling-1',
         projectName: 'Backend',
         state: 'processing',
         modelName: 'opus-4',
+      }),
+      expect.objectContaining({
+        id: 'own-session',
+        projectName: 'Main',
+        state: 'awaiting_option',
+        modelName: 'opus-4',
+        effortLevel: 'high',
       }),
       expect.objectContaining({
         id: 'sibling-2',
@@ -195,5 +204,26 @@ describe('session-aggregator', () => {
         agentType: 'codex-cli',
       }),
     ]);
+  });
+
+  it('buildEnrichedSessionsList returns own session in single-session mode without /health calls', async () => {
+    // single-session mode: only the own session is registered (no daemon, no siblings).
+    // This is the `agentdeck claude` standalone case where session-slot buttons would
+    // otherwise stay "Empty" because the aggregator returned [].
+    mockListActive.mockReturnValue([
+      makeSession({ id: 'own-session', port: 9121, projectName: 'Solo' }),
+    ]);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const sessions = await buildEnrichedSessionsList('own-session', 'idle', 'opus-4');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toEqual(expect.objectContaining({
+      id: 'own-session',
+      projectName: 'Solo',
+      state: 'idle',
+      modelName: 'opus-4',
+    }));
   });
 });

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -892,6 +892,15 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       }
       return true; // consumed
     }
+    if (msg.type === 'deck_slot_map') {
+      // Plugin pushed its keypad layout. Forward to other viewers (extra
+      // plugin instance, dashboard) and re-broadcast sessions_list so slot
+      // buttons populate immediately — without this they would stay "Empty"
+      // until the next 10 s sessions polling tick after the plugin connect.
+      core.wsServer.broadcastExcept(msg as unknown as BridgeEvent, sender);
+      core.broadcastSessionsList().catch(() => {});
+      return true; // consumed
+    }
     return false; // not consumed — pass to command handler
   });
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -844,6 +844,8 @@ export async function startSession(opts: SessionOptions): Promise<void> {
       core.wsServer.broadcastExcept(cachedSlotMap, sender);
       broadcastSse(cachedSlotMap);
       core.broadcast(computeButtonState());
+      // Re-broadcast sessions_list so slot buttons populate after plugin startup race
+      core.broadcastSessionsList().catch(() => {});
       return true;
     }
     return false;

--- a/bridge/src/session-aggregator.ts
+++ b/bridge/src/session-aggregator.ts
@@ -93,6 +93,10 @@ export async function enrichSessionsWithState(
 
 /**
  * Build an enriched sessions list for multi-session display.
+ *
+ * Includes the own session so single-session mode (`agentdeck claude` without a daemon)
+ * still surfaces the active session. The daemon-server enricher overrides this list in
+ * multi-session setups, so per-session bridges keeping their own entry is safe.
  */
 export async function buildEnrichedSessionsList(
   ownSessionId: string,
@@ -100,7 +104,7 @@ export async function buildEnrichedSessionsList(
   ownModelName?: string,
   ownEffortLevel?: string,
 ): Promise<EnrichedSession[]> {
-  const siblings = listActiveSessions().filter(s => s.agentType !== 'daemon' && s.id !== ownSessionId);
-  const enriched = await enrichSessionsWithState(siblings, ownSessionId, ownState, ownModelName, ownEffortLevel);
+  const all = listActiveSessions().filter(s => s.agentType !== 'daemon');
+  const enriched = await enrichSessionsWithState(all, ownSessionId, ownState, ownModelName, ownEffortLevel);
   return sortSessions(enriched);
 }

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -525,6 +525,10 @@ connMgr.on('display_state', (ev: { type: 'display_state'; displayOn: boolean }) 
 connMgr.on('connected', () => {
   dinfo('Plugin', `connected (agentType=${proxiedAgentType} prevState=${currentState})`);
   setDaemonConnected(true);
+  // Re-send slot map so bridge knows our layout when the WS comes up after
+  // the plugin has already loaded (onWillAppear's first send may have been
+  // dropped because the bridge was not yet connected).
+  sendSlotMap();
   // Announce ourselves so the daemon's Dashboard → Downstream rail can
   // surface a "Stream Deck" row with the physical devices this plugin
   // sees. Without this the daemon treats the WS as an anonymous viewer.


### PR DESCRIPTION
## Summary

Re-takes #4 — rebased onto current `master` and reduced to the three still-applicable fixes. Diagnosis credit to @pakuda; preserved via `Co-Authored-By` trailer.

Three independent root causes left session-slot buttons stuck on "Empty" after a clean install / first launch:

- **Plugin didn't re-send `deck_slot_map` on reconnect** — `sendSlotMap()` is triggered by `onWillAppear` (~5 s after plugin load). When the bridge starts *after* the plugin the first send is dropped. The `connected` handler only sent `client_register` + `query_usage` and never re-sent the slot map, so the bridge had no record of the button slots. Fix: call `sendSlotMap()` at the top of the `connected` handler.
- **Bridge didn't re-broadcast `sessions_list` after `deck_slot_map`** — even with a valid slot map, the bridge only broadcast `button_state`. Session-slot buttons populate from `sessions_list`, so they stayed empty. Fix: call `core.broadcastSessionsList()` in the `deck_slot_map` raw message handler.
- **`buildEnrichedSessionsList` excluded the own session** — the aggregator filtered `s.id !== ownSessionId`, producing an empty list in single-session mode (`agentdeck claude` without a daemon). Fix: include all non-daemon sessions; the daemon-server enricher continues to override this list in multi-session setups.

The `shared/src/svg-renderers/*` reconstruction from #4 is dropped — `0d8da018` already added the missing files and they've evolved further in `08ec688c` / `b7e682ae` / `38dd7f46` / `56ab762d` / `a50c9b23`.

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm test` — 1015/1015 passing (incl. updated + new aggregator cases)
- [ ] `agentdeck claude` standalone — slot 0 shows project name + state within ~5 s of connection
- [ ] Restart Stream Deck app while bridge is running — slots repopulate after reconnect
- [ ] `agentdeck daemon start` + multiple `agentdeck claude` sessions — all sessions appear

`session-aggregator.test.ts`:
- existing case `"buildEnrichedSessionsList excludes daemon and own session before enrichment"` renamed to `"includes own session and excludes daemon"`, length `2 → 3`, ordering reflects `sortSessions` (`Backend` < `Main` within `claude-code` group, then `codex-cli`)
- new case `"returns own session in single-session mode without /health calls"` covers the standalone `agentdeck claude` path that #4 was originally diagnosing

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)