### PR TITLE
docs(readme): document -c passthrough for resume / remote-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ The CLI command is `agentdeck`.
 **Flags:** `-p <port>`, `-c <command>`, `-d` (debug), `--no-update-check`
 **Module flags:** `--local` (all off), `--no-mdns`, `--no-adb`, `--no-serial`, `--no-pixoo`
 
+The `-c` flag sets the full command AgentDeck spawns inside the session PTY, so any arguments you add are forwarded straight to the underlying agent. For example, to resume an earlier Claude Code session (the interactive picker appears when no id is given):
+
+```bash
+agentdeck claude -c "claude --resume"
+```
+
+The same pattern passes through any other flag the agent accepts — for instance `-c "claude --remote-control"`.
+
 #### Daemon
 
 | Command | Description |


### PR DESCRIPTION
## Document `-c` argument passthrough in the CLI Reference

Adds a short note to the **CLI Reference → Sessions** section explaining that the `-c <command>` flag sets the full command AgentDeck spawns inside the session PTY, so any appended arguments are forwarded straight to the underlying agent binary.

No code change is needed — `command` is already passed whole to the shell (`pty.spawn(shell, ['-l', '-c', command])` in `bridge/src/pty-manager.ts`), so this capability already exists and was just undocumented.

### Worked example
```bash
agentdeck claude -c "claude --resume"
```
…with a note that the same pattern forwards any other flag the agent accepts (e.g. `-c "claude --remote-control"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
