### PR TITLE
feat(ulanzi): D200H OFFLINE hero → daemon install onboarding

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,7 +80,7 @@ The Stream Deck and Ulanzi plugins are **WebSocket clients of the AgentDeck daem
 Do not bundle the daemon into a marketplace plugin: it would collide with the existing daemon on port 9120 (singleton / split-brain) and silently edit the user's shell config from a plugin install. Instead:
 
 - **Marketplace listing** must state the prerequisite ("Requires AgentDeck — install with `npx @agentdeck/setup` or the macOS app"), the way the OBS plugin requires OBS.
-- **In-product onboarding**: when no daemon is reachable the plugin shows an OFFLINE state. The Stream Deck encoder OFFLINE strip points the user to `npx @agentdeck/setup` (`shared/src/svg-renderers/session-slot-renderer.ts → renderOfflineTouchStrip`). The Ulanzi/D200H OFFLINE hero copy (`shared/src/d200h-layout.ts`) should carry the same hint — **TODO**, deferred to avoid a concurrent edit.
+- **In-product onboarding**: when no daemon is reachable the plugin shows an OFFLINE state pointing the user to `npx @agentdeck/setup`. Stream Deck encoder strip: `shared/src/svg-renderers/session-slot-renderer.ts → renderOfflineTouchStrip`. Ulanzi/D200H OFFLINE hero: `shared/src/d200h-layout.ts` (center-key `renderInfoSlot` detail).
 
 ## After a bundle-ID change (Apple) — manual ASC steps
 

--- a/shared/src/d200h-layout.ts
+++ b/shared/src/d200h-layout.ts
@@ -415,12 +415,13 @@ export function buildSessionDeck(stateEvt: any, view: DeckView, positions: strin
   if (slots.length === 0) return out;
 
   // Daemon down → OFFLINE hero on the center key, rest dim. Every key launches
-  // the companion app on press (parity with the SD/SD+ keypad, which opens the
-  // app from any key while disconnected), so "press any key" always works.
+  // the companion app on press (parity with the SD/SD+ keypad). If AgentDeck
+  // isn't installed yet, the hero shows the install command so a marketplace-only
+  // user knows the daemon is the missing piece.
   if (state.state === 'DISCONNECTED' || state.state === 'disconnected') {
     const hero = Math.floor(slots.length / 2);
     slots.forEach((pos, i) => out.set(pos, {
-      svg: i === hero ? renderInfoSlot('OFFLINE', 'Open AgentDeck', 'activity', 'info', 'press any key') : renderEmptySlot(),
+      svg: i === hero ? renderInfoSlot('OFFLINE', 'Open AgentDeck', 'activity', 'info', 'npx @agentdeck/setup') : renderEmptySlot(),
       action: { kind: 'launch' },
     }));
     return out;


### PR DESCRIPTION
Completes marketplace onboarding parity — D200H/Ulanzi OFFLINE hero now points to `npx @agentdeck/setup` (matching the Stream Deck strip from #25). One-line copy change in `d200h-layout.ts` (non-overlapping with concurrent work in the same file) + clears the RELEASING.md TODO. d200h tests green (18 passed, not snapshot-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)