### PR TITLE
fix(plugin): hide READY/idle tile while a session is PROCESSING

### DIFF
--- a/plugin/src/__tests__/session-slot-manager.test.ts
+++ b/plugin/src/__tests__/session-slot-manager.test.ts
@@ -216,6 +216,30 @@ describe('SessionSlotManager detail layout', () => {
     expect(modelSurfaces[0].type).toBe('preset');
   });
 
+  it('does not render a READY/idle tile while a Claude session is PROCESSING', () => {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([makeSession({ state: State.PROCESSING, modelName: 'claude-opus-4-8' })], false);
+    manager.enterDetailView('session-1');
+    manager.updateDetailState(State.PROCESSING, [], 'Edit', 'cli.ts', undefined, 'claude-opus-4-8', 'acceptEdits');
+
+    const idleTiles = [0, 1, 2, 3, 4, 5, 6, 7]
+      .map(i => manager.getSlotConfig(i, SD_PLUS_LAYOUT))
+      .filter(c => c.type === 'status' && (c.label === 'READY' || c.subtitle === 'idle'));
+    expect(idleTiles).toHaveLength(0);
+  });
+
+  it('does not render a STANDBY/idle tile while an OpenClaw session is PROCESSING', () => {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([makeSession({ id: 'oc', agentType: 'openclaw', state: State.PROCESSING, modelName: 'gpt-5' })], true);
+    manager.enterDetailView('oc');
+    manager.updateDetailState(State.PROCESSING, [], 'route', undefined, undefined, 'gpt-5');
+
+    const idleTiles = [0, 1, 2, 3, 4, 5, 6, 7]
+      .map(i => manager.getSlotConfig(i, SD_PLUS_LAYOUT))
+      .filter(c => c.type === 'status' && (c.label === 'STANDBY' || c.subtitle === 'idle'));
+    expect(idleTiles).toHaveLength(0);
+  });
+
   it('uses actual parser options and reserves MORE only when awaiting overflow exists', () => {
     const manager = new SessionSlotManager();
     manager.updateSessions([makeSession({ state: State.AWAITING_OPTION })], false);

--- a/plugin/src/session-slot-manager.ts
+++ b/plugin/src/session-slot-manager.ts
@@ -508,17 +508,19 @@ export class SessionSlotManager {
     };
   }
 
-  private idleStatusCard(session: SessionInfo | undefined, idx: number, includeModel = true): SessionSlotConfig {
+  private idleStatusCard(session: SessionInfo | undefined, idx: number, includeModel = true, includeIdle = true): SessionSlotConfig {
     const cards = [
       includeModel ? this.modelStatusCard(session) : null,
       this.modeStatusCard(),
-      {
-        type: 'status',
-        label: session?.agentType === 'openclaw' ? 'STANDBY' : 'READY',
-        subtitle: 'idle',
-        icon: 'ready',
-        tone: 'ready',
-      } satisfies SessionSlotConfig,
+      includeIdle
+        ? {
+            type: 'status',
+            label: session?.agentType === 'openclaw' ? 'STANDBY' : 'READY',
+            subtitle: 'idle',
+            icon: 'ready',
+            tone: 'ready',
+          } satisfies SessionSlotConfig
+        : null,
     ].filter((card): card is SessionSlotConfig => card != null);
     return cards[idx] ?? { type: 'empty' };
   }
@@ -643,12 +645,15 @@ export class SessionSlotManager {
       return this.idleStatusCard(session, contentIdx - OC_PRESET_DEFS.length, false);
     }
 
+    // PROCESSING already shows the live tool/status tile at content slot 0, so
+    // the reused idleStatusCard helper must not emit its hardcoded READY/idle
+    // card here — otherwise a busy session shows a contradictory "idle" tile.
     if (isProcessing && isOpenClaw) {
-      return this.idleStatusCard(session, contentIdx - 1 - OC_PRESET_DEFS.length, false);
+      return this.idleStatusCard(session, contentIdx - 1 - OC_PRESET_DEFS.length, false, false);
     }
 
     if (isProcessing && !isOpenClaw) {
-      return this.idleStatusCard(session, contentIdx - 2, false);
+      return this.idleStatusCard(session, contentIdx - 2, false, false);
     }
 
     return { type: 'empty' };


### PR DESCRIPTION
## Fix: hide the READY/idle tile while a session is PROCESSING

In the Stream Deck+ session **detail view**, a busy session showed a contradictory **READY / idle** tile next to the live **WORKING** tile.

### Cause
`getDetailSlotConfig` renders the live tool/status tile at content slot 0 during PROCESSING, then reuses `idleStatusCard()` to pad the remaining slots. But `idleStatusCard()` hardcodes a `READY` / `idle` status card (`STANDBY` / `idle` for OpenClaw) — so that idle card leaked into the PROCESSING layout for an actively-working session.

### Change
`idleStatusCard` gains an `includeIdle` flag (default `true`). The two PROCESSING branches pass `false`, so the idle card is omitted while the session is busy; IDLE layouts are unchanged. Adds regression tests asserting no `READY`/`idle` (Claude) and no `STANDBY`/`idle` (OpenClaw) tile appears in a PROCESSING detail view.

`pnpm vitest run plugin/src/__tests__/session-slot-manager.test.ts` → 10 passed.

### Note
Touches the same `idleStatusCard` helper as #10 (duplicate MODEL tile). The two fixes are independent but overlap on this function, so whichever merges second will need a trivial rebase to combine the `includeModel` and `includeIdle` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
