### PR TITLE
fix(mdns): pin multicast egress to LAN interface on Windows

### DIFF
--- a/bridge/src/mdns.ts
+++ b/bridge/src/mdns.ts
@@ -95,9 +95,26 @@ export function advertiseBridge(
         instance = null;
       }
 
-      instance = new Bonjour();
-
       const lanIp = getLanIp();
+
+      // Windows multi-homed egress fix: a Hyper-V/WSL host has several IPv4
+      // interfaces (the real LAN adapter plus host-only virtual switches on
+      // 172.x and APIPA 169.254.x). Left to its own devices, `multicast-dns`
+      // joins the mDNS group on *all* of them and lets the OS pick the outbound
+      // multicast interface — which can be a virtual switch, so the announcement
+      // never egresses on the WiFi/LAN adapter and a remote iOS device never
+      // sees the service. Pinning `interface` to the default-route LAN IP makes
+      // multicast-dns bind the socket, addMembership, and setMulticastInterface
+      // all to that one adapter. Gated to win32 so macOS/Linux multi-interface
+      // discovery (where bonjour-service correctly fans out) is unaffected.
+      // `interface` isn't on bonjour-service's ServiceConfig type but is passed
+      // straight through to multicast-dns, so cast through the options object.
+      const bonjourOpts =
+        process.platform === 'win32' && lanIp && lanIp !== '127.0.0.1'
+          ? ({ interface: lanIp } as ConstructorParameters<typeof Bonjour>[0])
+          : undefined;
+      instance = new Bonjour(bonjourOpts);
+
       const txt: Record<string, string> = {
         project: projectName,
         agent: agentType,

--- a/shared/src/net-utils.ts
+++ b/shared/src/net-utils.ts
@@ -16,6 +16,7 @@ function defaultRouteIp(): string | null {
   // responsive) without spawning `route` on every connect.
   if (routeCache && now - routeCache.at < 3000) return routeCache.ip;
   let iface: string | null = null;
+  let directIp: string | null = null;
   try {
     if (process.platform === 'darwin') {
       const out = execFileSync('route', ['-n', 'get', 'default'], { timeout: 1000, encoding: 'utf8' });
@@ -23,12 +24,34 @@ function defaultRouteIp(): string | null {
     } else if (process.platform === 'linux') {
       const out = execFileSync('ip', ['route', 'get', '1.1.1.1'], { timeout: 1000, encoding: 'utf8' });
       iface = out.match(/\bdev\s+(\S+)/)?.[1] ?? null;
+    } else if (process.platform === 'win32') {
+      // Windows interface names are friendly strings ("Wi-Fi", "vEthernet (...)"),
+      // so the name-pattern heuristic below can't tell a host-only Hyper-V/WSL
+      // virtual switch (172.x, no gateway) from the real LAN adapter — and on a
+      // Hyper-V host the real LAN IP itself lives on a "vEthernet (External Switch)".
+      // `route print -4 0.0.0.0` resolves this by emitting the *source interface IP*
+      // of each default route directly in the Interface column; pick the lowest
+      // metric so VPN/host-only adapters lose to the physical route.
+      const out = execFileSync('route', ['print', '-4', '0.0.0.0'], { timeout: 1000, encoding: 'utf8' });
+      let bestMetric = Infinity;
+      for (const line of out.split('\n')) {
+        // Network  Netmask  Gateway  Interface  Metric
+        const m = line.trim().match(/^0\.0\.0\.0\s+0\.0\.0\.0\s+\S+\s+(\d+\.\d+\.\d+\.\d+)\s+(\d+)/);
+        if (!m) continue;
+        const candidate = m[1];
+        const metric = parseInt(m[2], 10);
+        if (candidate === '0.0.0.0' || candidate.startsWith('169.254.')) continue;
+        if (metric < bestMetric) {
+          bestMetric = metric;
+          directIp = candidate;
+        }
+      }
     }
   } catch {
     /* route tool missing / non-POSIX → null, fall back to the heuristic */
   }
-  let ip: string | null = null;
-  if (iface) {
+  let ip: string | null = directIp;
+  if (!ip && iface) {
     for (const net of networkInterfaces()[iface] ?? []) {
       if (net.family === 'IPv4' && !net.internal && !net.address.startsWith('169.254.')) {
         ip = net.address;


### PR DESCRIPTION
## Problem

On a Windows Hyper-V/WSL host, the bridge has several IPv4 interfaces — the real LAN adapter plus host-only virtual switches (172.x) and APIPA (169.254.x). `multicast-dns` (under `bonjour-service`) bound the mDNS socket to `0.0.0.0` and let Windows pick the outbound multicast interface, which was a **Hyper-V virtual switch**. The service announcement therefore never egressed on the real WiFi/LAN adapter, so **iOS clients on the LAN never discovered the bridge**.

## Fix

- `bridge/src/mdns.ts`: pass `interface: <default-route LAN ip>` to the `Bonjour` constructor on `win32`, so `multicast-dns` binds the socket, joins the group, and `setMulticastInterface` all on the physical LAN adapter. Gated to `win32` so macOS/Linux multi-interface discovery is unaffected.
- `shared/src/net-utils.ts`: resolve the default-route IPv4 correctly on Windows via `route print -4 0.0.0.0` (lowest-metric source IP), so the advertised TXT `ip=` and pairing URL point at the LAN adapter instead of a virtual switch.

## Verification (on the Hyper-V host)

`dns-sd -B _agentdeck._tcp local.`, before → after:

| | Interface the service multicasts on |
|---|---|
| Before | `if 64` only → `172.25.112.1` (Hyper-V switch) ❌ |
| After | `if 8` → `192.168.1.236` (real LAN) ✅ |

After the change the daemon's mDNS socket binds to `192.168.1.236:5353` (not `0.0.0.0`), the service resolves with TXT `ip=192.168.1.236`, and the iOS app now discovers it. Build clean; integration + net-utils tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)