### PR TITLE
feat(bridge): Windows daemon autostart via per-user Scheduled Task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ This diagnostic path is developer tooling only: it lives in `scripts/` and `.age
 
 ## Windows dev setup
 
-The Node.js bridge, hook installer, and Stream Deck plugin run on Windows 11 (Apple/Android/ESP32 native builds are out of scope). Full prereqs, install/run steps, and the intentional Windows differences (ConPTY, data dir, PowerShell hook one-liner, daemon-install no-op, device-module gating, darwin-only sampler) live in **[README → Windows (Bridge + Plugin)](README.md#windows-bridge--plugin)**. Code refs: `bridge/src/pty-manager.ts`, `hooks/src/install.ts`, `bridge/src/cli.ts`.
+The Node.js bridge, hook installer, and Stream Deck plugin run on Windows 11 (Apple/Android/ESP32 native builds are out of scope). Full prereqs, install/run steps, and the intentional Windows differences (ConPTY, data dir, PowerShell hook one-liner, daemon autostart via per-user Scheduled Task `AgentDeckDaemon` — `bridge/src/windows-service.ts`, NOT a session-0 Windows Service, device-module gating, darwin-only sampler) live in **[README → Windows (Bridge + Plugin)](README.md#windows-bridge--plugin)**. Code refs: `bridge/src/pty-manager.ts`, `hooks/src/install.ts`, `bridge/src/cli.ts`, `bridge/src/windows-service.ts`.
 
 Dev-only note: when debugging Windows issues, run commands directly in PowerShell so output appears in the conversation — the Apple/Xcode diagnostic bundle is macOS-only.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ agentdeck claude        # spawns Claude Code via Windows ConPTY (cmd.exe /d /s /
 - **Data dir** — `%USERPROFILE%\.agentdeck\` (same layout as macOS `~/.agentdeck/`). `AGENTDECK_DATA_DIR` override still works.
 - **PTY** — ConPTY through `cmd.exe` with `/d /s /c` (POSIX uses `/bin/zsh -l -c`). `node-pty`'s Windows prebuild is used as-is, so no Visual Studio Build Tools are required.
 - **Hooks** — Claude Code hook entries run a `powershell -NoProfile -ExecutionPolicy Bypass -Command "…"` one-liner that reads `daemon.json`, probes `/health`, and POSTs the payload via `Invoke-RestMethod`.
-- **`agentdeck daemon install` / `uninstall`** — no-op with a friendly message. There is no autostart yet; run `agentdeck daemon start` yourself, or add a Startup-folder shortcut. (See the Windows daemon TODO in the [Roadmap](#roadmap).)
+- **`agentdeck daemon install` / `uninstall`** — registers a per-user **Scheduled Task** `AgentDeckDaemon` with a logon trigger (built-in `schtasks.exe`, no admin elevation), the Windows analog of the macOS LaunchAgent. `install` registers + starts it now and installs Codex hooks; `uninstall` stops the daemon and removes the task. A real Windows Service is intentionally **not** used — it runs in session 0 with no desktop/device access, breaking USB-HID (D200H), audio (wake-word), and the Stream Deck app. See [docs/daemon.md → Autostart](docs/daemon.md#autostart-loginlogon).
 - **Device modules** — `adb` is probed cross-platform; the `/dev/tty.*` USB-serial scan is skipped on Windows (COM-port enumeration not implemented). mDNS, `node-hid` (D200H), and `better-sqlite3` (APME) use Windows-compatible prebuilds.
 - **APME hardware sampler** is darwin-only — it returns a minimal snapshot on Windows and the recommender treats that as "neutral".
 - **macOS-only plugin utility actions** (brightness / volume / dark-mode via `osascript`) gracefully no-op on Windows.
@@ -385,8 +385,8 @@ The same pattern passes through any other flag the agent accepts — for instanc
 | `agentdeck daemon stop` | Stop daemon |
 | `agentdeck daemon restart` | Restart daemon |
 | `agentdeck daemon status` | Show daemon status |
-| `agentdeck daemon install` | Register macOS LaunchAgent (auto-start) |
-| `agentdeck daemon uninstall` | Remove LaunchAgent |
+| `agentdeck daemon install` | Register auto-start (macOS LaunchAgent / Windows Scheduled Task) |
+| `agentdeck daemon uninstall` | Remove auto-start (LaunchAgent / Scheduled Task) |
 
 #### Session Management
 
@@ -1076,7 +1076,7 @@ Eval results broadcast to every device simultaneously (Stream Deck/Apple/Android
 
 ### Planned
 
-- [ ] **Windows daemon autostart / background service** — today `agentdeck daemon install` is a no-op on Windows and the daemon must be started manually with `agentdeck daemon start` in a terminal (run locally). Add native autostart (Windows Service or a Startup/Task Scheduler registration) so the daemon runs in the background like the macOS LaunchAgent
+- [x] **Windows daemon autostart** — `agentdeck daemon install` registers a per-user Scheduled Task (`AgentDeckDaemon`, logon trigger) so the daemon auto-starts in the interactive session, the Windows analog of the macOS LaunchAgent. See [docs/daemon.md → Autostart](docs/daemon.md#autostart-loginlogon).
 - [ ] Play Store distribution (Android app)
 - [ ] Stream Deck Marketplace registration (plugin distribution)
 

--- a/bridge/src/__tests__/windows-service.test.ts
+++ b/bridge/src/__tests__/windows-service.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the Windows Scheduled Task XML builder (pure, cross-platform).
+ *
+ * The schtasks /Create|/Run|/Query|/Delete calls in windows-service.ts are
+ * integration-only — they require a real Windows host and mutate the Task
+ * Scheduler — and are exercised manually per docs/daemon.md, not here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TASK_NAME,
+  xmlEscape,
+  buildScheduledTaskXml,
+} from '../windows-service.js';
+
+describe('xmlEscape', () => {
+  it('escapes XML metacharacters', () => {
+    expect(xmlEscape('a & b < c > d "e"')).toBe('a &amp; b &lt; c &gt; d &quot;e&quot;');
+  });
+});
+
+describe('buildScheduledTaskXml', () => {
+  const node = 'C:\\Program Files\\nodejs\\node.exe';
+  const cliJs = 'C:\\Users\\Test User\\AppData\\agentdeck\\cli.js';
+
+  it('produces a well-formed v1.2 task with a logon trigger', () => {
+    const xml = buildScheduledTaskXml({ node, cliJs, user: 'CORP\\alice' });
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-16"?>');
+    expect(xml).toContain('<Task version="1.2"');
+    expect(xml).toContain('<LogonTrigger>');
+    expect(xml).toContain(`<URI>\\${TASK_NAME}</URI>`);
+    expect(xml).toContain('<LogonType>InteractiveToken</LogonType>');
+    expect(xml).toContain('<RunLevel>LeastPrivilege</RunLevel>');
+  });
+
+  it('mirrors LaunchAgent KeepAlive / no-stop semantics', () => {
+    const xml = buildScheduledTaskXml({ node, cliJs });
+    expect(xml).toContain('<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>');
+    expect(xml).toContain('<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>');
+    expect(xml).toContain('<StopOnIdleEnd>false</StopOnIdleEnd>');
+    expect(xml).toContain('<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>');
+    expect(xml).toMatch(/<RestartOnFailure>\s*<Interval>PT1M<\/Interval>\s*<Count>3<\/Count>/);
+  });
+
+  it('uses node as unquoted Command and quotes the cli.js path in Arguments', () => {
+    const xml = buildScheduledTaskXml({ node, cliJs });
+    expect(xml).toContain(`<Command>${node}</Command>`);
+    // cli.js path has a space — must be wrapped in quotes inside Arguments.
+    expect(xml).toContain(`<Arguments>&quot;${cliJs}&quot; daemon start --foreground</Arguments>`);
+  });
+
+  it('XML-escapes special characters in the user id and paths', () => {
+    const xml = buildScheduledTaskXml({
+      node: 'C:\\n&ode.exe',
+      cliJs: 'C:\\c<li>.js',
+      user: 'DOM&AIN\\b<ob>',
+    });
+    expect(xml).toContain('<Command>C:\\n&amp;ode.exe</Command>');
+    expect(xml).toContain('c&lt;li&gt;.js');
+    expect(xml).not.toMatch(/<UserId>[^<]*&(?!amp;|lt;|gt;|quot;)/);
+    expect(xml).toContain('DOM&amp;AIN\\b&lt;ob&gt;');
+  });
+
+  it('places both UserId fields (trigger + principal) with the same user', () => {
+    const xml = buildScheduledTaskXml({ node, cliJs, user: 'CORP\\alice' });
+    const matches = xml.match(/<UserId>CORP\\alice<\/UserId>/g);
+    expect(matches).toHaveLength(2);
+  });
+});

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -8,6 +8,14 @@ import { execSync, spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { BRIDGE_WS_PORT } from './types.js';
+import {
+  TASK_NAME,
+  installWindowsTask,
+  taskExists,
+  runWindowsTask,
+  endWindowsTask,
+  deleteWindowsTask,
+} from './windows-service.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json') as { version: string };
@@ -369,12 +377,38 @@ daemon
 
 daemon
   .command('install')
-  .description('Install macOS LaunchAgent for auto-start')
+  .description('Install daemon auto-start (LaunchAgent on macOS, Scheduled Task on Windows)')
   .action(async () => {
     if (process.platform === 'win32') {
-      log('agentdeck daemon install/uninstall is not supported on Windows.');
-      log("Start the daemon manually with: agentdeck daemon start");
-      log('(Add to the Startup folder yourself if you want it to autostart.)');
+      try {
+        installWindowsTask();
+        log(`Scheduled task '${TASK_NAME}' registered. Daemon will auto-start on logon.`);
+      } catch (e) {
+        const detail = (e as { stderr?: Buffer }).stderr?.toString().trim() || (e as Error).message;
+        log('Failed to register the AgentDeck scheduled task.');
+        if (detail) log(detail);
+        log('You can still run the daemon manually with: agentdeck daemon start');
+        log('(or add a shortcut to shell:startup to autostart it yourself).');
+        process.exit(1);
+      }
+      // Start it now so the user does not have to log out/in (the singleton
+      // guard makes a double-start a safe no-op).
+      try {
+        runWindowsTask();
+        log('Daemon started.');
+      } catch {
+        log('Task registered; immediate start failed — it will start on next logon.');
+      }
+      // Install Codex lifecycle hooks for parity with the macOS install path.
+      try {
+        const { installCodexHooksIfNeeded } = await import('@agentdeck/hooks');
+        const result = installCodexHooksIfNeeded();
+        if (result.installed) {
+          log('Codex lifecycle hooks installed in ~/.codex/config.toml');
+        } else if (result.reason) {
+          log(`Codex hooks skipped: ${result.reason}`);
+        }
+      } catch { /* hooks package not built yet — task install still succeeds */ }
       process.exit(0);
     }
     if (process.platform !== 'darwin') {
@@ -402,10 +436,25 @@ daemon
 
 daemon
   .command('uninstall')
-  .description('Remove macOS LaunchAgent')
-  .action(() => {
+  .description('Remove daemon auto-start (LaunchAgent on macOS, Scheduled Task on Windows)')
+  .action(async () => {
     if (process.platform === 'win32') {
-      log('agentdeck daemon install/uninstall is not supported on Windows.');
+      if (!taskExists()) {
+        log(`Scheduled task '${TASK_NAME}' is not installed.`);
+        process.exit(0);
+      }
+      // Graceful daemon shutdown first, then stop + delete the task.
+      await stopDaemon(BRIDGE_WS_PORT);
+      try { endWindowsTask(); } catch { /* not running */ }
+      try {
+        deleteWindowsTask();
+        log(`Scheduled task '${TASK_NAME}' removed.`);
+      } catch (e) {
+        const detail = (e as { stderr?: Buffer }).stderr?.toString().trim() || (e as Error).message;
+        log('Failed to remove the scheduled task.');
+        if (detail) log(detail);
+        process.exit(1);
+      }
       process.exit(0);
     }
     if (!existsSync(PLIST_PATH)) {

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -838,10 +838,22 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     });
     httpServer.listen(port, '0.0.0.0', () => resolve());
   }).catch(async (err: Error) => {
-    // Handle race condition: port became unavailable after probe
+    // Handle race condition: port became unavailable after our pre-bind probe.
+    // This is the concurrent-start case (e.g. two logon-trigger fires landing
+    // within ~1s): both processes pass the singleton guard because neither has
+    // bound yet, then exactly one wins the OS bind and the rest get EADDRINUSE.
     if (err.message.startsWith('EADDRINUSE:') && port === requestedPort) {
+      // Re-probe the occupant. If ANOTHER daemon grabbed the port, we lost the
+      // race — exit instead of falling back to a new port, or we'd leave two
+      // daemons running (and clobber daemon.json to point at the wrong one).
+      // Only fall back when a *non-daemon* (e.g. a session bridge) holds it.
+      const occupant = await probeDaemonHealth(requestedPort);
+      if (occupant?.mode === 'daemon') {
+        log(`[agentdeck] Lost startup race for port ${requestedPort} (PID ${occupant.pid} already serving). Exiting.`);
+        process.exit(0);
+      }
       port = await findAvailablePort();
-      log(`[agentdeck] Port ${requestedPort} grabbed, retrying on ${port}...`);
+      log(`[agentdeck] Port ${requestedPort} grabbed by ${occupant?.mode ?? 'a non-daemon'}, retrying on ${port}...`);
       await new Promise<void>((resolve, reject) => {
         httpServer.on('error', (e: NodeJS.ErrnoException) => reject(e));
         httpServer.listen(port, '0.0.0.0', () => resolve());

--- a/bridge/src/windows-service.ts
+++ b/bridge/src/windows-service.ts
@@ -1,0 +1,149 @@
+/**
+ * Windows daemon autostart via a per-user Scheduled Task (logon trigger).
+ *
+ * The macOS LaunchAgent analog on Windows is a per-user Scheduled Task with a
+ * logon trigger — NOT a real Windows Service. A service runs in session 0 with
+ * no desktop and restricted device access, which breaks the daemon's USB-HID
+ * (D200H), audio (wake-word), mDNS, and Stream Deck app integration. A logon
+ * task runs in the interactive user session, needs no admin elevation, and uses
+ * only the built-in schtasks.exe (no npm dependency).
+ *
+ * The pure XML/args builder is unit-tested (cross-platform); the schtasks
+ * /Create|/Run|/Query|/Delete calls are integration-only (real Windows host +
+ * side effects) and are exercised manually per docs/daemon.md.
+ */
+import { writeFileSync, unlinkSync } from 'fs';
+import { homedir, tmpdir, userInfo } from 'os';
+import { dirname, join } from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+export const TASK_NAME = 'AgentDeckDaemon';
+
+export function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Resolve node.exe + cli.js directly rather than the `agentdeck` npm shim: the
+// global bin on Windows is an `agentdeck.cmd` wrapper whose quoting breaks the
+// Task Scheduler <Command>/<Arguments> split. process.execPath is the running
+// node; cli.js sits next to this module in the dist dir.
+export function getDaemonNodeTarget(): { node: string; cliJs: string } {
+  const distDir = dirname(fileURLToPath(import.meta.url));
+  return { node: process.execPath, cliJs: join(distDir, 'cli.js') };
+}
+
+export function getCurrentTaskUser(): string {
+  const domain = process.env.USERDOMAIN;
+  const user = process.env.USERNAME || userInfo().username;
+  return domain ? `${domain}\\${user}` : user;
+}
+
+export function buildScheduledTaskXml(opts?: { node?: string; cliJs?: string; user?: string }): string {
+  const { node, cliJs } = { ...getDaemonNodeTarget(), ...opts };
+  const user = opts?.user ?? getCurrentTaskUser();
+  const workingDir = join(homedir(), '.agentdeck');
+  const command = xmlEscape(node);
+  // cli.js wrapped in quotes to survive paths with spaces; --foreground so the
+  // task process IS the daemon (lets RestartOnFailure track the real process).
+  const args = xmlEscape(`"${cliJs}" daemon start --foreground`);
+  const userEsc = xmlEscape(user);
+  // schtasks /XML requires UTF-16 with a BOM (see installWindowsTask); declaring
+  // UTF-8 triggers "unable to switch the encoding". The bytes are written as
+  // UTF-16LE+BOM at install time to match this declaration.
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>AgentDeck monitoring daemon (auto-start on logon)</Description>
+    <URI>\\${TASK_NAME}</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>${userEsc}</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>${userEsc}</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${command}</Command>
+      <Arguments>${args}</Arguments>
+      <WorkingDirectory>${xmlEscape(workingDir)}</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>`;
+}
+
+/**
+ * Register (or overwrite) the AgentDeckDaemon scheduled task.
+ * Throws if schtasks /Create fails (e.g. group policy disabling user task creation).
+ */
+export function installWindowsTask(): void {
+  const xml = buildScheduledTaskXml();
+  const tmpFile = join(tmpdir(), `agentdeck-task-${process.pid}-${Date.now()}.xml`);
+  // Write UTF-16LE with a BOM (U+FEFF) — schtasks /XML rejects UTF-8 here.
+  writeFileSync(tmpFile, '﻿' + xml, 'utf16le');
+  try {
+    // /F overwrites an existing task (idempotent; mirrors macOS unload-before-load).
+    execSync(`schtasks /Create /TN "${TASK_NAME}" /XML "${tmpFile}" /F`, { stdio: 'pipe' });
+  } finally {
+    try { unlinkSync(tmpFile); } catch { /* temp cleanup best-effort */ }
+  }
+}
+
+/** True if the AgentDeckDaemon scheduled task is registered. */
+export function taskExists(): boolean {
+  try {
+    execSync(`schtasks /Query /TN "${TASK_NAME}"`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Start the registered task immediately (so no logout is required). */
+export function runWindowsTask(): void {
+  execSync(`schtasks /Run /TN "${TASK_NAME}"`, { stdio: 'pipe' });
+}
+
+/** Stop a running task instance (best-effort; ignores "not running"). */
+export function endWindowsTask(): void {
+  execSync(`schtasks /End /TN "${TASK_NAME}"`, { stdio: 'pipe' });
+}
+
+/** Delete the registered task (/F suppresses the confirm prompt). */
+export function deleteWindowsTask(): void {
+  execSync(`schtasks /Delete /TN "${TASK_NAME}" /F`, { stdio: 'pipe' });
+}

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -55,6 +55,15 @@ Daemon owns port **9120** (default, fallback to 9121+ if occupied by non-daemon)
 
 `httpServer.close()` + 5s `setTimeout(() => process.exit(0))` — CLOSE_WAIT connections from disconnected clients can block `close()` callback indefinitely, causing zombie daemons (session bridge has 3s failsafe in `index.ts`).
 
+## Autostart (login/logon)
+
+- **macOS** — per-user **LaunchAgent** `dev.agentdeck.daemon` (`~/Library/LaunchAgents/`), `RunAtLoad=true`, `KeepAlive.SuccessfulExit=false`. `agentdeck daemon install` writes the plist + `launchctl load`; `uninstall` unloads + deletes it.
+- **Windows** — per-user **Scheduled Task** `AgentDeckDaemon` with a **logon trigger**, registered via built-in `schtasks.exe` (no npm dependency, no admin elevation). `agentdeck daemon install` registers + immediately `/Run`s it and installs Codex hooks; `uninstall` gracefully `/shutdown`s the daemon then `/Delete`s the task. Builder + schtasks wrappers live in `bridge/src/windows-service.ts`; the pure XML builder is unit-tested in `bridge/src/__tests__/windows-service.test.ts` (the schtasks calls are integration-only).
+  - **Why a Scheduled Task, not a Windows Service**: a real service runs in **session 0** with no desktop and restricted device access, which breaks USB-HID (D200H), audio (wake-word), mDNS, and the Stream Deck app. A logon task runs in the **interactive user session** — the exact analog of the macOS *per-user* LaunchAgent.
+  - Task settings mirror the LaunchAgent: `LogonType=InteractiveToken` + `RunLevel=LeastPrivilege` (no elevation), `MultipleInstancesPolicy=IgnoreNew` (the singleton guard already dedupes), `RestartOnFailure` Interval=PT1M/Count=3 (≈KeepAlive), `ExecutionTimeLimit=PT0S`, no stop on idle/battery. Action runs `node.exe "<cli.js>" daemon start --foreground` so the task process **is** the daemon (lets RestartOnFailure track the real process).
+  - The task XML is written **UTF-16LE + BOM** with an `encoding="UTF-16"` declaration — `schtasks /XML` rejects UTF-8 (`unable to switch the encoding`).
+  - `daemon.json` discovery, port fallback, singleton guard, and graceful `/shutdown` are reused unchanged across both platforms.
+
 ## Whisper-server
 
 Uses fixed singleton port **9100** (`~/.agentdeck/whisper-server.json` info file for discovery, last session exit kills server).

--- a/setup/src/setup.ts
+++ b/setup/src/setup.ts
@@ -382,6 +382,8 @@ function success() {
   console.log('  2. Add AgentDeck actions to your Stream Deck profile');
   console.log("  3. Run 'agentdeck claude' or 'agentdeck codex' in terminal to start the bridge");
   console.log("     Codex observation hooks are installed automatically by 'agentdeck codex'");
+  console.log("  4. Optional: run 'agentdeck daemon install' to auto-start the daemon on login");
+  console.log("     (macOS LaunchAgent / Windows Scheduled Task)");
   console.log('');
   console.log('  Usage:');
   console.log('    agentdeck claude   Start bridge + Claude');


### PR DESCRIPTION
## Summary

Wires `agentdeck daemon install/uninstall` on Windows to register a per-user **Scheduled Task** (`AgentDeckDaemon`, logon trigger) via built-in `schtasks.exe` — the Windows analog of the macOS LaunchAgent. It runs in the interactive session (so USB-HID / audio / mDNS / Stream Deck app all work), needs no admin elevation, and adds no npm dependency. A session-0 Windows Service is intentionally **not** used.

## Changes

- **`bridge/src/windows-service.ts`**: pure `buildScheduledTaskXml()` (UTF-16+BOM, `RestartOnFailure`≈KeepAlive, `IgnoreNew`, `InteractiveToken`/`LeastPrivilege`, `node.exe` + quoted `cli.js` + `--foreground`) plus `schtasks` wrappers.
- **`bridge/src/cli.ts`**: win32 branches for install (register → run → Codex hooks, with fallback message) and uninstall (graceful `/shutdown` → `/Delete`, idempotent).
- **`bridge/src/daemon-server.ts`**: close a startup race exposed by autostart — when two daemon starts land within ~1s (concurrent logon-trigger fires), both passed the pre-bind singleton guard, then the loser hit `EADDRINUSE` and fell back to a fresh port, leaving two daemons and a clobbered `daemon.json`. Now on `EADDRINUSE` for the default port we re-probe `/health`: if a daemon already owns it, `exit(0)`; only fall back to a new port for a non-daemon occupant (session bridge), preserving prior behavior.
- **`setup/src/setup.ts`**: platform-neutral "optional daemon install" next-steps nudge.
- **`bridge/src/__tests__/windows-service.test.ts`**: unit tests for the XML builder.
- **docs**: `daemon.md` Autostart section, README + CLAUDE.md updates.

## Test

`windows-service.test.ts` covers the XML builder. Install/uninstall verified on Windows 11 (Scheduled Task registers, runs at logon, idempotent uninstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)