### PR TITLE
fix(hook-server): stop exposing pairingToken on unauthenticated /health

### DIFF
--- a/bridge/src/hook-server.ts
+++ b/bridge/src/hook-server.ts
@@ -33,7 +33,6 @@ export class HookServer extends EventEmitter {
   private sseIdCounter = 0;
   private lastStateEvent: BridgeEvent | null = null;
   private lastUsageEvent: BridgeEvent | null = null;
-  pairingToken: string | null = null;
 
   // Metadata for status page / health
   private meta: { agentType?: string; projectName?: string; clientCount?: number; state?: string; modelName?: string; effortLevel?: string } = {};
@@ -125,7 +124,6 @@ export class HookServer extends EventEmitter {
         effortLevel: this.meta.effortLevel,
         wsClients: this.meta.clientCount ?? 0,
         sseClients: this.sseClients.length,
-        pairingToken: this.pairingToken,
       });
     });
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -332,17 +332,14 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     hookServer.setMeta({ agentType, projectName });
     hookServer.setVoiceManager(voiceManager);
     hookServer.onApiUsage(() => ({ usage: core.cachedApiUsage, fetchedAt: core.lastApiFetchTime }));
-    hookServer.pairingToken = core.authToken;
   } else if (adapter instanceof CodexCliAdapter) {
     hookServer = adapter.getCodexHookServer();
     hookServer.setMeta({ agentType, projectName });
     hookServer.setVoiceManager(voiceManager);
-    hookServer.pairingToken = core.authToken;
   } else if (adapter instanceof OpenCodeAdapter) {
     hookServer = adapter.getHookServer();
     hookServer.setMeta({ agentType, projectName });
     hookServer.setVoiceManager(voiceManager);
-    hookServer.pairingToken = core.authToken;
     // OpenCode has no CLI-level hooks; SSE is the only event channel. Bind
     // the adapter to the APME session so SSE-derived spans (tool_call /
     // tool_result / task_boundary / turn_*) can reach the collector. Without
@@ -355,7 +352,6 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     hookServer.setMeta({ agentType, projectName });
     hookServer.setVoiceManager(voiceManager);
     hookServer.onApiUsage(() => ({ usage: core.cachedApiUsage, fetchedAt: core.lastApiFetchTime }));
-    hookServer.pairingToken = core.authToken;
   }
   const broadcastSse = (event: BridgeEvent) => hookServer?.broadcastSse(event);
   core.setSseBroadcast(broadcastSse);


### PR DESCRIPTION
## Summary
Salvages the one meaningful change from #27 (credit: @orbisai0security): the session **hook server's `/health`** (loopback-bound, unauthenticated) returned the session `pairingToken`, letting any co-resident local process read it. This drops the field.

- `bridge/src/hook-server.ts`: remove `pairingToken` from the `/health` payload and the now-dead `pairingToken` property.
- `bridge/src/index.ts`: remove the four now-dead `hookServer.pairingToken = core.authToken` assignments.

## Why only this part of #27
- Daemon discovery (iOS/macOS `BridgeDiscovery`) reads the token from the **daemon's** `/health` (`bridge/src/daemon-server.ts`), not the session hook server's — so removing it here is safe.
- #27 also added `checkAuth` to `POST /hooks/:eventName`, but that is a **no-op**: the hook server binds `127.0.0.1` only (all prod callers use `HookServer.listen(port)` → default host `127.0.0.1`), so every connection is local and `isLocalConnection()` always returns true. It blocks neither threat the PR described (a LAN attacker can't reach a loopback port; a same-machine process passes the local check). Not adopted.
- #27's committed test was non-functional (outside the vitest include globs so never collected, wrong import path, constructor takes no args, accesses `private app`, missing `supertest` dep, nested `test.each`, and asserts auth on endpoints the change never gated). Not adopted.

## Verification
- `pnpm build` — clean.
- `pnpm vitest run` for HookServer-touching suites (server-integration, usage-relay, daemon-lifecycle, tier3-integration) — 62 passed.
- No test references `pairingToken`.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
