### PR TITLE
fix(plugin): render MODEL detail tile exactly once

### DIFF
--- a/plugin/src/__tests__/session-slot-manager.test.ts
+++ b/plugin/src/__tests__/session-slot-manager.test.ts
@@ -191,6 +191,31 @@ describe('SessionSlotManager detail layout', () => {
     expect(ocModelPreset?.preset?.subtitle).toBe('opus 4.7');
   });
 
+  it('renders the MODEL tile exactly once in Claude PROCESSING detail (no duplicate)', () => {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([makeSession({ state: State.PROCESSING, modelName: 'claude-opus-4-8' })], false);
+    manager.enterDetailView('session-1');
+    manager.updateDetailState(State.PROCESSING, [], 'Edit', 'cli.ts', undefined, 'claude-opus-4-8', 'acceptEdits');
+
+    const labels = [0, 1, 2, 3, 4, 5, 6, 7]
+      .map(i => manager.getSlotConfig(i, SD_PLUS_LAYOUT))
+      .filter(c => c.type === 'status' && c.label === 'MODEL');
+    expect(labels).toHaveLength(1);
+  });
+
+  it('does not duplicate MODEL on OpenClaw idle (preset + status card)', () => {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([makeSession({ id: 'oc', agentType: 'openclaw', modelName: 'gpt-5' })], true);
+    manager.enterDetailView('oc');
+    manager.updateDetailState(State.IDLE, [], undefined, undefined, undefined, 'gpt-5');
+
+    const modelSurfaces = [0, 1, 2, 3, 4, 5, 6, 7]
+      .map(i => manager.getSlotConfig(i, SD_PLUS_LAYOUT))
+      .filter(c => (c.type === 'status' && c.label === 'MODEL') || (c.type === 'preset' && c.preset?.label === 'MODEL'));
+    expect(modelSurfaces).toHaveLength(1);
+    expect(modelSurfaces[0].type).toBe('preset');
+  });
+
   it('uses actual parser options and reserves MORE only when awaiting overflow exists', () => {
     const manager = new SessionSlotManager();
     manager.updateSessions([makeSession({ state: State.AWAITING_OPTION })], false);

--- a/plugin/src/session-slot-manager.ts
+++ b/plugin/src/session-slot-manager.ts
@@ -508,9 +508,9 @@ export class SessionSlotManager {
     };
   }
 
-  private idleStatusCard(session: SessionInfo | undefined, idx: number): SessionSlotConfig {
+  private idleStatusCard(session: SessionInfo | undefined, idx: number, includeModel = true): SessionSlotConfig {
     const cards = [
-      this.modelStatusCard(session),
+      includeModel ? this.modelStatusCard(session) : null,
       this.modeStatusCard(),
       {
         type: 'status',
@@ -636,16 +636,19 @@ export class SessionSlotManager {
       return this.idleStatusCard(session, contentIdx - CC_PRESET_DEFS.length);
     }
 
+    // OpenClaw already surfaces MODEL as an actionable preset, and PROCESSING
+    // (both agents) already renders the model status tile at content slot 1, so
+    // exclude the model card here to avoid showing MODEL twice.
     if (isOpenClaw && this._detailState === State.IDLE) {
-      return this.idleStatusCard(session, contentIdx - OC_PRESET_DEFS.length);
+      return this.idleStatusCard(session, contentIdx - OC_PRESET_DEFS.length, false);
     }
 
     if (isProcessing && isOpenClaw) {
-      return this.idleStatusCard(session, contentIdx - 1 - OC_PRESET_DEFS.length);
+      return this.idleStatusCard(session, contentIdx - 1 - OC_PRESET_DEFS.length, false);
     }
 
     if (isProcessing && !isOpenClaw) {
-      return this.idleStatusCard(session, contentIdx - 2);
+      return this.idleStatusCard(session, contentIdx - 2, false);
     }
 
     return { type: 'empty' };


### PR DESCRIPTION
## Fix: render the MODEL detail tile exactly once

Closes #9.

In the session detail view, **Claude PROCESSING** explicitly rendered the model status tile at content slot 1 and then `idleStatusCard` — which leads with the model card — filled the remaining slots, so **MODEL appeared twice**. The same double-render hit **OpenClaw** sessions, where MODEL is already an actionable preset.

### Change
`idleStatusCard` now takes an `includeModel` flag; the PROCESSING and OpenClaw branches pass `false` so the model card renders once.

### Tests
Adds regression tests for Claude PROCESSING and OpenClaw idle asserting the MODEL surface appears exactly once. `pnpm vitest run plugin/src/__tests__/session-slot-manager.test.ts` → 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
