### PR TITLE
fix(ble): await stateful-panel OFFLINE farewell on daemon shutdown

### DIFF
--- a/bridge/src/ble-sync-spawn.ts
+++ b/bridge/src/ble-sync-spawn.ts
@@ -53,3 +53,48 @@ export function spawnPythonSync(
     },
   };
 }
+
+/**
+ * SIGTERM a managed sync child and wait (bounded) for it to exit, so the child's
+ * OFFLINE / blank farewell frame finishes painting before the daemon process
+ * exits.
+ *
+ * The Python sync clients trap SIGTERM, break their loop, push a final OFFLINE
+ * (iDotMatrix) or black (Timebox) frame over BLE, then disconnect. That push
+ * takes ~1s. If we only fire SIGTERM and return immediately (the old behaviour),
+ * the daemon exits right away; when the daemon is a launchd job, launchd then
+ * tears the job down and SIGKILLs the orphaned child mid-farewell — leaving the
+ * stateful BLE panel frozen on its last dashboard frame instead of OFFLINE.
+ * Awaiting the child's exit here keeps the daemon alive just long enough for the
+ * farewell to land. Escalates to SIGKILL if the child overruns `timeoutMs`.
+ */
+export function terminateSyncChild(proc: ChildProcess, timeoutMs = 3_000): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      resolve();
+      return;
+    }
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      finish();
+    }, timeoutMs);
+    timer.unref?.();
+    proc.once('exit', finish);
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      finish();
+    }
+  });
+}

--- a/bridge/src/bridge-core.ts
+++ b/bridge/src/bridge-core.ts
@@ -820,7 +820,7 @@ export class BridgeCore {
     const hardExitTimer = setTimeout(() => {
       logError('Shutdown timeout — forcing exit.');
       exitProcessNow(0);
-    }, 5000);
+    }, 7000);
 
     // Clear all timers
     for (const iv of this.intervals) clearInterval(iv);
@@ -832,13 +832,16 @@ export class BridgeCore {
     // Stop display monitor
     this.displayMonitor.stop();
 
-    // Run shutdown callbacks (best-effort, 2s total budget)
+    // Run shutdown callbacks (best-effort, 5s total budget). Budget covers the
+    // BLE stateful-panel farewell: device modules (iDotMatrix/Timebox) await
+    // their Python sync child painting a final OFFLINE/blank frame over BLE
+    // (~1-3s) so the panel doesn't freeze on its last dashboard frame.
     const callbacksDone = Promise.all(
       this.shutdownCallbacks.map(cb =>
         Promise.resolve().then(cb).catch(() => {}),
       ),
     );
-    await Promise.race([callbacksDone, new Promise(r => { const t = setTimeout(r, 2000); t.unref(); })]);
+    await Promise.race([callbacksDone, new Promise(r => { const t = setTimeout(r, 5000); t.unref(); })]);
 
     // Close WS
     this.wsServer.close();

--- a/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
+++ b/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
@@ -21,7 +21,7 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { loadIDotMatrixDevices, type IDotMatrixDevice } from './idotmatrix-settings.js';
-import { spawnPythonSync } from '../ble-sync-spawn.js';
+import { spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
 
 let child: ChildProcess | null = null;
 let stopping = false;
@@ -74,7 +74,10 @@ export function startIDotMatrixSync(httpPort: number): void {
     // driving the old panel forever.
     if (runningKey === deviceKey(devices[0])) return;
     log('configured iDotMatrix changed; restarting BLE sync');
-    stopIDotMatrixSync();
+    // Fast stop on re-config (no farewell wait — we repaint immediately with the
+    // new device). Runs synchronously up to the SIGTERM, so `stopping = false`
+    // below still lands after the child is signalled.
+    void stopIDotMatrixSync();
     stopping = false;
   }
 
@@ -130,20 +133,32 @@ function spawnSync(venvPython: string, syncScript: string, httpPort: number): vo
   });
 }
 
