### PR TITLE
feat(plugin): OFFLINE onboarding → daemon install + marketplace release docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,8 @@ AgentDeck is a monorepo of independently-shipped artifacts. Each ships on its **
 | **Android** | `android/app/build.gradle.kts` → `versionName` + `versionCode` | `android-v*` | `.github/workflows/android-release.yml` → APK Release | 0.1.0 / code 1 |
 | **npm** (`@agentdeck/*`) | each `package.json` `version` (kept in lockstep) | `npm-v*` | manual `pnpm -r publish` | 0.1.0 source (registry latest 0.2.x — see note) |
 | **ESP32** firmware | `esp32/src/config.h` → `FIRMWARE_VERSION` | `esp32-v*` | `.github/workflows/esp32-release.yml` | 0.1.1 |
+| **Stream Deck** (Elgato Marketplace) | `plugin/bound.serendipity.agentdeck.sdPlugin/manifest.json` → `Version` (4-part `X.Y.Z.B`) | `streamdeck-v*` | manual: `pnpm package` → upload `.streamDeckPlugin` to Elgato Maker portal | 0.1.0.0 |
+| **Ulanzi** (Ulanzi Studio Marketplace) | `plugin-ulanzi/com.ulanzi.ulanzistudio.agentdeck.ulanziPlugin/manifest.json` → `Version` | `ulanzi-v*` | manual: `pnpm --filter @agentdeck/plugin-ulanzi package` → upload the `.ulanziPlugin` folder | 0.1.0 |
 
 ## Hard constraints (why we can't just renumber)
 
@@ -49,6 +51,30 @@ To publish a real release (forward version):
 ### ESP32 firmware
 1. Bump `FIRMWARE_VERSION` in `esp32/src/config.h`.
 2. `git tag esp32-v<VERSION> && git push origin esp32-v<VERSION>`.
+
+### Stream Deck plugin (Elgato Marketplace)
+1. Bump `Version` (4-part `X.Y.Z.B`, must **increase** for marketplace updates) in `plugin/.../manifest.json`. Optionally update the embedded `Version` in the bundled profile snapshots for consistency.
+2. `pnpm package` → `dist/bound.serendipity.agentdeck.streamDeckPlugin`.
+3. Upload via the Elgato Maker portal (Marketplace). The UUID `bound.serendipity.agentdeck` is **immutable post-distribution** — never change it.
+4. `git tag streamdeck-v<VERSION> && git push origin streamdeck-v<VERSION>` (annotation only — no CI consumes it).
+
+### Ulanzi plugin (Ulanzi Studio Marketplace)
+1. Bump `Version` in `plugin-ulanzi/.../manifest.json`.
+2. `pnpm --filter @agentdeck/plugin-ulanzi package` → `plugin-ulanzi/dist/com.ulanzi.ulanzistudio.agentdeck.ulanziPlugin/` (zip the folder for upload).
+3. Upload via the Ulanzi Studio Marketplace portal.
+4. `git tag ulanzi-v<VERSION> && git push origin ulanzi-v<VERSION>`.
+
+## Marketplace plugins are thin clients — the daemon is a separate install
+
+The Stream Deck and Ulanzi plugins are **WebSocket clients of the AgentDeck daemon** (port 9120); they do **not** embed or spawn the daemon. The daemon is a singleton that installs Claude/Codex hooks and manages the user's coding sessions — it must be installed once per dev machine, via either:
+
+- **Node CLI** — `npx @agentdeck/setup` (or `agentdeck daemon start`), or
+- **macOS app** — the App Store build runs an in-process Swift daemon.
+
+Do not bundle the daemon into a marketplace plugin: it would collide with the existing daemon on port 9120 (singleton / split-brain) and silently edit the user's shell config from a plugin install. Instead:
+
+- **Marketplace listing** must state the prerequisite ("Requires AgentDeck — install with `npx @agentdeck/setup` or the macOS app"), the way the OBS plugin requires OBS.
+- **In-product onboarding**: when no daemon is reachable the plugin shows an OFFLINE state. The Stream Deck encoder OFFLINE strip points the user to `npx @agentdeck/setup` (`shared/src/svg-renderers/session-slot-renderer.ts → renderOfflineTouchStrip`). The Ulanzi/D200H OFFLINE hero copy (`shared/src/d200h-layout.ts`) should carry the same hint — **TODO**, deferred to avoid a concurrent edit.
 
 ## After a bundle-ID change (Apple) — manual ASC steps
 

