### PR TITLE
Windows 11 port (bridge, hooks, plugin, setup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,38 @@ Then inspect `diagnostics/apple-xcode/latest/README.md`, `diag.json`, `status.js
 
 This diagnostic path is developer tooling only: it lives in `scripts/` and `.agents/workflows/`, writes local gitignored artifacts under `diagnostics/`, and must not add subprocesses, shell commands, terminal instructions, or external-tool prompts to the App Store app UI.
 
+## Windows dev setup
+
+The Node.js bridge, hook installer, and Stream Deck plugin run on Windows 11. Apple, Android, and ESP32 native builds are macOS/Linux-only and are out of scope for Windows.
+
+Prereqs (Windows 11):
+- **Node.js ≥ 22** + **pnpm**
+- **Stream Deck app** (Elgato) — `pnpm` setup also probes `%PROGRAMFILES%\Elgato\StreamDeck\` and `%LOCALAPPDATA%\Programs\Elgato\StreamDeck\`
+- **Claude Code CLI** on PATH
+- **Git Bash or WSL on PATH** for the bash scripts under `scripts/` (`install.sh`, `uninstall.sh`, `generate-protocol.sh`, `package-plugin.sh`) and `design/lint.sh`. The `postinstall` step is pure Node and runs without bash.
+
+Then:
+
+```powershell
+pnpm install            # postinstall runs scripts/postinstall.mjs (no-op on Windows)
+pnpm build
+pnpm test
+agentdeck daemon start  # daemon listens on 9120, writes %USERPROFILE%\.agentdeck\daemon.json
+# In another terminal:
+agentdeck claude        # spawns Claude Code via Windows ConPTY (cmd.exe /d /s /c)
+```
+
+Windows differences (intentional — see `bridge/src/pty-manager.ts`, `hooks/src/install.ts`, `bridge/src/cli.ts`):
+- **Data dir**: `%USERPROFILE%\.agentdeck\` (same layout as macOS `~/.agentdeck/`). The `AGENTDECK_DATA_DIR` env override still works.
+- **PTY**: ConPTY through `cmd.exe` with `/d /s /c` args (POSIX uses `/bin/zsh -l -c`). `node-pty`'s Windows prebuild is used as-is — no source build, so no Visual Studio Build Tools requirement.
+- **Hook command**: Claude Code hook entries on Windows use a `powershell -NoProfile -ExecutionPolicy Bypass -Command "..."` one-liner that reads `%USERPROFILE%\.agentdeck\daemon.json`, probes `/health`, and POSTs the stdin payload via `Invoke-RestMethod`. The macOS App Store sandbox-container fallback paths are intentionally omitted (those directories don't exist on Windows).
+- **`agentdeck daemon install/uninstall`**: no-op with a friendly message on Windows. Autostart is out of scope; add a Startup-folder shortcut yourself if you want it. `daemon start/stop/status` work normally.
+- **Device-module auto-detection**: `adb` is probed with `adb version` (cross-platform); the `/dev/tty.*` USB-serial scan is gated behind a `process.platform !== 'win32'` check (Windows COM-port enumeration not implemented). `bonjour-service`, `node-hid` (D200H), and `better-sqlite3` (APME) all use Windows-compatible prebuilds.
+- **APME hardware sampler** (`bridge/src/apme/hw-sampler.ts`) is darwin-only — it returns a minimal snapshot on Windows and the recommender treats that as "neutral".
+- **macOS-only plugin utility actions** (brightness / volume / dark-mode via `osascript`) gracefully no-op on Windows.
+
+When debugging Windows-specific issues, prefer running each command above directly in PowerShell so output appears in the conversation rather than relying on the Apple/Xcode diagnostic bundle, which is macOS-only.
+
 ## CLI
 
 The CLI command is `agentdeck` (`bridge/src/cli.ts`).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ AgentDeck is a physical control surface for AI coding agents. It started with an
 
 | | Requirement |
 |---|---|
-| **Platform** | macOS 15+ (Sequoia) — Windows/Linux not supported |
+| **Platform** | macOS 15+ (Sequoia) primary · Windows 11 runs the bridge + Stream Deck plugin ([see below](#windows-bridge--plugin)) · Linux not supported |
 | **Hardware** | Elgato Stream Deck+ (8 keys, 4 encoders, LCD touch strip) |
 | **Terminal** | iTerm2 (required for session management and voice paste) |
 | **Android** | *(Optional)* Android 10+ tablet or e-ink reader for remote dashboard |
@@ -59,6 +59,7 @@ AgentDeck is a physical control surface for AI coding agents. It started with an
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
 - [Manual Build & Install](#manual-build--install)
+- [Windows (Bridge + Plugin)](#windows-bridge--plugin)
 - [Usage](#usage)
   - [CLI Reference](#cli-reference)
 - [Stream Deck+ Layout (v4)](#stream-deck-layout-v4)
@@ -191,7 +192,7 @@ On macOS, the AgentDeck Dashboard SwiftUI app ships with a full **in-process Swi
 
 | Item | Required | Install |
 |------|----------|---------|
-| **macOS 15+** (Sequoia) | Yes | Windows/Linux not supported |
+| **macOS 15+** (Sequoia) | Yes (host) | Primary platform. Windows 11 runs the bridge + Stream Deck plugin — see [Windows](#windows-bridge--plugin). Linux not supported |
 | **Xcode Command Line Tools** | Yes | `xcode-select --install` (node-pty native build) |
 | **Node.js** >= 22 | Yes | `brew install node` |
 | **pnpm** >= 9 | Yes | `npm install -g pnpm` |
@@ -278,6 +279,56 @@ cd bridge && pnpm link --global
 Voice input uses Apple's on-device `SFSpeechRecognizer` (Speech framework). **No sox, no whisper.cpp, no model downloads** — the OS manages the dictation model via Settings → General → Keyboard → Dictation, which AgentDeck piggybacks on. The only user action is granting Microphone + Speech Recognition permission the first time the voice button is pressed (macOS shows the standard TCC prompts backed by `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`).
 
 All audio stays on-device (`requiresOnDeviceRecognition = true`), so the captured WAV — which may contain project/code names — never leaves the machine. See [Voice Setup Guide](docs/voice-setup.md) for permission troubleshooting and wake-word details.
+
+---
+
+## Windows (Bridge + Plugin)
+
+The Node.js **bridge**, the Claude Code **hook installer**, and the **Stream Deck plugin** run on Windows 11. The Apple, Android, and ESP32 native builds are macOS/Linux-only and are out of scope on Windows — but the core "steer Claude Code from a Stream Deck+" experience works.
+
+### Prerequisites (Windows 11)
+
+| Item | Required | Notes |
+|------|----------|-------|
+| **Node.js** ≥ 22 + **pnpm** | Yes | `winget install OpenJS.NodeJS`, then `npm install -g pnpm` |
+| **Stream Deck app** (Elgato) | For hardware | Setup also probes `%PROGRAMFILES%\Elgato\StreamDeck\` and `%LOCALAPPDATA%\Programs\Elgato\StreamDeck\` |
+| **Claude Code CLI** on `PATH` | Yes | `npm install -g @anthropic-ai/claude-code` |
+| **Git Bash or WSL** on `PATH` | For source scripts | Only the bash scripts under `scripts/` (`install.sh`, `uninstall.sh`, `package-plugin.sh`, …) need it. `pnpm install`/`build`/`test` are pure Node |
+
+### Install
+
+```powershell
+git clone https://github.com/puritysb/AgentDeck.git
+cd AgentDeck
+pnpm install            # postinstall (scripts/postinstall.mjs) is a no-op on Windows
+pnpm build              # shared → bridge, plugin, hooks
+pnpm test               # optional: run the Vitest suite
+
+# Register Claude Code hooks (writes a PowerShell one-liner hook command)
+node hooks/dist/install.js
+
+# Link the CLI + Stream Deck plugin
+cd bridge; pnpm link --global; cd ..
+cd plugin; streamdeck link .sdPlugin; cd ..   # then restart the Stream Deck app
+```
+
+### Run
+
+```powershell
+agentdeck daemon start  # daemon on 9120, writes %USERPROFILE%\.agentdeck\daemon.json
+# In another terminal:
+agentdeck claude        # spawns Claude Code via Windows ConPTY (cmd.exe /d /s /c)
+```
+
+### Windows differences (intentional)
+
+- **Data dir** — `%USERPROFILE%\.agentdeck\` (same layout as macOS `~/.agentdeck/`). `AGENTDECK_DATA_DIR` override still works.
+- **PTY** — ConPTY through `cmd.exe` with `/d /s /c` (POSIX uses `/bin/zsh -l -c`). `node-pty`'s Windows prebuild is used as-is, so no Visual Studio Build Tools are required.
+- **Hooks** — Claude Code hook entries run a `powershell -NoProfile -ExecutionPolicy Bypass -Command "…"` one-liner that reads `daemon.json`, probes `/health`, and POSTs the payload via `Invoke-RestMethod`.
+- **`agentdeck daemon install` / `uninstall`** — no-op with a friendly message. There is no autostart yet; run `agentdeck daemon start` yourself, or add a Startup-folder shortcut. (See the Windows daemon TODO in the [Roadmap](#roadmap).)
+- **Device modules** — `adb` is probed cross-platform; the `/dev/tty.*` USB-serial scan is skipped on Windows (COM-port enumeration not implemented). mDNS, `node-hid` (D200H), and `better-sqlite3` (APME) use Windows-compatible prebuilds.
+- **APME hardware sampler** is darwin-only — it returns a minimal snapshot on Windows and the recommender treats that as "neutral".
+- **macOS-only plugin utility actions** (brightness / volume / dark-mode via `osascript`) gracefully no-op on Windows.
 
 ---
 
@@ -963,6 +1014,7 @@ Eval results broadcast to every device simultaneously (Stream Deck/Apple/Android
 
 ### Planned
 
+- [ ] **Windows daemon autostart / background service** — today `agentdeck daemon install` is a no-op on Windows and the daemon must be started manually with `agentdeck daemon start` in a terminal (run locally). Add native autostart (Windows Service or a Startup/Task Scheduler registration) so the daemon runs in the background like the macOS LaunchAgent
 - [ ] Play Store distribution (Android app)
 - [ ] Stream Deck Marketplace registration (plugin distribution)
 

--- a/bridge/src/__tests__/apme-runner.test.ts
+++ b/bridge/src/__tests__/apme-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { execSync } from 'child_process';
 import { ApmeStore } from '../apme/store.js';
 import { ApmeCollector } from '../apme/collector.js';
@@ -15,7 +15,7 @@ function tmpProject(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), 'apme-proj-'));
   for (const [rel, content] of Object.entries(files)) {
     const full = join(dir, rel);
-    mkdirSync(full.replace(/\/[^/]+$/, ''), { recursive: true });
+    mkdirSync(dirname(full), { recursive: true });
     writeFileSync(full, content);
   }
   return dir;
@@ -457,7 +457,7 @@ describe('runDeterministic (end-to-end spawn)', () => {
     store = null; project = null;
   });
 
-  it('runs sh-based commands against the project path and reports pass', async () => {
+  it.skipIf(process.platform === 'win32')('runs sh-based commands against the project path and reports pass', async () => {
     // Dirty the worktree so hasChanges() returns true.
     writeFileSync(join(project, 'README.md'), 'dirty');
 
@@ -481,7 +481,7 @@ describe('runDeterministic (end-to-end spawn)', () => {
     expect(results.map((r) => r.metric).sort()).toEqual(['build_ok', 'lint_clean', 'tests_pass']);
   });
 
-  it('captures exit code 1 as tests_pass=0', async () => {
+  it.skipIf(process.platform === 'win32')('captures exit code 1 as tests_pass=0', async () => {
     writeFileSync(join(project, 'README.md'), 'dirty');
     const run: ApmeRunRow = {
       id: 'r2', sessionId: 's', agentType: 'claude-code',

--- a/bridge/src/check-deps.ts
+++ b/bridge/src/check-deps.ts
@@ -57,10 +57,16 @@ export function checkDependencies(agentType?: AgentType): { ok: boolean; warning
   let ok = true;
   let agentVersion: string | undefined;
 
-  // Use login shell so profile-added PATHs (pnpm, nvm, etc.) are available
+  // POSIX: invoke via login shell so profile-added PATHs (pnpm, nvm, etc.) are
+  // visible. Windows: PATH is system-managed (no shell profile), so a direct
+  // execSync is correct — the POSIX wrapper would try `/bin/zsh` which doesn't
+  // exist and every check would fail with "system cannot find the path".
+  const isWin = process.platform === 'win32';
   const loginShell = process.env.SHELL || '/bin/zsh';
   const shellExec = (cmd: string, opts?: Parameters<typeof execSync>[1]) =>
-    execSync(`${loginShell} -l -c '${cmd}'`, opts);
+    isWin
+      ? execSync(cmd, opts)
+      : execSync(`${loginShell} -l -c '${cmd}'`, opts);
 
   // Check agent-specific binary
   const agentDep = agentType ? AGENT_DEPS[agentType] : AGENT_DEPS['claude-code'];
@@ -74,12 +80,16 @@ export function checkDependencies(agentType?: AgentType): { ok: boolean; warning
     }
   }
 
-  // Check shared optional deps
-  for (const dep of SHARED_DEPS) {
-    try {
-      shellExec(dep.command, { stdio: 'ignore' });
-    } catch {
-      warnings.push(`${dep.name} not found — ${dep.installHint}`);
+  // Check shared optional deps. All current entries use `which` + brew install
+  // hints — they're macOS voice features. Skip on Windows so we don't emit
+  // bogus warnings.
+  if (!isWin) {
+    for (const dep of SHARED_DEPS) {
+      try {
+        shellExec(dep.command, { stdio: 'ignore' });
+      } catch {
+        warnings.push(`${dep.name} not found — ${dep.installHint}`);
+      }
     }
   }
 

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -357,6 +357,12 @@ daemon
   .command('install')
   .description('Install macOS LaunchAgent for auto-start')
   .action(async () => {
+    if (process.platform === 'win32') {
+      log('agentdeck daemon install/uninstall is not supported on Windows.');
+      log("Start the daemon manually with: agentdeck daemon start");
+      log('(Add to the Startup folder yourself if you want it to autostart.)');
+      process.exit(0);
+    }
     if (process.platform !== 'darwin') {
       log('LaunchAgent is macOS-only');
       process.exit(1);
@@ -384,6 +390,10 @@ daemon
   .command('uninstall')
   .description('Remove macOS LaunchAgent')
   .action(() => {
+    if (process.platform === 'win32') {
+      log('agentdeck daemon install/uninstall is not supported on Windows.');
+      process.exit(0);
+    }
     if (!existsSync(PLIST_PATH)) {
       log('LaunchAgent not installed');
       return;

--- a/bridge/src/display-monitor.ts
+++ b/bridge/src/display-monitor.ts
@@ -42,6 +42,15 @@ export class DisplayMonitor extends EventEmitter {
 
   start(): void {
     if (this.running) return;
+    // Both the CGDisplayIsAsleep + pmset paths are macOS-only. On other
+    // platforms keep `isDisplayOn()` at its default `true` (display assumed
+    // on) and skip the python3/pmset spawn loop — otherwise Windows users
+    // see a console window flash every 5s as the doomed python3 restart
+    // timer fires.
+    if (process.platform !== 'darwin') {
+      debug('display', `DisplayMonitor skipped (platform=${process.platform})`);
+      return;
+    }
     this.running = true;
     this.restartCount = 0;
     debug('display', `DisplayMonitor started (${POLL_INTERVAL_S}s persistent poll)`);

--- a/bridge/src/modules/adb-module.ts
+++ b/bridge/src/modules/adb-module.ts
@@ -14,9 +14,10 @@ export class AdbModule implements DeviceModule {
   async shouldActivate(config: 'auto' | boolean): Promise<boolean> {
     if (config === false) return false;
     if (config === true) return true;
-    // auto: check if adb is available
+    // auto: check if adb is available. Use `adb version` instead of `which`
+    // so detection works on Windows too (which lacks `which`).
     try {
-      execSync('which adb', { stdio: 'pipe' });
+      execSync('adb version', { stdio: 'pipe', timeout: 2000 });
       return true;
     } catch {
       return false;

--- a/bridge/src/pty-manager.ts
+++ b/bridge/src/pty-manager.ts
@@ -30,7 +30,13 @@ export class PtyManager extends EventEmitter {
       );
     }
 
-    const shell = process.env.SHELL || '/bin/zsh';
+    const isWin = process.platform === 'win32';
+    const shell = isWin
+      ? (process.env.COMSPEC || 'cmd.exe')
+      : (process.env.SHELL || '/bin/zsh');
+    // Windows ConPTY uses cmd-style switches: /d (skip AutoRun), /s (literal),
+    // /c (run command then exit). POSIX shells use -l (login) -c (command).
+    const args = isWin ? ['/d', '/s', '/c', command] : ['-l', '-c', command];
     const cols = process.stdout.columns || 120;
     const rows = process.stdout.rows || 40;
 
@@ -40,7 +46,7 @@ export class PtyManager extends EventEmitter {
 
     let proc: IPty;
     try {
-      proc = pty.spawn(shell, ['-l', '-c', command], {
+      proc = pty.spawn(shell, args, {
         name: 'xterm-256color',
         cols,
         rows,

--- a/bridge/src/session-aggregator.ts
+++ b/bridge/src/session-aggregator.ts
@@ -20,6 +20,7 @@ export interface EnrichedSession {
   totalTokens?: number;
   question?: string;
   requestId?: string;
+  elapsedSec?: number;
 }
 
 /** Cache last-known sibling state to avoid propagating undefined on transient fetch failures */

--- a/bridge/src/tui/renderer.ts
+++ b/bridge/src/tui/renderer.ts
@@ -520,7 +520,7 @@ function renderOauthCatalogLines(
   width: number,
 ): string[] {
   const lines: string[] = [];
-  const models = modelCatalog.filter((m) => m.available).map((m) => m.name);
+  const models = (modelCatalog ?? []).filter((m) => m.available).map((m) => m.name);
 
   if (models.length > 0) {
     return wrapCommaList(' OAuth: ', models, width);

--- a/bridge/src/usage-api.ts
+++ b/bridge/src/usage-api.ts
@@ -70,10 +70,15 @@ interface OAuthCredentials {
 }
 
 function getOAuthCredentials(): OAuthCredentials | null {
+  // The `security` CLI is macOS-only. On other platforms there's no equivalent
+  // path implemented for this OAuth token — return null instead of spawning
+  // a doomed `security` child whose stderr (`'security' is not recognized…`)
+  // would otherwise corrupt the session-bridge TTY.
+  if (process.platform !== 'darwin') return null;
   try {
     const raw = execSync(
       `security find-generic-password -s "${KEYCHAIN_SERVICE}" -w`,
-      { encoding: 'utf-8', timeout: 5000 },
+      { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] },
     ).trim();
     const creds = JSON.parse(raw);
     const oauth = creds?.claudeAiOauth;

--- a/bridge/src/utility-proxy.ts
+++ b/bridge/src/utility-proxy.ts
@@ -67,6 +67,14 @@ export class UtilityProxy {
   private skipTicks = 0;
 
   constructor() {
+    // osascript is macOS-only; spawning it on Windows would either flash
+    // console windows (if Node's CreateProcess pops one) or just fail-then-
+    // retry every POLL_INTERVAL_MS. Skip the polling loop and let getState()
+    // serve its initial cached defaults.
+    if (process.platform !== 'darwin') {
+      debug('Utility', `polling skipped (platform=${process.platform})`);
+      return;
+    }
     void this.poll();
     this.pollTimer = setInterval(() => { void this.poll(); }, POLL_INTERVAL_MS);
   }

--- a/hooks/src/__tests__/install.test.ts
+++ b/hooks/src/__tests__/install.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   HOOK_EVENTS,
+  buildHookCommand,
+  buildHookCommandWin,
   buildHookEntry,
   applyHooks,
   removeHooks,
@@ -14,20 +16,25 @@ describe('Hook Installer', () => {
       expect(entry.matcher).toBe('');
       expect(entry.hooks).toHaveLength(1);
       expect(entry.hooks[0].type).toBe('command');
+      // Both POSIX and Windows commands reference AGENTDECK_PORT and the event name.
+      // POSIX inlines the full `/hooks/<event>` path; Windows builds it via `/hooks/`+$ev,
+      // so assert both substrings without assuming a single concatenated form.
       expect(entry.hooks[0].command).toContain('AGENTDECK_PORT');
-      expect(entry.hooks[0].command).toContain('/hooks/SessionStart');
+      expect(entry.hooks[0].command).toContain('SessionStart');
+      expect(entry.hooks[0].command).toContain('/hooks/');
     });
 
-    it('includes daemon.json port resolution with fallback to 9120', () => {
-      const entry = buildHookEntry('Stop');
-      expect(entry.hooks[0].command).toContain('daemon.json');
-      expect(entry.hooks[0].command).toContain('${PORT:-9120}');
-      expect(entry.hooks[0].command).toContain('$PORT');
+    it('uses `*` matcher for tool events and empty matcher for lifecycle events', () => {
+      expect(buildHookEntry('PreToolUse').matcher).toBe('*');
+      expect(buildHookEntry('PostToolUse').matcher).toBe('*');
+      expect(buildHookEntry('Stop').matcher).toBe('');
+      expect(buildHookEntry('SessionStart').matcher).toBe('');
     });
+  });
 
+  describe('buildHookCommand (POSIX)', () => {
     it('reads PORT from AGENTDECK_PORT env var first, then daemon.json, then 9120', () => {
-      const entry = buildHookEntry('SessionStart');
-      const cmd = entry.hooks[0].command;
+      const cmd = buildHookCommand('SessionStart');
       // Priority chain: AGENTDECK_PORT → ~/.agentdeck/daemon.json → App Store sandbox daemon.json → legacy group daemon.json → 9120
       expect(cmd).toContain('PORT="${AGENTDECK_PORT:-}"');
       expect(cmd).toContain('.agentdeck/daemon.json');
@@ -38,13 +45,37 @@ describe('Hook Installer', () => {
     });
 
     it('emits newline-separated shell so if/then/for/do keywords are not mis-terminated by `;`', () => {
-      const cmd = buildHookEntry('SessionStart').hooks[0].command;
+      const cmd = buildHookCommand('SessionStart');
       // Regression guard: `; then;` / `; do;` is a zsh-only oddity that fails under
       // sh/bash — Claude Code runs hooks via /bin/sh so the joined output must
       // use newlines between statements.
       expect(cmd).not.toMatch(/;\s*then\s*;/);
       expect(cmd).not.toMatch(/;\s*do\s*;/);
       expect(cmd).toContain('\n');
+    });
+  });
+
+  describe('buildHookCommandWin (Windows)', () => {
+    it('wraps a PowerShell one-liner that targets the event endpoint', () => {
+      const cmd = buildHookCommandWin('SessionStart');
+      expect(cmd.startsWith('powershell -NoProfile -ExecutionPolicy Bypass -Command "')).toBe(true);
+      expect(cmd).toContain("$ev='SessionStart'");
+      expect(cmd).toContain('$env:AGENTDECK_PORT');
+      expect(cmd).toContain(".agentdeck\\daemon.json");
+      expect(cmd).toContain("/hooks/'+$ev");
+      expect(cmd).toContain('Invoke-RestMethod');
+      expect(cmd).toContain('$port=9120');
+    });
+
+    it('uses single-line PowerShell so cmd.exe can pass it as one -Command argument', () => {
+      const cmd = buildHookCommandWin('Stop');
+      expect(cmd).not.toContain('\n');
+    });
+
+    it('omits the macOS App Store sandbox-container fallback paths', () => {
+      const cmd = buildHookCommandWin('SessionStart');
+      expect(cmd).not.toContain('Library/Containers/bound.serendipity');
+      expect(cmd).not.toContain('group.bound.serendipity');
     });
   });
 
@@ -259,26 +290,13 @@ describe('Hook Installer', () => {
 
   describe('migrateHooksIfNeeded (file-based)', () => {
     it('upgrades old :-9120 fallback hooks to daemon.json-reading format', () => {
-      // Simulate old-format hooks in settings file
-      const oldSettings = {
-        hooks: {
-          SessionStart: [
-            {
-              matcher: '',
-              hooks: [{
-                type: 'command',
-                command: "curl -sf -X POST http://localhost:${AGENTDECK_PORT:-9120}/hooks/SessionStart ...",
-              }],
-            },
-          ],
-        },
-      };
-
-      // The new format should contain daemon.json instead of the old :-9120 fallback
-      const newSettings = applyHooks({});
-      expect(newSettings.hooks.SessionStart[0].hooks[0].command).toContain('daemon.json');
-      expect(newSettings.hooks.SessionStart[0].hooks[0].command).not.toContain('${AGENTDECK_PORT:-9120}');
-      expect(newSettings.hooks.SessionStart[0].hooks[0].command).toContain('$PORT');
+      // The new format should contain daemon.json instead of the old :-9120 fallback.
+      // Test the POSIX builder directly so the assertion shape is stable regardless of
+      // host OS — `applyHooks` picks the platform variant.
+      const newCmd = buildHookCommand('SessionStart');
+      expect(newCmd).toContain('daemon.json');
+      expect(newCmd).not.toContain('${AGENTDECK_PORT:-9120}');
+      expect(newCmd).toContain('$PORT');
     });
   });
 });

--- a/hooks/src/install.ts
+++ b/hooks/src/install.ts
@@ -71,11 +71,40 @@ export function buildHookCommand(eventName: string): string {
   ]).join('\n');
 }
 
+/**
+ * Windows variant of `buildHookCommand`. Claude Code v2.1+ executes hook
+ * commands through `cmd.exe` on Windows, so we shell out to PowerShell for
+ * the JSON read + HTTP POST. Discovery is narrower than POSIX since the
+ * macOS App Store sandbox paths don't exist on Windows:
+ *
+ *   1. `$env:AGENTDECK_PORT`
+ *   2. `%USERPROFILE%\.agentdeck\daemon.json` (verified with `/health` probe)
+ *   3. `9120` fallback
+ *
+ * Single quotes are used inside the PowerShell script so the entire `-Command`
+ * argument can stay double-quoted under cmd.exe. Errors are swallowed so a
+ * dead daemon never blocks the host session.
+ */
+export function buildHookCommandWin(eventName: string): string {
+  const ps = [
+    `$ev='${eventName}'`,
+    `$port=$env:AGENTDECK_PORT`,
+    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $p=if($d.httpPort){$d.httpPort}else{$d.port}; if($p){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$p+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$p}catch{}}}catch{}}}`,
+    `if(-not $port){$port=9120}`,
+    `$body=[Console]::In.ReadToEnd()`,
+    `try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$port+'/hooks/'+$ev) -Method Post -Body $body -ContentType 'application/json' -TimeoutSec 2 -ErrorAction Stop|Out-Null}catch{}`,
+  ].join('; ');
+  return `powershell -NoProfile -ExecutionPolicy Bypass -Command "${ps}"`;
+}
+
 // Claude Code v2.1+ requires 3-level nesting: event → matcher group → hook handler.
 export function buildHookEntry(eventName: string) {
+  const command = process.platform === 'win32'
+    ? buildHookCommandWin(eventName)
+    : buildHookCommand(eventName);
   const handler: any = {
     type: 'command',
-    command: buildHookCommand(eventName),
+    command,
   };
   // Tool-specific hooks (PreToolUse, PostToolUse) need a glob matcher to fire.
   // Empty string "" means "match nothing" for tool events — use "" for non-tool
@@ -246,8 +275,13 @@ export function migrateHooksIfNeeded(): void {
 }
 
 // CLI execution
-const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url === new URL(process.argv[1], 'file://').href;
+// Use pathToFileURL so the comparison is correct on Windows too — process.argv[1]
+// is a native path (E:\dev\...\install.js), but import.meta.url is a file:// URL
+// (file:///E:/dev/.../install.js). Manually building `file://${argv[1]}` only
+// matches on POSIX, which is why the installer used to be a silent no-op on
+// Windows.
+import { pathToFileURL } from 'url';
+const isMainModule = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
 
 if (isMainModule) {
   const action = process.argv[2] || 'install';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Stream Deck+ controller for Claude Code CLI",
   "scripts": {
-    "build": "pnpm --filter @agentdeck/shared build && pnpm --filter '!@agentdeck/shared' -r build",
+    "build": "pnpm --filter @agentdeck/shared build && pnpm --filter=!@agentdeck/shared -r build",
     "dev": "pnpm -r --parallel dev",
     "demo": "node scripts/render-creature-simulator.mjs && npx --yes vite tools/creature-simulator",
     "demo:build": "node scripts/render-creature-simulator.mjs && vite build tools/creature-simulator --base=/AgentDeck/demo/ --outDir ../../dist/demo --emptyOutDir && cp tools/creature-simulator/sim-data.js dist/demo/sim-data.js",
@@ -24,7 +24,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "postinstall": "bash scripts/postinstall.sh"
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/plugin/bound.serendipity.agentdeck.sdPlugin/manifest.json
+++ b/plugin/bound.serendipity.agentdeck.sdPlugin/manifest.json
@@ -117,6 +117,10 @@
     {
       "Platform": "mac",
       "MinimumVersion": "15.0"
+    },
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
     }
   ],
   "Nodejs": {

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Fix node-pty spawn-helper permissions on POSIX (pnpm doesn't preserve
+// execute bits from prebuilds). No-op on Windows: node-pty's Windows
+// prebuilds are DLLs that don't carry POSIX execute bits.
+import { execSync } from 'child_process';
+
+if (process.platform === 'win32') process.exit(0);
+
+try {
+  const out = execSync(
+    'find node_modules -path "*node-pty*/prebuilds/darwin-*/spawn-helper" 2>/dev/null',
+    { encoding: 'utf-8' },
+  );
+  for (const line of out.split('\n')) {
+    const path = line.trim();
+    if (!path) continue;
+    try {
+      execSync(`chmod +x ${JSON.stringify(path)}`, { stdio: 'pipe' });
+      console.log(`[postinstall] Fixed spawn-helper permissions: ${path}`);
+    } catch {
+      /* non-critical */
+    }
+  }
+} catch {
+  /* node_modules may not exist yet, or find unavailable */
+}

--- a/setup/src/setup.ts
+++ b/setup/src/setup.ts
@@ -18,9 +18,14 @@ function ok(msg: string) { console.log(`${GREEN}[OK]${NC} ${msg}`); }
 function warn(msg: string) { console.log(`${YELLOW}[WARN]${NC} ${msg}`); }
 function fail(msg: string) { console.log(`${RED}[FAIL]${NC} ${msg}`); }
 
+const IS_WIN = process.platform === 'win32';
+
 function which(cmd: string): string | null {
   try {
-    return execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim();
+    // `where` on Windows can print multiple lines (one per match); take the first.
+    const probe = IS_WIN ? `where ${cmd}` : `which ${cmd}`;
+    const out = execSync(probe, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    return out.split(/\r?\n/)[0] || null;
   } catch {
     return null;
   }
@@ -55,13 +60,17 @@ function checkPrerequisites(): boolean {
   // CLT the node-pty source build fails with a cryptic compiler-missing error
   // deep inside node-gyp. Catch it here with a clear message so the user
   // knows the one command to run.
-  if (which('xcode-select') && checkXcodeCliTools()) {
-    ok('Xcode Command Line Tools installed');
-  } else {
-    fail('Xcode Command Line Tools not installed — required to build node-pty from source.');
-    console.log(`       Install with: ${YELLOW}xcode-select --install${NC}`);
-    console.log('       After the installer finishes, re-run `npx @agentdeck/setup`.');
-    pass = false;
+  // Windows uses node-pty's prebuilt binary (no source build), so this check
+  // is darwin-only.
+  if (!IS_WIN) {
+    if (which('xcode-select') && checkXcodeCliTools()) {
+      ok('Xcode Command Line Tools installed');
+    } else {
+      fail('Xcode Command Line Tools not installed — required to build node-pty from source.');
+      console.log(`       Install with: ${YELLOW}xcode-select --install${NC}`);
+      console.log('       After the installer finishes, re-run `npx @agentdeck/setup`.');
+      pass = false;
+    }
   }
 
   const hasClaude = Boolean(which('claude'));
@@ -86,11 +95,15 @@ function checkPrerequisites(): boolean {
     pass = false;
   }
 
-  // Stream Deck app
-  if (
-    existsSync('/Applications/Elgato Stream Deck.app') ||
-    existsSync('/Applications/Stream Deck.app')
-  ) {
+  // Stream Deck app — paths differ per OS
+  const streamDeckPaths = IS_WIN
+    ? [
+        join(process.env.PROGRAMFILES ?? 'C:\\Program Files', 'Elgato', 'StreamDeck', 'StreamDeck.exe'),
+        join(process.env['PROGRAMFILES(X86)'] ?? 'C:\\Program Files (x86)', 'Elgato', 'StreamDeck', 'StreamDeck.exe'),
+        join(process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'), 'Programs', 'Elgato', 'StreamDeck', 'StreamDeck.exe'),
+      ]
+    : ['/Applications/Elgato Stream Deck.app', '/Applications/Stream Deck.app'];
+  if (streamDeckPaths.some((p) => existsSync(p))) {
     ok('Stream Deck app installed');
   } else {
     fail('Stream Deck app not found — download from https://www.elgato.com/downloads');
@@ -139,10 +152,16 @@ function installStreamDeckCli() {
 
 function installBridge() {
   info('Installing AgentDeck bridge (@agentdeck/bridge)...');
-  // Force source build of node-pty to avoid prebuilt binary ABI mismatch (see #3)
+  // Force source build of node-pty on macOS to avoid prebuilt binary ABI
+  // mismatch (see #3). On Windows we rely on node-pty's prebuilt binary —
+  // forcing a source build would require Visual Studio Build Tools, which
+  // is a much larger prereq than we want.
+  const env = IS_WIN
+    ? { ...process.env }
+    : { ...process.env, npm_config_build_from_source: 'true' };
   execSync('npm install -g @agentdeck/bridge', {
     stdio: 'inherit',
-    env: { ...process.env, npm_config_build_from_source: 'true' },
+    env,
   });
 
   if (which('agentdeck')) {
@@ -196,14 +215,28 @@ function buildHookCommand(eventName: string): string {
   ]).join('\n');
 }
 
+/** Windows variant — kept in sync with `@agentdeck/hooks` `buildHookCommandWin`. */
+function buildHookCommandWin(eventName: string): string {
+  const ps = [
+    `$ev='${eventName}'`,
+    `$port=$env:AGENTDECK_PORT`,
+    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $p=if($d.httpPort){$d.httpPort}else{$d.port}; if($p){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$p+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$p}catch{}}}catch{}}}`,
+    `if(-not $port){$port=9120}`,
+    `$body=[Console]::In.ReadToEnd()`,
+    `try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$port+'/hooks/'+$ev) -Method Post -Body $body -ContentType 'application/json' -TimeoutSec 2 -ErrorAction Stop|Out-Null}catch{}`,
+  ].join('; ');
+  return `powershell -NoProfile -ExecutionPolicy Bypass -Command "${ps}"`;
+}
+
 function buildHookEntry(eventName: string) {
   const needsToolMatcher = ['PreToolUse', 'PostToolUse'].includes(eventName);
+  const command = IS_WIN ? buildHookCommandWin(eventName) : buildHookCommand(eventName);
   return {
     matcher: needsToolMatcher ? '*' : '',
     hooks: [
       {
         type: 'command',
-        command: buildHookCommand(eventName),
+        command,
       },
     ],
   };
@@ -312,6 +345,13 @@ function seedCompatibility() {
 function checkOptionalDeps() {
   console.log('');
   console.log('----- Optional Dependencies -----');
+
+  if (IS_WIN) {
+    // Voice input (sox/whisper) on AgentDeck currently targets macOS only.
+    // Skip the prompts on Windows so the user isn't told to run `brew`.
+    warn('Voice input (sox + whisper.cpp) is macOS-only — skipped.');
+    return;
+  }
 
   if (which('sox') || which('rec')) {
     ok('sox installed (voice recording)');

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -8,6 +8,11 @@ import { join } from 'path';
 const dataDir = mkdtempSync(join(tmpdir(), 'agentdeck-vitest-'));
 process.env.AGENTDECK_DATA_DIR = dataDir;
 
+// Pin TZ so timeline-renderer snapshots are stable regardless of host TZ.
+// CI sets this via env (Asia/Seoul); pinning here covers local dev across
+// macOS, Linux, and Windows without each contributor having to set TZ.
+process.env.TZ = 'Asia/Seoul';
+
 process.once('exit', () => {
   rmSync(dataDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Windows 11 port

Adds Windows 11 support for the Node.js side of AgentDeck (bridge, hook installer, Stream Deck plugin, setup). Apple/Android/ESP32 native builds remain macOS/Linux-only and are out of scope.

### Changes
- **`port: Windows 11 support for bridge, hooks, plugin, setup`** — ConPTY via `cmd.exe /d /s /c`, `%USERPROFILE%\.agentdeck\` data dir, PowerShell-based Claude Code hook command, `daemon install/uninstall` no-op with friendly message on Windows, USB-serial scan gated behind `process.platform !== 'win32'`, darwin-only APME hardware sampler returns neutral snapshot, macOS-only plugin utility actions no-op gracefully.
- **`docs: Windows install/run guide + native daemon-autostart TODO`** — adds the "Windows dev setup" section to `CLAUDE.md` and documents prereqs, the data-dir/PTY/hook differences, and the daemon-autostart follow-up.

### Notes
- Uses `node-pty`, `bonjour-service`, `node-hid`, and `better-sqlite3` Windows prebuilds — no Visual Studio Build Tools requirement.
- Bash scripts under `scripts/` still require Git Bash or WSL on PATH; `postinstall` is pure Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
