### PR TITLE
fix(openclaw): unify visibility under a single presence-driven predicate

### DIFF
--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
@@ -141,36 +141,29 @@ fun DashboardState.toTerrariumState(): TerrariumState {
     // Reachability alone (`gatewayAvailable`) used to trigger a cheerful
     // SITTING crayfish even when the shared token was missing, which
     // misled users into thinking OpenClaw was wired up.
+    // Presence-driven SSOT: the crayfish tracks the OpenClaw SESSION that the
+    // daemon emits — never raw gateway flags. The daemon injects an `openclaw`
+    // session iff the Gateway is authenticated (isOpenClawSessionActive), so
+    // `ocSibling == null` means OpenClaw is not an active, routable agent and
+    // the crayfish must stay hidden — even if the port is reachable or doctor
+    // reports an error. This kills the "OpenClaw won't go away" trace.
     val ocSibling = siblingSessions.firstOrNull { it.agentType == "openclaw" }
-    val hasGatewayError = gatewayAvailable == true && gatewayHasError == true
+    val hasGatewayError = gatewayHasError == true
     val crayfish = when {
-        // Gateway not authenticated and no error to surface — hide.
-        gatewayConnected != true && !hasGatewayError -> CrayfishVisualState.DORMANT
-        // OpenClaw's own sibling state is authoritative — read it before
-        // falling back to the aggregate `effectiveAgentState`. Without
-        // this, an OpenClaw aggregate primary inherits Claude's PROCESSING
-        // through `effectiveAgentState` and the crayfish wrongly routes.
-        ocSibling != null -> when (ocSibling.state) {
+        // No emitted OpenClaw session — hide regardless of gateway flags.
+        ocSibling == null -> CrayfishVisualState.DORMANT
+        // OpenClaw's own sibling state is authoritative.
+        else -> when (ocSibling.state) {
             "processing" -> CrayfishVisualState.ROUTING
             "idle" -> CrayfishVisualState.SITTING
             "awaiting_permission", "awaiting_option", "awaiting_diff" -> CrayfishVisualState.WAITING
             else -> if (ocSibling.alive) CrayfishVisualState.SITTING else CrayfishVisualState.DORMANT
         }
-        // Primary is OpenClaw but no sibling row yet (sessions_list pending).
-        isOpenClaw -> when (effectiveAgentState) {
-            AgentState.PROCESSING -> CrayfishVisualState.ROUTING
-            AgentState.IDLE -> CrayfishVisualState.SITTING
-            AgentState.DISCONNECTED -> CrayfishVisualState.DORMANT
-            else -> CrayfishVisualState.WAITING
-        }
-        // Gateway authenticated but no OpenClaw session yet.
-        gatewayConnected == true -> CrayfishVisualState.SITTING
-        // Only error surfaces remain — fall through to SICK below.
-        else -> CrayfishVisualState.SITTING
     }
 
-    // Override to SICK if gateway has errors (but not when DORMANT — gateway unreachable)
-    val effectiveCrayfish = if (hasGatewayError && crayfish != CrayfishVisualState.DORMANT) {
+    // SICK override only when an active OpenClaw session is also erroring — an
+    // error with no live session must not spawn a creature.
+    val effectiveCrayfish = if (hasGatewayError && ocSibling != null && crayfish != CrayfishVisualState.DORMANT) {
         CrayfishVisualState.SICK
     } else {
         crayfish
@@ -341,7 +334,8 @@ fun DashboardState.toTerrariumState(): TerrariumState {
         agents = agents,
         cloudCreatures = cloudCreatures,
         openCodeCreatures = openCodeCreatures,
-        workerCrayfishCount = if (gatewayConnected == true) workerSessionCount ?: 0 else 0,
+        // Presence-driven: worker crayfish only when an OpenClaw session exists.
+        workerCrayfishCount = if (ocSibling != null) workerSessionCount ?: 0 else 0,
     )
 }
 

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/eink/EinkFormatUtils.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/eink/EinkFormatUtils.kt
@@ -84,6 +84,16 @@ fun agentTypeRank(agentType: String?): Int = when (agentType) {
     else -> 5
 }
 
+// OpenClaw / Gateway visibility SSOT — hand-mirrored from
+// shared/src/session-utils.ts (isOpenClawSessionActive / hasOpenClawSession).
+// "Active" = authenticated / can-route (gatewayConnected). Consumers must gate
+// OpenClaw rendering on session PRESENCE, never re-derive from raw gateway
+// flags — the daemon source is the single authority.
+fun isOpenClawSessionActive(gatewayConnected: Boolean?): Boolean = gatewayConnected == true
+
+fun hasOpenClawSession(sessions: List<SessionInfo>): Boolean =
+    sessions.any { it.agentType == "openclaw" }
+
 private val naturalChunks = Regex("\\d+|\\D+")
 
 fun naturalLabelCompare(left: String?, right: String?): Int {

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/EnginePanel.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/EnginePanel.kt
@@ -57,7 +57,12 @@ fun TankStatusPanel(
     val staleSuffix = if (usage.usageStale == true) " !" else ""
     val ollamaStatus = state.ollamaStatus
     val modelCatalog = state.modelCatalog ?: emptyList()
-    val openClawLines = if (state.gatewayConnected == true && state.agentType == "openclaw") {
+    // Catalog-ownership gate (mirrors Apple TopologyRail `catalogOwner == .openclaw`):
+    // state.modelCatalog belongs to the focused/primary agent, so only render it
+    // under the OpenClaw header when OpenClaw IS that agent — otherwise Claude's
+    // catalog would show under "OpenClaw" whenever an OpenClaw sibling exists.
+    // The raw `gatewayConnected` flag is intentionally dropped; ownership implies it.
+    val openClawLines = if (state.agentType == "openclaw") {
         openClawDisplayLines(modelCatalog)
     } else {
         emptyList()

--- a/android/app/src/test/kotlin/dev/agentdeck/terrarium/TerrariumStateTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/terrarium/TerrariumStateTest.kt
@@ -11,8 +11,13 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class TerrariumStateTest {
 
+    // Presence-driven SSOT: the crayfish tracks the emitted OpenClaw SESSION,
+    // never raw gateway flags. No session row ⇒ DORMANT, regardless of
+    // reachability/auth/error — this is the regression lock for the
+    // "OpenClaw won't go away" trace.
+
     @Test
-    fun `reachable gateway without auth hides OpenClaw and workers`() {
+    fun `reachable gateway without an emitted session hides OpenClaw and workers`() {
         val terrarium = DashboardState(
             agentState = AgentState.IDLE,
             agentType = "daemon",
@@ -27,7 +32,24 @@ class TerrariumStateTest {
     }
 
     @Test
-    fun `authenticated gateway shows OpenClaw at rest`() {
+    fun `stuck gatewayConnected without an emitted session still hides OpenClaw`() {
+        // The phantom "trace" scenario: a stale gatewayConnected=true but the
+        // daemon emitted NO openclaw session — the crayfish must stay hidden.
+        val terrarium = DashboardState(
+            agentState = AgentState.IDLE,
+            agentType = "daemon",
+            gatewayAvailable = true,
+            gatewayConnected = true,
+            workerSessionCount = 2,
+            siblingSessions = emptyList(),
+        ).toTerrariumState()
+
+        assertEquals(CrayfishVisualState.DORMANT, terrarium.crayfish)
+        assertEquals(0, terrarium.workerCrayfishCount)
+    }
+
+    @Test
+    fun `emitted OpenClaw session shows OpenClaw at rest`() {
         val terrarium = DashboardState(
             agentState = AgentState.IDLE,
             agentType = "daemon",
@@ -35,6 +57,9 @@ class TerrariumStateTest {
             gatewayConnected = true,
             gatewayHasError = false,
             workerSessionCount = 2,
+            siblingSessions = listOf(
+                SessionInfo(id = "oc-1", port = 18789, agentType = "openclaw", alive = true, state = "idle"),
+            ),
         ).toTerrariumState()
 
         assertEquals(CrayfishVisualState.SITTING, terrarium.crayfish)
@@ -42,24 +67,27 @@ class TerrariumStateTest {
     }
 
     @Test
-    fun `gateway error surfaces sick OpenClaw`() {
+    fun `gateway error with a live session surfaces sick OpenClaw`() {
         val terrarium = DashboardState(
             agentState = AgentState.IDLE,
             agentType = "daemon",
             gatewayAvailable = true,
-            gatewayConnected = false,
+            gatewayConnected = true,
             gatewayHasError = true,
+            siblingSessions = listOf(
+                SessionInfo(id = "oc-1", port = 18789, agentType = "openclaw", alive = true, state = "idle"),
+            ),
         ).toTerrariumState()
 
         assertEquals(CrayfishVisualState.SICK, terrarium.crayfish)
     }
 
     @Test
-    fun `stale gateway error is ignored when gateway is unavailable`() {
+    fun `gateway error without an emitted session does not spawn a creature`() {
         val terrarium = DashboardState(
             agentState = AgentState.IDLE,
             agentType = "daemon",
-            gatewayAvailable = false,
+            gatewayAvailable = true,
             gatewayConnected = false,
             gatewayHasError = true,
             workerSessionCount = 2,

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -4178,9 +4178,12 @@ final class DaemonServer {
 
     private func buildSessionsListEvent() -> [String: Any] {
         var sessions = cachedSessions.map { sessionToDict($0) }
-        // Inject virtual OpenClaw session when Gateway is reachable
-        if cachedGatewayConnected {
-            if !sessions.contains(where: { ($0["id"] as? String) == "openclaw-gateway" || ($0["agentType"] as? String) == "openclaw" }) {
+        // Inject virtual OpenClaw session iff Gateway is authenticated. SSOT:
+        // DashboardDataRules.isOpenClawSessionActive (mirror of
+        // shared/src/session-utils.ts). Identical predicate to the Node bridge.
+        if DashboardDataRules.isOpenClawSessionActive(gatewayConnected: cachedGatewayConnected) {
+            if !DashboardDataRules.hasOpenClawSession(sessions)
+                && !sessions.contains(where: { ($0["id"] as? String) == "openclaw-gateway" }) {
                 // Only authenticated Gateway connections should materialize as
                 // a virtual OpenClaw session. Reachability/auth failures stay
                 // in the topology/status rows so the terrarium does not render

--- a/apple/AgentDeck/Model/Protocol.swift
+++ b/apple/AgentDeck/Model/Protocol.swift
@@ -47,6 +47,25 @@ struct ModelCatalogEntry: Codable, Sendable {
 }
 
 enum DashboardDataRules {
+    // OpenClaw / Gateway visibility SSOT — hand-mirrored from
+    // shared/src/session-utils.ts (isOpenClawSessionActive / hasOpenClawSession).
+    // Keep all three (TS / Swift / Kotlin) in lockstep.
+    //
+    // "Active" = authenticated / can-route (gatewayConnected). Reachability and
+    // health are topology hints only and MUST NOT materialize a session — that
+    // is what kept a phantom OpenClaw alive on devices after it was off.
+    static func isOpenClawSessionActive(gatewayConnected: Bool) -> Bool {
+        gatewayConnected
+    }
+
+    static func hasOpenClawSession(_ sessions: [[String: Any]]) -> Bool {
+        sessions.contains { ($0["agentType"] as? String) == "openclaw" }
+    }
+
+    static func hasOpenClawSession(_ sessions: [SessionInfo]) -> Bool {
+        sessions.contains { $0.agentType == "openclaw" }
+    }
+
     static func agentTypeRank(_ agentType: String?) -> Int {
         switch agentType {
         case "openclaw": 0

--- a/apple/AgentDeck/Terrarium/TerrariumState.swift
+++ b/apple/AgentDeck/Terrarium/TerrariumState.swift
@@ -359,21 +359,22 @@ extension DashboardState {
         result.environment = mapToEnvironment(effectiveState)
         result.hasError = gatewayHasError
 
-        // Crayfish (OpenClaw gateway) — visible only when the gateway is
-        // authenticated. Reachability alone (`gatewayAvailable`) used to
-        // trigger a cheerful crayfish even when the shared token was
-        // missing, which misled users into thinking OpenClaw was wired up.
-        // Now: no token / no auth → dormant (hidden). Auth error → sick.
-        result.crayfishVisible = gatewayConnected || gatewayHasError
+        // Crayfish (OpenClaw gateway) — presence-driven SSOT. The crayfish
+        // tracks the OpenClaw SESSION the daemon emits, never raw gateway
+        // flags. The daemon injects an `openclaw` session iff the Gateway is
+        // authenticated (DashboardDataRules.isOpenClawSessionActive), so no
+        // emitted session ⇒ dormant (hidden) even if the port is reachable or
+        // doctor reports an error. This keeps every surface in lockstep and
+        // kills the "OpenClaw won't go away" trace.
+        let ocSibling = siblingSessions.first(where: { $0.agentType == "openclaw" })
+        result.crayfishVisible = ocSibling != nil
 
-        if gatewayHasError {
-            result.crayfishState = .sick
-        } else if let ocSibling = siblingSessions.first(where: { $0.agentType == "openclaw" }) {
-            result.crayfishState = ocSibling.state == "processing" ? .routing : .sitting
-        } else if gatewayConnected {
-            result.crayfishState = .sitting
-        } else {
+        if ocSibling == nil {
             result.crayfishState = .dormant
+        } else if gatewayHasError {
+            result.crayfishState = .sick
+        } else {
+            result.crayfishState = ocSibling!.state == "processing" ? .routing : .sitting
         }
 
         // Tetra state — use effectiveState so daemon mode isn't stuck on ABSENT

--- a/apple/AgentDeck/UI/Monitor/MonitorScreen.swift
+++ b/apple/AgentDeck/UI/Monitor/MonitorScreen.swift
@@ -422,13 +422,11 @@ struct MonitorScreen: View {
     }
 
     private var openClawGatewaySessionId: String? {
-        if let session = stateHolder.state.siblingSessions.first(where: { $0.agentType == "openclaw" }) {
-            return session.id
-        }
-        if stateHolder.state.gatewayConnected || stateHolder.state.gatewayHasError {
-            return "openclaw-gateway"
-        }
-        return nil
+        // Presence-driven SSOT: resolve to the emitted OpenClaw session only.
+        // No raw-flag fallback — a reachable-but-unauthenticated Gateway must
+        // not synthesize a phantom "openclaw-gateway" id (that was a "trace"
+        // source). The daemon emits the session iff the Gateway is authenticated.
+        stateHolder.state.siblingSessions.first(where: { $0.agentType == "openclaw" })?.id
     }
 
     private var emptyGuidePreviewAction: (() -> Void)? {

--- a/apple/AgentDeck/UI/Settings/IntegrationsView.swift
+++ b/apple/AgentDeck/UI/Settings/IntegrationsView.swift
@@ -627,44 +627,27 @@ enum ProviderRailEvaluator {
         return RowState(status: status, subtitle: subtitle)
     }
 
-    /// Returns `nil` when the OpenClaw gateway hasn't been discovered yet —
-    /// rails use that to suppress the row entirely rather than render a
-    /// dim placeholder for a provider the user never opted into. Mirrors
-    /// the gating done by the pre-existing rail code.
+    /// Returns `nil` unless the daemon actually emitted an OpenClaw session.
+    ///
+    /// This evaluator drives the CREATURE / topology rails only (TopologyRail,
+    /// MenuBarTopologyList). Presence-driven SSOT: the daemon injects an
+    /// `openclaw` session iff the Gateway is authenticated
+    /// (DashboardDataRules.isOpenClawSessionActive), so gating on session
+    /// presence keeps the rail crayfish in lockstep with every other surface
+    /// and stops a reachable-but-unauthenticated Gateway from rendering a
+    /// creature. The richer "Pairing required / Approve this Mac" ladder lives
+    /// in the Settings → Integrations row (`openClawStatus`), which is the
+    /// configuration surface and is intentionally NOT gated this way.
     static func openClaw(state: DashboardState) -> RowState? {
-        guard state.gatewayAvailable || state.gatewayHasError else { return nil }
-        let status: LEDStatus = state.gatewayHasError
-            ? .error
-            : (state.gatewayConnected ? .ok : .warn)
-        let subtitle: String? = {
-            switch state.gatewayAuthStatus {
-            case "approval_pending":
-                return "Approve in OpenClaw"
-            // Normal first-pairing states — show a single "Pairing required"
-            // message so the menu-bar and dashboard subtitle can't confuse
-            // users with different wording for the same underlying ask.
-            // `gateway_reachable` is *not* a pairing state — it just means the
-            // adapter is mid-handshake. Leave its subtitle empty (default branch)
-            // so the row doesn't nag the user during the brief connecting window.
-            case "pairing_required",
-                 "device_auth_invalid":
-                return "Pairing required"
-            case "gateway_token_missing":
-                return "Gateway token required"
-            case "auth_failed", "token_mismatch":
-                return "Auth failed — re-approve"
-            case "connect_timeout":
-                return "Handshake timeout"
-            case "unsupported_protocol":
-                return "Unsupported — update OpenClaw"
-            case "reconnecting":
-                return "Reconnecting…"
-            case "connected":
-                return nil
-            default:
-                return state.gatewayHasError ? "Gateway error" : nil
-            }
-        }()
+        // Presence-driven: a session only exists when the Gateway is
+        // authenticated, so the rail row is .ok (or .error if the live session
+        // is also erroring). The pre-pairing ladder (approval_pending /
+        // pairing_required / token-missing, etc.) is intentionally NOT shown on
+        // the rail — that affordance lives in the Settings → Integrations
+        // `openClawStatus` row, the configuration surface for getting paired.
+        guard DashboardDataRules.hasOpenClawSession(state.siblingSessions) else { return nil }
+        let status: LEDStatus = state.gatewayHasError ? .error : .ok
+        let subtitle: String? = state.gatewayHasError ? "Gateway error" : nil
         return RowState(status: status, subtitle: subtitle)
     }
 }

--- a/apple/AgentDeckTests/ProviderRailEvaluatorTests.swift
+++ b/apple/AgentDeckTests/ProviderRailEvaluatorTests.swift
@@ -61,97 +61,53 @@ final class ProviderRailEvaluatorTests: XCTestCase {
         XCTAssertNil(row.subtitle)
     }
 
-    // MARK: - OpenClaw
+    // MARK: - OpenClaw (presence-driven rail — SSOT)
+    //
+    // The rail evaluator gates on the emitted OpenClaw SESSION (the daemon
+    // injects one iff the Gateway is authenticated), never on raw gateway
+    // flags. The pre-pairing ladder (approval_pending / pairing_required /
+    // token-missing, etc.) lives in the Settings → Integrations `openClawStatus`
+    // row, NOT here — so those states must NOT surface a rail row.
 
-    func testOpenClawHiddenWhenUnavailable() {
-        let s = DashboardState()
-        XCTAssertNil(ProviderRailEvaluator.openClaw(state: s),
-                     "rail must suppress the row entirely until gateway is discovered")
+    private func openClawSession(state: String = "idle") -> SessionInfo {
+        SessionInfo(id: "openclaw-gateway", port: 18789, projectName: "OpenClaw",
+                    agentType: "openclaw", state: state)
     }
 
-    func testOpenClawConnected() {
+    func testOpenClawHiddenWithoutSession() {
         var s = DashboardState()
+        // Reachable + erroring but NO emitted session → rail must stay empty.
         s.gatewayAvailable = true
+        s.gatewayHasError = true
+        s.gatewayAuthStatus = "pairing_required"
+        XCTAssertNil(ProviderRailEvaluator.openClaw(state: s),
+                     "rail must suppress the row until the daemon emits an openclaw session")
+    }
+
+    func testOpenClawReachableUnauthenticatedHidden() {
+        var s = DashboardState()
+        // Port reachable but never authenticated (no session) — the classic
+        // "OpenClaw won't go away" trace must NOT render on the rail.
+        s.gatewayAvailable = true
+        s.gatewayConnected = false
+        s.siblingSessions = []
+        XCTAssertNil(ProviderRailEvaluator.openClaw(state: s))
+    }
+
+    func testOpenClawShownWhenSessionPresent() {
+        var s = DashboardState()
         s.gatewayConnected = true
-        s.gatewayAuthStatus = "connected"
+        s.siblingSessions = [openClawSession()]
         let row = ProviderRailEvaluator.openClaw(state: s)
         XCTAssertEqual(row?.status, .ok)
         XCTAssertNil(row?.subtitle)
     }
 
-    func testOpenClawReconnecting() {
+    func testOpenClawErrorWithLiveSession() {
         var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayConnected = false
-        s.gatewayAuthStatus = "reconnecting"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .warn)
-        XCTAssertEqual(row?.subtitle, "Reconnecting…")
-    }
-
-    func testOpenClawPairingRequired() {
-        var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayAuthStatus = "pairing_required"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .warn)
-        XCTAssertEqual(row?.subtitle, "Pairing required")
-    }
-
-    func testOpenClawDeviceAuthInvalidMapsToPairing() {
-        // `device_auth_invalid` is expected on first launch + after identity
-        // reset — treat it as pairing-required so users don't read it as a
-        // hard failure.
-        var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayAuthStatus = "device_auth_invalid"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .warn)
-        XCTAssertEqual(row?.subtitle, "Pairing required")
-    }
-
-    func testOpenClawApprovalPending() {
-        var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayAuthStatus = "approval_pending"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .warn)
-        XCTAssertEqual(row?.subtitle, "Approve in OpenClaw")
-    }
-
-    func testOpenClawAuthFailed() {
-        var s = DashboardState()
-        s.gatewayAvailable = true
+        s.gatewayConnected = true
         s.gatewayHasError = true
-        s.gatewayAuthStatus = "auth_failed"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .error)
-        XCTAssertEqual(row?.subtitle, "Auth failed — re-approve")
-    }
-
-    func testOpenClawUnsupportedProtocol() {
-        var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayHasError = true
-        s.gatewayAuthStatus = "unsupported_protocol"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .error)
-        XCTAssertEqual(row?.subtitle, "Unsupported — update OpenClaw")
-    }
-
-    func testOpenClawGatewayTokenMissing() {
-        var s = DashboardState()
-        s.gatewayAvailable = true
-        s.gatewayAuthStatus = "gateway_token_missing"
-        let row = ProviderRailEvaluator.openClaw(state: s)
-        XCTAssertEqual(row?.status, .warn)
-        XCTAssertEqual(row?.subtitle, "Gateway token required")
-    }
-
-    func testOpenClawErrorWithoutAuthStatusFallsBackToGenericError() {
-        var s = DashboardState()
-        s.gatewayHasError = true
-        s.gatewayAuthStatus = nil
+        s.siblingSessions = [openClawSession()]
         let row = ProviderRailEvaluator.openClaw(state: s)
         XCTAssertEqual(row?.status, .error)
         XCTAssertEqual(row?.subtitle, "Gateway error")

--- a/apple/AgentDeckTests/TerrariumCrayfishPresenceTests.swift
+++ b/apple/AgentDeckTests/TerrariumCrayfishPresenceTests.swift
@@ -1,0 +1,78 @@
+#if os(macOS)
+import XCTest
+@testable import AgentDeck
+
+/// Presence-driven SSOT parity with Android `TerrariumStateTest`: the crayfish
+/// (OpenClaw) tracks the emitted OpenClaw SESSION, never raw gateway flags. No
+/// session row ⇒ dormant (hidden), regardless of reachability/auth/error — the
+/// regression lock for the "OpenClaw won't go away" phantom trace.
+final class TerrariumCrayfishPresenceTests: XCTestCase {
+
+    private func openClawSession(state: String = "idle") -> SessionInfo {
+        SessionInfo(id: "openclaw-gateway", port: 18789, projectName: "OpenClaw",
+                    agentType: "openclaw", alive: true, state: state)
+    }
+
+    func testReachableWithoutSessionHidesCrayfish() {
+        var s = DashboardState()
+        s.state = .idle
+        s.gatewayAvailable = true
+        s.gatewayConnected = false
+        let t = s.toTerrariumState()
+        XCTAssertFalse(t.crayfishVisible)
+        XCTAssertEqual(t.crayfishState, .dormant)
+    }
+
+    func testStuckConnectedWithoutSessionHidesCrayfish() {
+        // Phantom-trace scenario: a stale gatewayConnected=true but the daemon
+        // emitted no openclaw session — the crayfish must stay hidden.
+        var s = DashboardState()
+        s.state = .idle
+        s.gatewayConnected = true
+        s.siblingSessions = []
+        let t = s.toTerrariumState()
+        XCTAssertFalse(t.crayfishVisible)
+        XCTAssertEqual(t.crayfishState, .dormant)
+    }
+
+    func testEmittedSessionShowsCrayfishAtRest() {
+        var s = DashboardState()
+        s.state = .idle
+        s.gatewayConnected = true
+        s.siblingSessions = [openClawSession()]
+        let t = s.toTerrariumState()
+        XCTAssertTrue(t.crayfishVisible)
+        XCTAssertEqual(t.crayfishState, .sitting)
+    }
+
+    func testProcessingSessionRoutesCrayfish() {
+        var s = DashboardState()
+        s.state = .processing
+        s.gatewayConnected = true
+        s.siblingSessions = [openClawSession(state: "processing")]
+        let t = s.toTerrariumState()
+        XCTAssertEqual(t.crayfishState, .routing)
+    }
+
+    func testErrorWithLiveSessionIsSick() {
+        var s = DashboardState()
+        s.state = .idle
+        s.gatewayConnected = true
+        s.gatewayHasError = true
+        s.siblingSessions = [openClawSession()]
+        let t = s.toTerrariumState()
+        XCTAssertEqual(t.crayfishState, .sick)
+    }
+
+    func testErrorWithoutSessionDoesNotSpawnCrayfish() {
+        var s = DashboardState()
+        s.state = .idle
+        s.gatewayAvailable = true
+        s.gatewayConnected = false
+        s.gatewayHasError = true
+        let t = s.toTerrariumState()
+        XCTAssertFalse(t.crayfishVisible)
+        XCTAssertEqual(t.crayfishState, .dormant)
+    }
+}
+#endif

--- a/bridge/src/__tests__/openclaw-session.test.ts
+++ b/bridge/src/__tests__/openclaw-session.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { injectOpenClawSession } from '../openclaw-session.js';
+import type { EnrichedSession } from '../session-aggregator.js';
+
+const claude: EnrichedSession = {
+  id: 'claude-1', port: 9121, projectName: 'Backend', agentType: 'claude-code', alive: true, state: 'idle',
+};
+const existingOpenClaw: EnrichedSession = {
+  id: 'openclaw-gateway', port: 18789, projectName: 'OpenClaw', agentType: 'openclaw', alive: true, state: 'idle',
+};
+
+describe('injectOpenClawSession', () => {
+  it('does NOT inject when the Gateway is reachable but not authenticated (regression: phantom trace)', () => {
+    // The exact stuck state: index.ts used to gate on gatewayAvailable and
+    // injected a phantom session whenever port 18789 answered. Authentication
+    // (gatewayConnected) is now the only gate.
+    const out = injectOpenClawSession([claude], { gatewayConnected: false });
+    expect(out).toHaveLength(1);
+    expect(out.some(s => s.agentType === 'openclaw')).toBe(false);
+  });
+
+  it('injects a minimal session when authenticated (CLI bridge shape)', () => {
+    const out = injectOpenClawSession([claude], { gatewayConnected: true });
+    expect(out).toHaveLength(2);
+    const oc = out.find(s => s.agentType === 'openclaw')!;
+    expect(oc.id).toBe('openclaw-gateway');
+    expect(oc.port).toBe(18789);
+    expect(oc.projectName).toBe('OpenClaw');
+    // CLI bridge omits the daemon-hub extras.
+    expect(oc.state).toBeUndefined();
+    expect(oc.controlMode).toBeUndefined();
+  });
+
+  it('carries daemon-hub extras (state/projectName/modelName/controlMode) when provided', () => {
+    const out = injectOpenClawSession([claude], {
+      gatewayConnected: true,
+      state: 'processing',
+      projectName: 'my-repo',
+      modelName: 'opus-4',
+      controlMode: 'managed',
+    });
+    const oc = out.find(s => s.agentType === 'openclaw')!;
+    expect(oc.state).toBe('processing');
+    expect(oc.projectName).toBe('my-repo');
+    expect(oc.modelName).toBe('opus-4');
+    expect(oc.controlMode).toBe('managed');
+  });
+
+  it('is idempotent — does not duplicate an already-present openclaw session', () => {
+    const out = injectOpenClawSession([claude, existingOpenClaw], { gatewayConnected: true });
+    expect(out).toHaveLength(2);
+    expect(out.filter(s => s.agentType === 'openclaw')).toHaveLength(1);
+  });
+
+  it('returns the original array reference when not injecting (no needless copy)', () => {
+    const input = [claude];
+    expect(injectOpenClawSession(input, { gatewayConnected: false })).toBe(input);
+  });
+});

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -69,6 +69,7 @@ import { getConnectedAdbDevices, hasAdb, getAdbDeviceCount } from './adb-reverse
 import { getPixooDeviceDetails, pixooDeviceCount } from './pixoo/pixoo-bridge.js';
 import { loadTimeboxDevices } from './timebox/timebox-settings.js';
 import { getLanIp } from '@agentdeck/shared';
+import { injectOpenClawSession } from './openclaw-session.js';
 import { readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -1131,20 +1132,18 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       const sec = Math.round((now - Date.parse(s.startedAt)) / 1000);
       return Number.isFinite(sec) && sec >= 0 ? { ...s, elapsedSec: sec } : s;
     });
-    const adapterAlive = gatewayAdapter?.isAlive() ?? false;
-    if (!adapterAlive && !core.cachedGatewayConnected) return enrichedSessions;
-    if (enrichedSessions.some(s => s.agentType === 'openclaw')) return enrichedSessions;
+    // SSOT: inject iff Gateway is authenticated (gatewayConnected). Reachability
+    // / adapter-liveness alone must not materialize a session — that kept a
+    // phantom OpenClaw alive on devices after it was effectively off. Shared
+    // injector with bridge/src/index.ts; mirror of Swift buildSessionsListEvent.
     const snap = core.stateMachine.getSnapshot();
-    return [...enrichedSessions, {
-      id: 'openclaw-gateway',
-      port: 18789,
-      projectName: adapterAlive ? (snap.projectName ?? 'OpenClaw') : 'OpenClaw',
-      agentType: 'openclaw' as const,
-      alive: true,
-      state: adapterAlive ? snap.state : 'idle',
-      modelName: adapterAlive ? (snap.modelName ?? undefined) : undefined,
-      controlMode: 'managed' as const,
-    }];
+    return injectOpenClawSession(enrichedSessions, {
+      gatewayConnected: core.cachedGatewayConnected,
+      state: snap.state,
+      projectName: snap.projectName ?? 'OpenClaw',
+      modelName: snap.modelName ?? undefined,
+      controlMode: 'managed',
+    });
   });
 
   // OpenClaw-specific APME session id. Distinct from `core.sessionId`

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -31,6 +31,7 @@ import {
   cleanDetailText, cleanRawText, prepareMarkdownDetail,
   extractTopicHintWithKind, promptSnippetFallback,
 } from '@agentdeck/shared';
+import { injectOpenClawSession } from './openclaw-session.js';
 import { VoiceAssistantManager } from './voice-assistant.js';
 import { TerminalStatus } from './terminal-status.js';
 import { readFileSync, existsSync } from 'fs';
@@ -958,18 +959,14 @@ export async function startSession(opts: SessionOptions): Promise<void> {
   core.startGatewayHealthCheck();
   core.startSessionsListPolling();
 
-  // Inject virtual OpenClaw session when Gateway is detected (same as daemon-server.ts)
-  core.setSessionsEnricher((sessions) => {
-    if (!core.cachedGatewayAvailable) return sessions;
-    if (sessions.some(s => s.agentType === 'openclaw')) return sessions;
-    return [...sessions, {
-      id: 'openclaw-gateway',
-      port: 18789,
-      projectName: 'OpenClaw',
-      agentType: 'openclaw' as const,
-      alive: true,
-    }];
-  });
+  // Inject virtual OpenClaw session only after Gateway authentication succeeds
+  // (gatewayConnected). Reachability alone (cachedGatewayAvailable) is a
+  // topology signal, not proof commands can route — gating on it kept a phantom
+  // OpenClaw session alive whenever anything held port 18789 open. Shared
+  // injector with daemon-server.ts; mirror of Swift buildSessionsListEvent.
+  core.setSessionsEnricher((sessions) =>
+    injectOpenClawSession(sessions, { gatewayConnected: core.cachedGatewayConnected }),
+  );
 
   // ===== Encoder state computation =====
   function computeEncoderState(): EncoderStateEvent {

--- a/bridge/src/openclaw-session.ts
+++ b/bridge/src/openclaw-session.ts
@@ -1,0 +1,43 @@
+/**
+ * openclaw-session.ts — single injector for the virtual OpenClaw Gateway
+ * session. Shared by the CLI session bridge (index.ts) and the daemon hub
+ * (daemon-server.ts) so both apply the SSOT predicate identically and can never
+ * drift. Mirror of Swift `buildSessionsListEvent`.
+ */
+import { isOpenClawSessionActive, hasOpenClawSession } from '@agentdeck/shared';
+import type { EnrichedSession } from './session-aggregator.js';
+
+export interface InjectOpenClawOptions {
+  /** SSOT gate — inject only when the Gateway is authenticated. */
+  gatewayConnected: boolean;
+  /** Daemon-hub extras (the CLI bridge omits these → a minimal session row). */
+  state?: string;
+  projectName?: string;
+  modelName?: string;
+  controlMode?: 'managed';
+}
+
+/**
+ * Append the virtual `openclaw` session iff the Gateway is authenticated
+ * (`gatewayConnected`) and one isn't already present. Reachability
+ * (`gatewayAvailable`) and health alone must NEVER materialize a session — that
+ * kept a phantom OpenClaw alive on devices after it was off.
+ */
+export function injectOpenClawSession(
+  sessions: EnrichedSession[],
+  opts: InjectOpenClawOptions,
+): EnrichedSession[] {
+  if (!isOpenClawSessionActive({ gatewayConnected: opts.gatewayConnected })) return sessions;
+  if (hasOpenClawSession(sessions)) return sessions;
+  const injected: EnrichedSession = {
+    id: 'openclaw-gateway',
+    port: 18789,
+    projectName: opts.projectName ?? 'OpenClaw',
+    agentType: 'openclaw',
+    alive: true,
+  };
+  if (opts.state !== undefined) injected.state = opts.state;
+  if (opts.modelName !== undefined) injected.modelName = opts.modelName;
+  if (opts.controlMode !== undefined) injected.controlMode = opts.controlMode;
+  return [...sessions, injected];
+}

--- a/bridge/src/pixoo/pixoo-renderer.ts
+++ b/bridge/src/pixoo/pixoo-renderer.ts
@@ -21,6 +21,7 @@
 import { State } from '../types.js';
 import type { StateUpdateEvent, UsageEvent } from '../types.js';
 import type { SessionInfo } from '@agentdeck/shared/protocol';
+import { hasOpenClawSession } from '@agentdeck/shared';
 import { drawTextCentered } from './pixoo-font.js';
 import {
   type RGB, COLORS, setPixel, blendPixel, glowPixel, fillRect, lerpColor,
@@ -678,9 +679,10 @@ function renderMicroFrame(
   sessions: SessionInfo[] | null,
   usagePct: number,
 ): void {
-  const hasGateway = (stateEvent?.gatewayConnected ?? false)
-    || (stateEvent?.gatewayHasError ?? false)
-    || (sessions?.some((s) => s.agentType === 'openclaw') ?? false);
+  // Presence-driven SSOT: the crayfish renders iff the daemon emitted an
+  // OpenClaw session — never from raw gateway flags. The daemon emits it iff
+  // the Gateway is authenticated, so reachability/error alone won't draw it.
+  const hasGateway = hasOpenClawSession(sessions ?? []);
   const gatewayHasError = stateEvent?.gatewayHasError ?? false;
 
   // Pick the dominant creature: awaiting (most urgent) → processing → idle.
@@ -763,10 +765,9 @@ export function renderFrame(
   const surfaceY = SURFACE_Y;
   const palette = ZONE_BLUE; // Water stays blue — usage shown only via HUD gauge
 
-  // Gateway creature is gated by authenticated connection, not reachability.
-  const hasGateway = (stateEvent?.gatewayConnected ?? false)
-    || (stateEvent?.gatewayHasError ?? false)
-    || (sessions?.some(s => s.agentType === 'openclaw') ?? false);
+  // Presence-driven SSOT: crayfish renders iff the daemon emitted an OpenClaw
+  // session (authenticated), not from raw gateway reachability/error flags.
+  const hasGateway = hasOpenClawSession(sessions ?? []);
 
   // === Sync creature instances ===
   syncCreatures(sessions, stateEvent);

--- a/shared/src/__tests__/session-utils.test.ts
+++ b/shared/src/__tests__/session-utils.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import {
   agentTypeRank, sortSessions, assignDisplayNames, naturalLabelCompare, foldCodexSessionsForDisplay,
+  isOpenClawSessionActive, hasOpenClawSession,
 } from '../session-utils.js';
 import type { FoldableSession } from '../session-utils.js';
+
+describe('OpenClaw visibility SSOT', () => {
+  it('isOpenClawSessionActive is true only when gatewayConnected', () => {
+    expect(isOpenClawSessionActive({ gatewayConnected: true })).toBe(true);
+    // reachability / health alone must NOT materialize a session
+    expect(isOpenClawSessionActive({ gatewayAvailable: true })).toBe(false);
+    expect(isOpenClawSessionActive({ gatewayHasError: true })).toBe(false);
+    expect(isOpenClawSessionActive({ gatewayAvailable: true, gatewayConnected: false })).toBe(false);
+    expect(isOpenClawSessionActive({})).toBe(false);
+  });
+
+  it('hasOpenClawSession detects an emitted openclaw session', () => {
+    expect(hasOpenClawSession([{ agentType: 'claude-code' }, { agentType: 'openclaw' }])).toBe(true);
+    expect(hasOpenClawSession([{ agentType: 'claude-code' }])).toBe(false);
+    expect(hasOpenClawSession([])).toBe(false);
+  });
+});
 
 describe('agentTypeRank', () => {
   it('ranks openclaw first, then claude-code, codex-cli, codex-app, opencode, others', () => {

--- a/shared/src/session-utils.ts
+++ b/shared/src/session-utils.ts
@@ -59,6 +59,43 @@ export function naturalLabelCompare(a: string | undefined, b: string | undefined
   return (a || '').localeCompare(b || '', undefined, { numeric: true, sensitivity: 'base' });
 }
 
+// ===== OpenClaw / Gateway Visibility (SSOT) =====
+
+export interface GatewayVisibilityFlags {
+  /** TCP port 18789 reachable — a topology hint only, NOT proof commands route. */
+  gatewayAvailable?: boolean;
+  /** Gateway WS handshake + auth succeeded — proof commands can route. */
+  gatewayConnected?: boolean;
+  /** `openclaw doctor`/health reports an error. */
+  gatewayHasError?: boolean;
+}
+
+/**
+ * SSOT: the daemon injects the virtual `openclaw` session iff this holds.
+ *
+ * "Active" = authenticated / can-route = the Gateway WS handshake+auth
+ * succeeded (`gatewayConnected`). Reachability (`gatewayAvailable`) and health
+ * (`gatewayHasError`) are topology/status hints only and MUST NOT materialize a
+ * session — surfacing them as a session is what made OpenClaw "stick" on
+ * devices after it was effectively off.
+ *
+ * Hand-mirrored in Swift `DashboardDataRules.isOpenClawSessionActive`
+ * (apple/AgentDeck/Model/Protocol.swift) and Kotlin `isOpenClawSessionActive`
+ * (android/.../ui/eink/EinkFormatUtils.kt) — keep all three in lockstep.
+ */
+export function isOpenClawSessionActive(flags: GatewayVisibilityFlags): boolean {
+  return flags.gatewayConnected === true;
+}
+
+/**
+ * Consumer SSOT: render OpenClaw iff the daemon actually emitted the session.
+ * Consumers must NOT re-derive OpenClaw visibility from raw gateway flags;
+ * the daemon source is the single authority. Hand-mirrored in Swift/Kotlin.
+ */
+export function hasOpenClawSession<T extends { agentType?: string }>(sessions: readonly T[]): boolean {
+  return sessions.some(s => s.agentType === 'openclaw');
+}
+
 // ===== Sorting =====
 
 /**


### PR DESCRIPTION
> Clean replacement for #28, which got contaminated by unrelated concurrent-session commits on the shared working tree. This branch contains **only** the OpenClaw work (3 commits).

## Context

OpenClaw (Gateway / 가재 크리처) showed phantom traces on devices after it was effectively off. Root cause: OpenClaw has **no on/off flag** — the daemon probes port 18789 and surfaces a virtual `openclaw` session, but the "should we show it" predicate **diverged across every surface**, so whichever gateway flag got stuck decided which surface lit up.

The worst offender: `bridge/src/index.ts` gated on `cachedGatewayAvailable` (TCP reachability **only**) — anything holding port 18789 open injected a phantom session forever, regardless of authentication.

## Change — single presence-driven predicate

**SSOT** `isOpenClawSessionActive(flags) = gatewayConnected === true` + `hasOpenClawSession(sessions)` in `shared/src/session-utils.ts`, hand-mirrored to Swift `DashboardDataRules` and Kotlin `EinkFormatUtils`.

- **Daemon is the single authority**: inject the virtual `openclaw` session iff authenticated — Node (`index.ts` + `daemon-server.ts`, via the shared `injectOpenClawSession` helper) and Swift (`buildSessionsListEvent`) use the identical predicate.
- **Consumers render off session PRESENCE**, never raw gateway flags: Android terrarium crayfish + `workerCrayfishCount` + EnginePanel, Apple terrarium + `MonitorScreen` + `ProviderRailEvaluator.openClaw` (rail-only), Pixoo renderer.
- **Settings → Integrations `openClawStatus`** keeps the full pairing ladder (config surface); it never spawns a creature elsewhere.

## Review fixes (commit 2)

- Android EnginePanel: restored the **catalog-ownership gate** (`agentType == "openclaw"`, mirroring Apple `catalogOwner == .openclaw`) — `state.modelCatalog` belongs to the focused agent, so gating on mere session presence would render Claude's catalog under the OpenClaw header.

## Tests (commit 3)

- `injectOpenClawSession` extracted as the shared SSOT injector (index.ts + daemon-server.ts).
- bridge `openclaw-session.test.ts`: locks the regression — reachable-but-unauthenticated injects **no** session; authenticated injects one; idempotent dedupe.
- Apple `TerrariumCrayfishPresenceTests.swift`: parity with Android — dormant without a live session even when connected/erroring.

## Verification
- `pnpm build` + vitest **1481 passed**
- macOS Swift `BUILD SUCCEEDED` + test target compiles
- Android terrarium/openclaw/ordering JUnit pass

## Diagnosing a stuck instance
\`\`\`
lsof -i :9120        # which daemon is serving
lsof -nP -i :18789   # stale port holder?
agentdeck status     # available:true/connected:false = classic stuck state
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)