### PR TITLE
fix(devices): re-apply dropped iDotMatrix Node module registration

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -6,6 +6,26 @@
 
 ---
 
+## 2026-06-27 — iDotMatrix / Divoom Timebox Mini 가 대시보드·패널에 안 보이던 문제
+
+### 문제
+두 BLE 매트릭스 패널(iDotMatrix 32×32, Timebox Mini 11×11)이 대시보드 토폴로지에 안 뜨고 패널 렌더도 깨졌다. 단일 버그가 아니라 3겹 plumbing gap이었다.
+
+### 해결
+- **Node 가시성**: Timebox는 정식 `TimeboxModule`인데 **iDotMatrix는 모듈 미등록**(직접 `startIDotMatrixSync` spawn만)이라 `buildNodeModuleHealth`/`/devices`/TUI/`agentdeck devices` 전부에서 누락. `IDotMatrixModule` 신설(Timebox 미러)+`createDefaultModules` 등록+health/devices/cli/TUI 분기+`ModuleConfigs.idotmatrix`. daemon-server의 직접 start 호출은 제거(모듈이 단일 소유).
+- **Apple 가시성**: Swift 데몬은 `/health`에 idotmatrix+timebox `statusSnapshot()`을 이미 emit하지만 **클라가 버렸음** — `ModuleHealthState` 필드 없음+`BridgeEventParser.parseModuleHealth` 미디코드+`TopologyRail` 섹션 없음. 공유 `BLEMatrixHealth` struct+파서 분기+`bleMatrixSection`(statusReason→LEDStatus).
+- **진단성**: 양 daemon-sync가 `stdio:'ignore'`로 Python 크래시(bleak/idotmatrix 미설치 등)를 삼켜 blank 패널이 무진단이었다. 공유 `bridge/src/ble-sync-spawn.ts`(stdout 묵음+stderr ring buffer, exit 시 tail 로그)로 교체. iDotMatrix는 설정 변경 시 재시작도 추가.
+
+### 핵심 설계 결정
+- **★ 실사용 즉시 원인 = settings 경로 분리.** App Store 플래그 빌드는 컨테이너 settings.json을 읽는데 `agentdeck ... add`는 `~/.agentdeck/`에 씀 → 앱이 `configuredDeviceCount:0`("no device configured")으로 아무것도 안 그림. 컨테이너 빌드는 앱 Settings 시트로 페어링해야 한다.
+- **Swift 렌더 하드닝 후보 3건은 defect 아님(검증 후 변경 안 함)**: Timebox dim `max(0)`=의도(hw 밝기 없어 0=blank), TimeboxBLE settle 불필요(프레임당 1패킷+flow-control), wake stale-connected는 `handleWake()`가 이미 처리.
+- **병렬 세션 브랜치 정리 중 Phase 1 Node 누락 → 재적용.** "Salvage … #30"이 Apple/Phase2/cli는 가져갔으나 iDotMatrix 모듈 등록+daemon-server health/devices 배선을 빠뜨려 Node 가시성 회귀. 본 브랜치에서 surgical 재적용.
+
+### 검증
+`pnpm build` green, `xcodebuild -scheme AgentDeck_macOS` BUILD SUCCEEDED, Node 데몬 e2e로 `/health`·`/devices`에 두 기기 표출 확인.
+
+---
+
 ## 2026-06-25 — TRMNL App Store standalone hub parity + observability
 
 ### 문제

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -42,8 +42,7 @@ import {
 import { fetchUsageFromApi, hasOAuthToken, resetConsecutiveFailures, type ApiUsageData } from './usage-api.js';
 import { isLocalConnection, validateToken } from './auth.js';
 import { getLastFrame, renderPreviewFrame, onFrameRendered, offFrameRendered } from './pixoo/pixoo-bridge.js';
-import { startIDotMatrixSync, stopIDotMatrixSync } from './idotmatrix/idotmatrix-daemon-sync.js';
-import { autoDiscoverIDotMatrix } from './idotmatrix/idotmatrix-discover.js';
+import { loadIDotMatrixDevices } from './idotmatrix/idotmatrix-settings.js';
 import { handlePixooWake } from './pixoo/pixoo-client.js';
 import { triggerMdnsRecovery } from './mdns.js';
 import { rgbToBmp, pixooLiveHtml } from './hook-server.js';
@@ -339,6 +338,23 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
     };
   }
 
