### PR TITLE
fix(timebox): auto-reconnect BLE Mini after power-cycle

### DIFF
--- a/apple/AgentDeck/Daemon/Modules/TimeboxModule.swift
+++ b/apple/AgentDeck/Daemon/Modules/TimeboxModule.swift
@@ -62,7 +62,12 @@ actor TimeboxModule: DeviceModule {
     private var consecutiveFailures = 0
     private var backoffUntil: Date?
     private let backoffInitialSec: TimeInterval = 5
-    private let backoffMaxSec: TimeInterval = 120
+    // Capped low so a power-cycled Timebox is re-acquired within ~tens of seconds.
+    // A successful frame resets consecutiveFailures (recordSuccess), so a clean
+    // disconnect restarts the backoff at backoffInitialSec; the cap only bounds the
+    // case where the device stays off/out-of-range — there's no value in waiting
+    // minutes, since CoreBluetooth gives no async reappear signal during the gap.
+    private let backoffMaxSec: TimeInterval = 15
 
     private var renderTask: Task<Void, Never>?
     private var settingsReloadTask: Task<Void, Never>?

--- a/bridge/src/timebox/sync_ble.py
+++ b/bridge/src/timebox/sync_ble.py
@@ -213,9 +213,21 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
         if should_exit():
             stop.set()
             break
+        link_lost = asyncio.Event()
+
+        def on_disconnect(_client):
+            # Fired by bleak when the GATT link drops (e.g. the Timebox is powered
+            # off). A stateful BLE panel driven by write-without-response means our
+            # writes can silently "succeed" over a dead link, so this callback — not
+            # a write error — is the authoritative "reconnect now" signal. Without it
+            # the inner loop would spin forever on a dead link and the outer reconnect
+            # path (below) would never run.
+            print("BLE peripheral disconnected — will reconnect.", file=sys.stderr)
+            loop.call_soon_threadsafe(link_lost.set)
+
         try:
             print(f"Connecting BLE {address}...")
-            async with BleakClient(address, timeout=15.0) as client:
+            async with BleakClient(address, timeout=15.0, disconnected_callback=on_disconnect) as client:
                 print(f"BLE connected (MTU={client.mtu_size})")
 
                 last_key = ""
@@ -234,6 +246,14 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                 while not stop.is_set():
                     if should_exit():
                         stop.set()
+                        break
+                    # 0. The link dropped (peripheral powered off / out of range):
+                    #    leave the `async with` so the outer loop reconnects by
+                    #    address (macOS bleak addresses are stable UUIDs). Checked
+                    #    every iteration because write-without-response never errors
+                    #    on a dead link — only this flag / is_connected reveals it.
+                    if link_lost.is_set() or not client.is_connected:
+                        print("BLE link lost — reconnecting.", file=sys.stderr)
                         break
                     # 1. Apply host display sleep/wake. The daemon exposes the same
                     #    display_state Pixoo/iDotMatrix/ESP32 receive; older session-
@@ -261,6 +281,8 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                                 last_bridge_ok = time.monotonic()
                             except Exception as e:
                                 print(f"Dim-frame send error: {e}", file=sys.stderr)
+                                if link_lost.is_set() or not client.is_connected:
+                                    break
                         if once:
                             return
                         try:
@@ -277,6 +299,12 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                         last_bridge_ok = time.monotonic()
                     except Exception as e:
                         print(f"Frame fetch/send error: {e}", file=sys.stderr)
+                        # A write error after the link dropped must escalate to a
+                        # reconnect; a transient HTTP fetch error (bridge blip) must
+                        # not — keep streaming and let should_exit() handle a truly
+                        # gone bridge.
+                        if link_lost.is_set() or not client.is_connected:
+                            break
                     if once:
                         return
                     try:


### PR DESCRIPTION
## Problem

Powering the Divoom Timebox Mini off and on again did not restore the BLE link — the 11×11 panel stayed frozen and never reconnected. Root cause differs per runtime:

### Node CLI (`bridge/src/timebox/sync_ble.py`) — PRIMARY: *never* reconnects
Once connected, the inner streaming loop only exited on `stop`. When the device powered off:
- the write failure was swallowed by the catch-all `except` (print + `continue`);
- worse, write-without-response can silently "succeed" over a dead link with **no exception at all**;
- no `disconnected_callback` was registered, so nothing flagged the drop.

So `async with BleakClient(...)` never exited → the **outer reconnect loop never ran**, and the process never exited → the daemon supervisor (`timebox-daemon-sync.ts`, respawns on process exit) never restarted it either.

### Swift App Store (`apple/.../TimeboxModule.swift`) — SECONDARY: reconnects, but slow
It does detect disconnect and retry, but exponential backoff grew to **120s**, so a power-cycled device could take up to ~2 minutes to be re-acquired.

## Fix

**`sync_ble.py`**
- Register a `disconnected_callback` that sets a per-connection `link_lost` event (loop-safe).
- Break the inner loop on `link_lost`/`not client.is_connected` so the outer loop reconnects by address (macOS bleak addresses are stable UUIDs).
- Escalate BLE write failures to a reconnect, while keeping transient HTTP fetch blips streaming (handled by `should_exit()` if the bridge is truly gone).

**`TimeboxModule.swift`**
- Cap `backoffMaxSec` 120s → 15s. A successful frame resets `consecutiveFailures` (so a clean disconnect restarts at 5s); the cap only bounds the device-stays-off case. Worst-case re-acquire ~25s (15s backoff + 10s connect timeout).

## Verification
- `python3 -m py_compile bridge/src/timebox/sync_ble.py` → OK
- `xcodebuild ... -scheme AgentDeck_macOS` → **BUILD SUCCEEDED** (no `.pbxproj` drift)

⚠️ **Hardware check still required** (cannot be done in CI): power-cycle a real Timebox Mini and confirm the panel re-renders.
- Node: tail daemon log `[agentdeck] [timebox]` → OFF shows `BLE peripheral disconnected` / `BLE link lost — reconnecting` → ON re-acquires within ~15–20s.
- Swift: power-cycle and confirm re-acquire in seconds, not minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)