--- a/plugin/src/__tests__/encoder-offline-policy.test.ts
+++ b/plugin/src/__tests__/encoder-offline-policy.test.ts
@@ -25,7 +25,7 @@ describe('renderOfflineTouchStrip — all-or-nothing 800px slice contract', () =
       const svg = renderOfflineTouchStrip(i);
       expect(svg).toContain('width="200" height="100"');
       expect(svg).toContain('AGENTDECK OFFLINE');
-      expect(svg).toContain('launch AgentDeck application');
+      expect(svg).toContain('npx @agentdeck/setup');
     }
   });
 

--- a/shared/src/svg-renderers/session-slot-renderer.ts
+++ b/shared/src/svg-renderers/session-slot-renderer.ts
@@ -600,7 +600,7 @@ export function renderOfflineTouchStrip(index: number): string {
 
     // Center: Offline text and helper instruction
     `<text x="400" y="44" text-anchor="middle" font-family="${fontFam}" font-size="22" font-weight="800" fill="${colors.text}">AGENTDECK OFFLINE</text>`,
-    `<text x="400" y="70" text-anchor="middle" font-family="${fontFam}" font-size="12" font-weight="650" fill="${colors.sub}" opacity="0.86">Press any button or dial to launch AgentDeck application</text>`,
+    `<text x="400" y="70" text-anchor="middle" font-family="${fontFam}" font-size="12" font-weight="650" fill="${colors.sub}" opacity="0.86">Open the AgentDeck app — or install:  npx @agentdeck/setup</text>`,
 
     // Right side: offline icon (x=680, y=50)
     renderGlyphIcon('offline', colors.icon, colors.accent, 680, 50, 1.2),


### PR DESCRIPTION
## Summary
Prepares the **Stream Deck (Elgato)** and **Ulanzi Studio** plugins as marketplace releases at **0.1.0**, keeping them as **thin WS clients** of the AgentDeck daemon (no embedded daemon).

## Why not embed the daemon
The daemon is a port-9120 **singleton** that installs Claude/Codex hooks and manages the user's coding sessions. Embedding it in a marketplace plugin would collide with the daemon already provided by `npx @agentdeck/setup` or the macOS app (split-brain) and silently edit shell config from a plugin install. So plugins stay clients; the daemon is a separate install (like the OBS plugin requires OBS).

## Changes
- **Onboarding**: Stream Deck encoder OFFLINE strip now reads *"Open the AgentDeck app — or install: npx @agentdeck/setup"* instead of the misleading "press any button to launch" (wrong when no daemon is installed). `renderOfflineTouchStrip`.
- **Docs**: `RELEASING.md` gains `streamdeck-v*` + `ulanzi-v*` tracks and a section on the thin-client model + daemon prerequisite + why not to embed.
- Version reset (`0.4.0.0 → 0.1.0.0` Stream Deck manifest) landed in the prior commit on master; Ulanzi manifest was already `0.1.0`.

## Deferred
- Ulanzi/D200H OFFLINE hero copy (`shared/src/d200h-layout.ts`) should carry the same install hint — left as a TODO to avoid a concurrent edit on that file.

## Verification
- Build green; targeted tests 67 passed (offline-policy assertion updated to the new copy; `renderOfflineTouchStrip` is not snapshotted so no snapshot churn).
- Both plugins packaged from clean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)