### PR TITLE
[codex] Normalize Xcode shared schemes

### DIFF
--- a/apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_iOS.xcscheme
+++ b/apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_iOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -30,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1B95C9515EBB97FD5022C08C"
-               BuildableName = "AgentDeck_iOS.app"
+               BuildableName = "AgentDeck.app"
                BlueprintName = "AgentDeck_iOS"
                ReferencedContainer = "container:AgentDeck.xcodeproj">
             </BuildableReference>
@@ -42,13 +41,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1B95C9515EBB97FD5022C08C"
-            BuildableName = "AgentDeck_iOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_iOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
@@ -66,8 +64,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,13 +80,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1B95C9515EBB97FD5022C08C"
-            BuildableName = "AgentDeck_iOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_iOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -103,13 +97,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1B95C9515EBB97FD5022C08C"
-            BuildableName = "AgentDeck_iOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_iOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_macOS.xcscheme
+++ b/apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_macOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -30,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E4D80DB9ABDABC379778AF7C"
-               BuildableName = "AgentDeck_macOS.app"
+               BuildableName = "AgentDeck.app"
                BlueprintName = "AgentDeck_macOS"
                ReferencedContainer = "container:AgentDeck.xcodeproj">
             </BuildableReference>
@@ -42,13 +41,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E4D80DB9ABDABC379778AF7C"
-            BuildableName = "AgentDeck_macOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_macOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
@@ -66,8 +64,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,13 +80,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E4D80DB9ABDABC379778AF7C"
-            BuildableName = "AgentDeck_macOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_macOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -103,13 +97,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E4D80DB9ABDABC379778AF7C"
-            BuildableName = "AgentDeck_macOS.app"
+            BuildableName = "AgentDeck.app"
             BlueprintName = "AgentDeck_macOS"
             ReferencedContainer = "container:AgentDeck.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
## Summary

- Normalize the shared iOS and macOS Xcode scheme metadata.
- Keep the scheme BuildableName values aligned to `AgentDeck.app`.
- Remove empty command-line argument blocks and redundant scheme attributes generated by newer Xcode metadata.

## Validation

- `git diff --check`
- `xmllint --noout apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_iOS.xcscheme apple/AgentDeck.xcodeproj/xcshareddata/xcschemes/AgentDeck_macOS.xcscheme`
- `xcodebuild -list -project apple/AgentDeck.xcodeproj`