### PR TITLE
chore(ci): cross-platform sed in generate-protocol + sync drift

### DIFF
--- a/generated/protocol/BridgeEvent.kt
+++ b/generated/protocol/BridgeEvent.kt
@@ -26,6 +26,7 @@ private val klaxon = Klaxon()
     .convert(PromptType::class,          { PromptType.fromValue(it.string!!) },          { "\"${it.value}\"" })
     .convert(Layer::class,               { Layer.fromValue(it.string!!) },               { "\"${it.value}\"" })
     .convert(Outcome::class,             { Outcome.fromValue(it.string!!) },             { "\"${it.value}\"" })
+    .convert(ControlMode::class,         { ControlMode.fromValue(it.string!!) },         { "\"${it.value}\"" })
     .convert(State::class,               { State.fromValue(it.string!!) },               { "\"${it.value}\"" })
     .convert(BridgeEventStatus::class,   { BridgeEventStatus.fromValue(it.string!!) },   { "\"${it.value}\"" })
     .convert(TokenStatus::class,         { TokenStatus.fromValue(it.string!!) },         { "\"${it.value}\"" })
@@ -684,14 +685,33 @@ data class OcSessionStatus (
 data class SessionInfo (
     val agentType: AgentType? = null,
     val alive: Boolean,
+    val contextPercent: Double? = null,
+    val controlMode: ControlMode? = null,
+    val currentTask: String? = null,
+    val cwd: String? = null,
     val effortLevel: String? = null,
     val id: String,
     val modelName: String? = null,
+    val pid: Double? = null,
     val port: Double,
     val projectName: String,
     val startedAt: String? = null,
-    val state: String? = null
+    val state: String? = null,
+    val totalTokens: Double? = null
 )
+
+enum class ControlMode(val value: String) {
+    Managed("managed"),
+    Observed("observed");
+
+    companion object {
+        public fun fromValue(value: String): ControlMode = when (value) {
+            "managed"  -> Managed
+            "observed" -> Observed
+            else       -> throw IllegalArgumentException()
+        }
+    }
+}
 
 /**
  * Voice assistant pipeline state (wake word → STT → LLM → TTS)

--- a/generated/protocol/BridgeEvent.swift
+++ b/generated/protocol/BridgeEvent.swift
@@ -1586,24 +1586,36 @@ extension ADOcSessionStatus {
 struct ADSessionInfo: Codable, Equatable {
     var agentType: ADAgentType?
     var alive: Bool
+    var contextPercent: Double?
+    var controlMode: ADControlMode?
+    var currentTask: String?
+    var cwd: String?
     var effortLevel: String?
     var id: String
     var modelName: String?
+    var pid: Double?
     var port: Double
     var projectName: String
     var startedAt: String?
     var state: String?
+    var totalTokens: Double?
 
     enum CodingKeys: String, CodingKey {
         case agentType = "agentType"
         case alive = "alive"
+        case contextPercent = "contextPercent"
+        case controlMode = "controlMode"
+        case currentTask = "currentTask"
+        case cwd = "cwd"
         case effortLevel = "effortLevel"
         case id = "id"
         case modelName = "modelName"
+        case pid = "pid"
         case port = "port"
         case projectName = "projectName"
         case startedAt = "startedAt"
         case state = "state"
+        case totalTokens = "totalTokens"
     }
 }
 
@@ -1628,24 +1640,36 @@ extension ADSessionInfo {
     func with(
         agentType: ADAgentType?? = nil,
         alive: Bool? = nil,
+        contextPercent: Double?? = nil,
+        controlMode: ADControlMode?? = nil,
+        currentTask: String?? = nil,
+        cwd: String?? = nil,
         effortLevel: String?? = nil,
         id: String? = nil,
         modelName: String?? = nil,
+        pid: Double?? = nil,
         port: Double? = nil,
         projectName: String? = nil,
         startedAt: String?? = nil,
-        state: String?? = nil
+        state: String?? = nil,
+        totalTokens: Double?? = nil
     ) -> ADSessionInfo {
         return ADSessionInfo(
             agentType: agentType ?? self.agentType,
             alive: alive ?? self.alive,
+            contextPercent: contextPercent ?? self.contextPercent,
+            controlMode: controlMode ?? self.controlMode,
+            currentTask: currentTask ?? self.currentTask,
+            cwd: cwd ?? self.cwd,
             effortLevel: effortLevel ?? self.effortLevel,
             id: id ?? self.id,
             modelName: modelName ?? self.modelName,
+            pid: pid ?? self.pid,
             port: port ?? self.port,
             projectName: projectName ?? self.projectName,
             startedAt: startedAt ?? self.startedAt,
-            state: state ?? self.state
+            state: state ?? self.state,
+            totalTokens: totalTokens ?? self.totalTokens
         )
     }
 
@@ -1656,6 +1680,11 @@ extension ADSessionInfo {
     func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
         return String(data: try self.jsonData(), encoding: encoding)
     }
+}
+
+enum ADControlMode: String, Codable, Equatable {
+    case managed = "managed"
+    case observed = "observed"
 }
 
 /// Voice assistant pipeline state (wake word → STT → LLM → TTS)

--- a/generated/protocol/bridge-event-schema.json
+++ b/generated/protocol/bridge-event-schema.json
@@ -790,6 +790,22 @@
         "alive": {
           "type": "boolean"
         },
+        "contextPercent": {
+          "type": "number"
+        },
+        "controlMode": {
+          "enum": [
+            "managed",
+            "observed"
+          ],
+          "type": "string"
+        },
+        "currentTask": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
         "effortLevel": {
           "type": "string"
         },
@@ -798,6 +814,9 @@
         },
         "modelName": {
           "type": "string"
+        },
+        "pid": {
+          "type": "number"
         },
         "port": {
           "type": "number"
@@ -810,6 +829,9 @@
         },
         "state": {
           "type": "string"
+        },
+        "totalTokens": {
+          "type": "number"
         }
       },
       "required": [

--- a/scripts/generate-protocol.sh
+++ b/scripts/generate-protocol.sh
@@ -91,8 +91,12 @@ npx quicktype \
 
 # Swift 6 strict concurrency rejects non-final Sendable classes. Quicktype's
 # boilerplate JSON helpers don't mark `JSONCodingKey` as final; patch it so
-# the generated file compiles under `-swift-version 6`.
-sed -i '' -e 's/^class JSONCodingKey:/final class JSONCodingKey:/' "$OUT_DIR/GatewayFrame.swift"
+# the generated file compiles under `-swift-version 6`. Use the temp-file
+# rewrite pattern instead of `sed -i` so this works on both BSD sed (macOS)
+# and GNU sed (Linux/CI) — `sed -i ''` is BSD-specific and fails on GNU sed.
+sed -e 's/^class JSONCodingKey:/final class JSONCodingKey:/' \
+  "$OUT_DIR/GatewayFrame.swift" > "$OUT_DIR/GatewayFrame.swift.tmp"
+mv "$OUT_DIR/GatewayFrame.swift.tmp" "$OUT_DIR/GatewayFrame.swift"
 
 echo "   → BridgeEvent.swift"
 echo "   → PluginCommand.swift"


### PR DESCRIPTION
## Summary

Master CI has been red since 2026-04-23 (every push since failed at the same step):

\`\`\`
=== Step 2: Generate Swift types ===
sed: can't read : No such file or directory
ELIFECYCLE  Command failed with exit code 2.
\`\`\`

Root cause: \`scripts/generate-protocol.sh:95\` uses \`sed -i ''\` to mark \`JSONCodingKey\` as \`final\` (Swift 6 \`Sendable\` requirement). \`-i ''\` is BSD sed syntax — on macOS the empty arg is the in-place suffix; on GNU sed (Ubuntu CI) the empty arg is parsed as a filename, hence the \"can't read :\" error.

Fix: rewrite the patched output to a temp file and \`mv\` over the original — POSIX, works on both seds, no \`-i\` flag.

Once the script ran end-to-end, step 3 (Kotlin) + step 4 (command builders) + the final \`git diff\` drift gate finally executed — and surfaced unsynced \`SessionListSession\` fields (\`contextPercent\`, \`controlMode\`, \`currentTask\`, \`cwd\`, \`pid\`, \`totalTokens\`). These were added to \`shared/src/protocol.ts\` but the generated artifacts were never regenerated. Sync committed alongside.

The two changes are in one commit because the drift wasn't observable until the script ran past step 2.

## Test plan

- [x] \`pnpm generate-protocol\` completes without error
- [x] Re-running it produces no further diff (idempotent)
- [x] Local typecheck + build + test (1015/1015) still green
- [ ] CI run on this branch goes green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)