+  const idotmatrix = startedModules.find((m) => m.name === 'idotmatrix') as DeviceModule & {
+    statusSnapshot?: () => Record<string, unknown>;
+  };
+  const configuredIDotMatrix = loadIDotMatrixDevices();
+  if (idotmatrix?.statusSnapshot) {
+    modules.idotmatrix = idotmatrix.statusSnapshot();
+  } else if (configuredIDotMatrix.length > 0) {
+    modules.idotmatrix = {
+      configuredDeviceCount: configuredIDotMatrix.length,
+      devices: configuredIDotMatrix.map((d) => ({
+        address: d.address,
+        name: d.name ?? 'iDotMatrix',
+        brightness: d.brightness ?? 100,
+      })),
+    };
+  }
+
   if (started.has('serial')) {
     const connectionStatus = getSerialConnectionStatus();
     const connections = connectionStatus.map((status) => ({
@@ -507,6 +523,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           { type: 'esp32', count: esp32ConnectionCount(), ports: getESP32Ports() },
           { type: 'pixoo', details: getPixooDeviceDetails() },
           { type: 'timebox', devices: loadTimeboxDevices() },
+          { type: 'idotmatrix', devices: loadIDotMatrixDevices() },
           { type: 'adb', count: getAdbDeviceCount() },
           {
             type: 'd200h',
@@ -1025,25 +1042,17 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     // device being registered, so it's cheap when no panel is present.
     // d200h: false — direct-HID fallback retired. The D200H is driven exclusively
     // by the Ulanzi Studio plugin (`ulanzi-plugin`); the daemon never opens it over HID.
-    { mdns: true, adb: 'auto', serial: 'auto', pixoo: 'auto', timebox: 'auto', d200h: false, trmnl: true },
+    { mdns: true, adb: 'auto', serial: 'auto', pixoo: 'auto', timebox: 'auto', idotmatrix: 'auto', d200h: false, trmnl: true },
     { port, authToken: core.authToken, projectName: 'AgentDeck', wsServer: core.wsServer },
   );
 
   moduleHealthProvider = () => buildNodeModuleHealth(startedModules);
   core.setModuleHealthProvider(moduleHealthProvider);
 
-  // iDotMatrix BLE: the daemon can't speak BLE in-process, so auto-spawn the
-  // Python sync client when a device is configured. This is what makes the
-  // panel run with only the CLI daemon up (no Swift app, no manual `idotmatrix
-  // sync`). No-op when nothing is configured or the Python venv is absent.
-  startIDotMatrixSync(port);
-
-  // Zero-config: when nothing is configured, run a background BLE scan and, if
-  // a panel is found, add it + (re)start sync. Non-blocking so the ~5s scan
-  // doesn't delay daemon startup; skipped entirely once a device is configured.
-  void autoDiscoverIDotMatrix().then((added) => {
-    if (added > 0) startIDotMatrixSync(port);
-  });
+  // iDotMatrix BLE is now driven by IDotMatrixModule (registered in
+  // createDefaultModules): the module owns spawning the Python sync client,
+  // zero-config auto-discovery, and teardown — so the daemon doesn't start it
+  // directly here anymore (avoids double-spawn).
 
   // Serial module state provider (heartbeat needs cached state)
   const serialModule = startedModules.find(m => m.name === 'serial') as SerialModule | undefined;
@@ -1774,7 +1783,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     voiceAssistant?.stop();
     voiceManager?.disconnectFromServer();
     bridgeLogStream.stop();
-    stopIDotMatrixSync();
+    // iDotMatrix BLE sync is stopped by IDotMatrixModule.stop() via stopModules below.
     await Promise.all([
       gatewayAdapter ? gatewayAdapter.shutdown().catch(() => {}) : Promise.resolve(),
       stopModules(startedModules)

--- a/bridge/src/modules/idotmatrix-module.ts
+++ b/bridge/src/modules/idotmatrix-module.ts
@@ -1,0 +1,49 @@
+import type { BridgeContext, DeviceModule } from './types.js';
+import {
+  loadIDotMatrixDevices,
+  isIDotMatrixAutoDiscoverEnabled,
+} from '../idotmatrix/idotmatrix-settings.js';
+import { startIDotMatrixSync, stopIDotMatrixSync } from '../idotmatrix/idotmatrix-daemon-sync.js';
+import { autoDiscoverIDotMatrix } from '../idotmatrix/idotmatrix-discover.js';
+
+export class IDotMatrixModule implements DeviceModule {
+  readonly name = 'idotmatrix';
+
+  async shouldActivate(config: 'auto' | boolean): Promise<boolean> {
+    if (config === false) return false;
+    if (config === true) return true;
+    // Activate when a device is configured OR auto-discovery may find one.
+    return loadIDotMatrixDevices().length > 0 || isIDotMatrixAutoDiscoverEnabled();
+  }
+
+  async start(ctx: BridgeContext): Promise<void> {
+    // Start sync for any already-configured device immediately, then run a
+    // background BLE scan if none is configured. Discovery is non-blocking so
+    // daemon startup isn't delayed by the ~8s scan; when it adds a device we
+    // re-invoke startIDotMatrixSync (no-op if already running) to pick it up.
+    startIDotMatrixSync(ctx.port);
+    if (loadIDotMatrixDevices().length === 0 && isIDotMatrixAutoDiscoverEnabled()) {
+      void autoDiscoverIDotMatrix().then((added) => {
+        if (added > 0) startIDotMatrixSync(ctx.port);
+      });
+    }
+  }
+
+  async stop(): Promise<void> {
+    stopIDotMatrixSync();
+  }
+
+  statusSnapshot(): Record<string, unknown> {
+    const devices = loadIDotMatrixDevices();
+    return {
+      configuredDeviceCount: devices.length,
+      devices: devices.map((d) => ({
+        id: d.address,
+        transport: 'ble',
+        address: d.address,
+        name: d.name ?? 'iDotMatrix',
+        brightness: d.brightness ?? 100,
+      })),
+    };
+  }
+}

--- a/bridge/src/modules/index.ts
+++ b/bridge/src/modules/index.ts
@@ -4,6 +4,7 @@ import { AdbModule } from './adb-module.js';
 import { SerialModule } from './serial-module.js';
 import { PixooModule } from './pixoo-module.js';
 import { TimeboxModule } from './timebox-module.js';
+import { IDotMatrixModule } from './idotmatrix-module.js';
 import { D200hModule } from './d200h-module.js';
 import { TrmnlModule } from './trmnl-module.js';
 import type { AgentType } from '../types.js';
@@ -15,6 +16,7 @@ export { AdbModule } from './adb-module.js';
 export { SerialModule } from './serial-module.js';
 export { PixooModule } from './pixoo-module.js';
 export { TimeboxModule } from './timebox-module.js';
+export { IDotMatrixModule } from './idotmatrix-module.js';
 export { D200hModule } from './d200h-module.js';
 export { TrmnlModule } from './trmnl-module.js';
 
@@ -28,6 +30,7 @@ export function createDefaultModules(agentType: AgentType): DeviceModule[] {
     new SerialModule(),
     new PixooModule(),
     new TimeboxModule(),
+    new IDotMatrixModule(),
     new D200hModule(),
     new TrmnlModule(),
   ];

--- a/bridge/src/modules/types.ts
+++ b/bridge/src/modules/types.ts
@@ -41,6 +41,7 @@ export interface ModuleConfigs {
   serial?: 'auto' | boolean;
   pixoo?: 'auto' | boolean;
   timebox?: 'auto' | boolean;
+  idotmatrix?: 'auto' | boolean;
   d200h?: 'auto' | boolean;
   trmnl?: 'auto' | boolean;
 }


### PR DESCRIPTION
## Why

A branch cleanup (the "Salvage … #30" commit) kept the **Apple + Phase-2 + cli** parts of the iDotMatrix/Timebox topology-visibility fix but **dropped the Phase-1 Node wiring**. Net effect on the **Node daemon**: iDotMatrix still rendered to the panel (legacy direct sync call) but became **invisible again** in `/health`, `/devices`, the TUI dashboard, and `agentdeck devices` — the exact bug the original fix addressed. (The Apple/Swift surface was unaffected.)

This PR surgically re-applies only the missing Node pieces.

## What

- **New `bridge/src/modules/idotmatrix-module.ts`** — mirrors `TimeboxModule` (`shouldActivate` / `start` owns sync + zero-config auto-discover / `stop` / `statusSnapshot`).
- **`modules/index.ts`** — register `IDotMatrixModule` in `createDefaultModules` (+ export).
- **`modules/types.ts`** — add `idotmatrix?: 'auto' | boolean` to `ModuleConfigs`.
- **`daemon-server.ts`** — add the `idotmatrix` branch to `buildNodeModuleHealth`, the `/devices` entry, and `idotmatrix: 'auto'` to the default module config; **remove** the now-redundant direct `startIDotMatrixSync` / `autoDiscoverIDotMatrix` / `stopIDotMatrixSync` calls so the module is the single owner (no double-spawn).
- **`DEVELOPMENT_LOG.md`** — restore the dropped entry documenting the 3-layer gap.

Timebox was already a proper module and is unaffected; this brings iDotMatrix to parity.

## Verification

- `pnpm build` green (bridge `tsc` clean); affected unit tests 22/22 pass (`server-integration`, `timebox-ble`).
- Node daemon e2e (temp HOME with a configured device): `/health.modules` now includes `idotmatrix` with device details and `/devices` includes the `idotmatrix` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)