### PR TITLE
fix(daemon): verify occupant PID before conceding startup-race port

### DIFF
--- a/bridge/src/__tests__/session-registry.test.ts
+++ b/bridge/src/__tests__/session-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldConcedePortToOccupant } from '../session-registry.js';
 import { readFileSync, mkdirSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -173,6 +174,36 @@ describe('Session Registry Logic', () => {
       expect(read[0].projectName).toBe('test');
       // Temp file should not exist after rename
       expect(existsSync(tmpFile)).toBe(false);
+    });
+  });
+
+  describe('shouldConcedePortToOccupant (startup-race hardening)', () => {
+    const SELF = 4242;
+    const alive = () => true;
+    const dead = () => false;
+
+    it('does not concede to a non-daemon occupant (session bridge)', () => {
+      expect(shouldConcedePortToOccupant({ mode: 'session', pid: 99 }, SELF, alive)).toBe(false);
+    });
+
+    it('does not concede when the probe failed (null occupant)', () => {
+      expect(shouldConcedePortToOccupant(null, SELF, alive)).toBe(false);
+    });
+
+    it('concedes to a daemon backed by a live, distinct PID', () => {
+      expect(shouldConcedePortToOccupant({ mode: 'daemon', pid: 1234 }, SELF, alive)).toBe(true);
+    });
+
+    it('does NOT concede to a forged/stale daemon whose PID is dead', () => {
+      expect(shouldConcedePortToOccupant({ mode: 'daemon', pid: 1234 }, SELF, dead)).toBe(false);
+    });
+
+    it('does NOT concede when the reported PID is our own', () => {
+      expect(shouldConcedePortToOccupant({ mode: 'daemon', pid: SELF }, SELF, alive)).toBe(false);
+    });
+
+    it('trusts the mode when no PID is reported (e.g. Swift App Store daemon)', () => {
+      expect(shouldConcedePortToOccupant({ mode: 'daemon' }, SELF, dead)).toBe(true);
     });
   });
 });

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -32,6 +32,7 @@ import {
   findExistingDaemon,
   DAEMON_DEFAULT_PORT,
   probeDaemonHealth,
+  shouldConcedePortToOccupant,
   writeDaemonInfo,
   removeDaemonInfo,
   readDaemonInfo,
@@ -466,7 +467,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       res.end(JSON.stringify({
         status: 'ok', mode: 'daemon', state: snap.state,
         gateway: gatewayAdapter?.isAlive() ? 'connected' : 'disconnected',
-        uptime: process.uptime(), port,
+        uptime: process.uptime(), port, pid: process.pid,
         pairingToken: core.authToken,
         modules: moduleHealthProvider(),
         apme: apme
@@ -849,9 +850,17 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       // daemons running (and clobber daemon.json to point at the wrong one).
       // Only fall back when a *non-daemon* (e.g. a session bridge) holds it.
       const occupant = await probeDaemonHealth(requestedPort);
-      if (occupant?.mode === 'daemon') {
-        log(`[agentdeck] Lost startup race for port ${requestedPort} (PID ${occupant.pid} already serving). Exiting.`);
+      // Harden against a forged/stale `mode:'daemon'` response squatting the
+      // port: concede (exit) only to a verified live distinct daemon. A claim
+      // backed by a dead/own PID is treated as stale → fall through to a fresh
+      // port and keep running. See `shouldConcedePortToOccupant`.
+      if (shouldConcedePortToOccupant(occupant, process.pid)) {
+        const who = typeof occupant?.pid === 'number' ? `PID ${occupant.pid}` : 'a daemon';
+        log(`[agentdeck] Lost startup race for port ${requestedPort} (${who} already serving). Exiting.`);
         process.exit(0);
+      }
+      if (occupant?.mode === 'daemon') {
+        log(`[agentdeck] Port ${requestedPort} reports a daemon but PID ${occupant.pid} is not a live distinct process; treating as stale and falling back.`);
       }
       port = await findAvailablePort();
       log(`[agentdeck] Port ${requestedPort} grabbed by ${occupant?.mode ?? 'a non-daemon'}, retrying on ${port}...`);

--- a/bridge/src/session-registry.ts
+++ b/bridge/src/session-registry.ts
@@ -123,13 +123,40 @@ function writeSessions(sessions: SessionEntry[]): void {
 }
 
 /** Check if a PID is alive */
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Decide whether a daemon that just lost the bind race for its requested port
+ * should concede (exit) to the process currently answering `/health` there.
+ *
+ * Concede ONLY when the occupant is a verified, distinct, live daemon:
+ *  - `mode !== 'daemon'` → a non-daemon (e.g. a session bridge) holds it; do
+ *    not concede (caller falls back to a fresh port, preserving prior behavior).
+ *  - `mode === 'daemon'` with a numeric `pid` → concede only if that PID is a
+ *    live process other than ourselves. A forged or stale `mode:'daemon'`
+ *    response with a dead/own/missing-but-claimed PID must NOT evict us.
+ *  - `mode === 'daemon'` with no `pid` → trust the mode (e.g. the Swift App
+ *    Store daemon omits `pid`), so cross-implementation coexistence still
+ *    hands the port over.
+ *
+ * `aliveCheck` is injectable for tests; defaults to the real PID liveness probe.
+ */
+export function shouldConcedePortToOccupant(
+  occupant: { mode?: string; pid?: number } | null,
+  selfPid: number,
+  aliveCheck: (pid: number) => boolean = isProcessAlive,
+): boolean {
+  if (occupant?.mode !== 'daemon') return false;
+  const pid = typeof occupant.pid === 'number' ? occupant.pid : null;
+  if (pid === null) return true;
+  return pid !== selfPid && aliveCheck(pid);
 }
 
 /** Remove dead sessions (PID no longer alive) */


### PR DESCRIPTION
## Summary
Hardens the EADDRINUSE concurrent-start handling added in #23.

Previously, when a starting daemon lost the bind race for port 9120, it probed `/health` and `exit(0)` if the response merely claimed `mode:'daemon'`. A forged or stale responder squatting the port could therefore **block the real daemon from ever starting** (the pre-#23 behavior was to fall back to a fresh port).

## Changes
- `bridge/src/daemon-server.ts`: daemon `/health` now emits `pid: process.pid`; the race handler concedes via `shouldConcedePortToOccupant()`.
- `bridge/src/session-registry.ts`: export `isProcessAlive`; add pure, injectable `shouldConcedePortToOccupant(occupant, selfPid, aliveCheck?)`.
  - Concede iff `mode==='daemon'` **and** the reported PID is alive **and** not our own.
  - A `mode:'daemon'` claim backed by a dead/own PID → treated as stale, fall back to a fresh port (keep running).
  - No PID reported (e.g. the Swift App Store daemon, which omits it) → retain prior trust-the-mode behavior so cross-implementation coexistence still hands the port over.
- `bridge/src/__tests__/session-registry.test.ts`: 6 unit tests for the predicate (non-daemon, null probe, live PID, dead PID, own PID, pid-less daemon).

## Verification
- Unit tests for `shouldConcedePortToOccupant` pass locally (35 passed in session-registry + daemon-lifecycle suites).
- Full build verified by CI on this branch (built in isolation from `origin/master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