-/** Stop the managed BLE sync and cancel any pending respawn (daemon shutdown). */
-export function stopIDotMatrixSync(): void {
+/**
+ * Stop the managed BLE sync and cancel any pending respawn.
+ *
+ * When `awaitFarewell` is true (daemon shutdown), wait for the child to exit so
+ * its OFFLINE-frame farewell finishes painting before the daemon process exits —
+ * otherwise launchd tears the job down and SIGKILLs the orphaned child
+ * mid-farewell, freezing the panel on its last dashboard frame. When false
+ * (re-config restart), just signal the child and return synchronously.
+ */
+export async function stopIDotMatrixSync(awaitFarewell = false): Promise<void> {
   stopping = true;
   if (respawnTimer) {
     clearTimeout(respawnTimer);
     respawnTimer = null;
   }
-  if (child) {
+  const proc = child;
+  child = null;
+  runningKey = null;
+  if (!proc) return;
+  if (awaitFarewell) {
+    await terminateSyncChild(proc);
+  } else {
     try {
-      child.kill('SIGTERM');
+      proc.kill('SIGTERM');
     } catch {
       /* already gone */
     }
-    child = null;
   }
-  runningKey = null;
 }

--- a/bridge/src/idotmatrix/sync.py
+++ b/bridge/src/idotmatrix/sync.py
@@ -314,6 +314,11 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
         print("Shutting down — sending OFFLINE frame to iDotMatrix...")
         try:
             await upload_offline_frame(idm_image)
+            # Let the final frame transmit before we drop the BLE link below —
+            # otherwise the disconnect races the in-flight write and the panel
+            # freezes on its last dashboard frame instead of showing OFFLINE.
+            await asyncio.sleep(0.5)
+            print("  OFFLINE frame sent.")
         except Exception as e:
             print(f"  offline frame push failed: {e}")
         try:

--- a/bridge/src/modules/idotmatrix-module.ts
+++ b/bridge/src/modules/idotmatrix-module.ts
@@ -30,7 +30,9 @@ export class IDotMatrixModule implements DeviceModule {
   }
 
   async stop(): Promise<void> {
-    stopIDotMatrixSync();
+    // Await the child's OFFLINE-frame farewell so the panel doesn't freeze on its
+    // last dashboard frame when the daemon exits.
+    await stopIDotMatrixSync(true);
   }
 
   statusSnapshot(): Record<string, unknown> {

--- a/bridge/src/modules/timebox-module.ts
+++ b/bridge/src/modules/timebox-module.ts
@@ -31,7 +31,9 @@ export class TimeboxModule implements DeviceModule {
   }
 
   async stop(): Promise<void> {
-    stopTimeboxSync();
+    // Await each child's blank-panel farewell so the panel doesn't freeze on its
+    // last dashboard frame when the daemon exits.
+    await stopTimeboxSync(true);
   }
 
   statusSnapshot(): Record<string, unknown> {

--- a/bridge/src/timebox/sync_ble.py
+++ b/bridge/src/timebox/sync_ble.py
@@ -292,6 +292,12 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                 if stop.is_set() and client.is_connected:
                     try:
                         await blank_panel(client)
+                        # blank_panel writes WITHOUT response — the await returns once
+                        # the packet is queued to the OS, not once it's transmitted.
+                        # The `async with` below drops the BLE link immediately on
+                        # exit; without this beat the queued blank never goes over the
+                        # air and the panel freezes on its last dashboard frame.
+                        await asyncio.sleep(0.5)
                         print("Shutting down — blanked Timebox panel.")
                     except Exception as e:
                         print(f"Farewell blank failed: {e}", file=sys.stderr)

--- a/bridge/src/timebox/timebox-daemon-sync.ts
+++ b/bridge/src/timebox/timebox-daemon-sync.ts
@@ -11,7 +11,7 @@ import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { deviceId, loadTimeboxDevices, type TimeboxDevice } from './timebox-settings.js';
-import { spawnPythonSync } from '../ble-sync-spawn.js';
+import { spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
 
 interface SyncEntry {
   device: TimeboxDevice;
@@ -108,7 +108,17 @@ function spawnSync(entry: SyncEntry, venvPython: string, syncScript: string, htt
   });
 }
 
-export function stopTimeboxSync(): void {
+/**
+ * Stop all managed Timebox BLE syncs and cancel pending respawns.
+ *
+ * When `awaitFarewell` is true (daemon shutdown), wait for each child to exit so
+ * its blank-panel farewell finishes painting before the daemon process exits —
+ * otherwise launchd tears the job down and SIGKILLs the orphaned children
+ * mid-farewell, freezing each panel on its last dashboard frame. Children are
+ * awaited in parallel (BLE is per-device, so farewells don't serialize).
+ */
+export async function stopTimeboxSync(awaitFarewell = false): Promise<void> {
+  const procs: ChildProcess[] = [];
   for (const entry of entries.values()) {
     entry.stopping = true;
     if (entry.respawnTimer) {
@@ -116,13 +126,19 @@ export function stopTimeboxSync(): void {
       entry.respawnTimer = null;
     }
     if (entry.child) {
-      try {
-        entry.child.kill('SIGTERM');
-      } catch {
-        /* already gone */
-      }
+      const proc = entry.child;
       entry.child = null;
+      if (awaitFarewell) {
+        procs.push(proc);
+      } else {
+        try {
+          proc.kill('SIGTERM');
+        } catch {
+          /* already gone */
+        }
+      }
     }
   }
   entries.clear();
+  if (procs.length) await Promise.all(procs.map((p) => terminateSyncChild(p)));
 }


### PR DESCRIPTION
## Problem

iDotMatrix and Timebox Mini BLE panels freeze on their **last dashboard frame** — not the OFFLINE/blank farewell — after the daemon stops, even on a *clean* `agentdeck daemon stop`. Other (in-process) devices go OFFLINE correctly; only the two Python-sync-child-driven BLE panels freeze.

Confirmed on hardware via a debug trace of the child stdout during `daemon stop`.

## Root cause (two layers)

**1. Daemon didn't wait for the farewell.** `stopIDotMatrixSync()` / `stopTimeboxSync()` fired `SIGTERM` at the Python sync child but returned synchronously. The daemon called `exitProcessNow(0)` immediately; under launchd, the job teardown then SIGKILLs the orphaned child mid-farewell.

**2. The child dropped the BLE link before the farewell frame transmitted.** Even once the child got time, the farewell write is **write-without-response** — the `await` returns when the packet is queued to the OS, not when it's transmitted. The child then immediately disconnected (`async with` __aexit__ / `manager.disconnect()`), so the queued OFFLINE/blank packet never went over the air → panel frozen.

## Fix

- **Daemon side:** shared `terminateSyncChild()` (`ble-sync-spawn.ts`) — SIGTERM the child and await its exit (SIGKILL fallback). Device modules' `stop()` await it on shutdown; re-config restart keeps the fast path. Shutdown callback budget 2s → 5s (hard-exit 5s → 7s).
- **Child side:** `sleep(0.5s)` after the farewell write, before disconnecting, in both `idotmatrix/sync.py` and `timebox/sync_ble.py`, so the BLE stack transmits the final frame.

## Verification
- `pnpm build` clean; `pnpm vitest run` 1568/1568.
- **Hardware (confirmed):** `agentdeck daemon stop` → iDotMatrix shows OFFLINE, Timebox blanks. Debug trace shows both children completing the farewell (`blanked Timebox panel` / `OFFLINE frame sent`) before the daemon exits.

## Notes
- Independent of #35 (auto-reconnect). Both touch `timebox/sync_ble.py` but in different regions (this PR: end-of-run farewell block; #35: connection loop) — no textual conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)