### PR TITLE
Daemon log hygiene (iDotMatrix respawn root cause, TRMNL setup 404) + timeline task-completeness gaps

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -6,6 +6,23 @@
 
 ---
 
+## 2026-07-02 — 타임라인 완결성 후속: 갭 5건 구현 (마일스톤 행 · OpenCode idle-gap · task 행 FIFO 보호 · APME-off fallback · unscored 종결)
+
+### 배경
+dd43efd2(중복/이중 인제스트 수정)에서 확정만 해 둔 잔여 갭 5건. 사용자 방향 확인 후 전부 구현 (①마일스톤 행 표면화 ③task 행 FIFO 보호 ⑤타임아웃→unscored 는 권장안 채택).
+
+### 구현
+1. **`task_milestone` 타임라인 타입 신설** — TodoWrite-all-completed soft hint(발화율 ~18%, 비세그먼트 유지)를 타임라인 행으로 표면화. `shared/src/timeline.ts` union + `timeline-icons.ts`(success 아이콘, detail body 제외). Node: `collector.onTaskMilestone` 콜백(per task+turn 1회 dedup, `fireTaskMilestone`) → `apme/index.ts` emit(`Todos done (N)`). Swift 패리티: `ApmeCollector.emitTaskMilestoneIfNeeded`(deferred task_start 승격 포함) + `Timeline.swift` enum case + TimelineStripView `TODOS ✓` 라벨/아이콘. Kotlin: TimelineIcons.kt 매핑. `pnpm generate-protocol` 재생성. 소비 표면 전수조사 결과 미인지 클라이언트는 전방 호환(Swift lenient enum `.unknown`, Kotlin String type).
+2. **OpenCode idle-gap 경계** — OpenClaw 미러: `opencode-hook.ts`에 `OPENCODE_IDLE_GAP_MS=90s` + `opencodeIdleGapTaskBoundary()`; 어댑터가 `session.idle`에서 arm, 새 작업 신호(`beginChatIfNeeded`)·shutdown에서 clear, 발화 시 `task_boundary(idle_gap)` span → `closeTask`. 이전엔 session_end로만 닫혀 세션=1태스크(per-task eval 무효).
+3. **task 행 FIFO 보호** — `BridgeTimelineStore`: 일반 FIFO에서 task 행 제외, 별도 캡 `MAX_TASK_ENTRIES=60`(초과 시 닫힌 태스크부터 evict, in-flight `task_start`는 절대 evict 금지), `loadPersistedEntries` trim·`getHistoryForSession`(limit=chat/tool에만 적용, task 행은 전량 동승) 동일 보호. Swift `DaemonTimelineStore` 미러(evictOne/loadFromDisk/historyForSession).
+4. **APME-off fallback task 행** — 신규 `bridge/src/fallback-task-timeline.ts`: better-sqlite3 로드 실패 시 hook 경계 신호만으로 task_start/task_end 행 발행(합성 taskId, eval 없음). daemon-server hook 엔드포인트(`json.session_id` per-session 귀속) + 세션 브리지 index.ts hook 경로에 wiring.
+5. **eval 배지 unscored 종결** — `TaskEvalBadge`에 `closedAt` 추가: task_end 후 5분 내 judge 결과 없으면 "…"→"unscored" 확정 표기 (judge 비활성/백엔드 다운/enqueue 유실 시 영구 pending 방지).
+
+### 검증
+vitest 92파일/1635 pass(신규: timeline-task-retention 4, fallback-task-timeline 3, apme-task-milestone 2), `xcodebuild AgentDeck_macOS` BUILD SUCCEEDED, Android `compileDebugKotlin` OK.
+
+---
+
 ## 2026-07-02 — 데몬 로그 위생: iDotMatrix 60초 respawn 근본 원인 + BLE sync 반복 사이클 억제 + TRMNL `/api/setup/` trailing-slash 404
 
 ### 문제

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -6,6 +6,27 @@
 
 ---
 
+## 2026-07-02 — 데몬 로그 위생: iDotMatrix 60초 respawn 근본 원인 + BLE sync 반복 사이클 억제 + TRMNL `/api/setup/` trailing-slash 404
+
+### 문제
+`~/.agentdeck/daemon-stderr.log`가 iDotMatrix BLE sync의 60초 주기 respawn 로그(connect→send→disconnect→respawn, code=0)로 도배(clean exit 4,057행, 비정상 0행). 조사에서 근본 원인 3건 확정:
+1. **iDotMatrix `sync.py` 워치독 굶주림** — bridge-gone 워치독(30s)의 `last_bridge_ok`가 frame fetch에서만 갱신되는데, host display dimmed 경로는 frame fetch를 건너뛰므로(display-state fetch는 성공하는데도) 30초마다 "Bridge unreachable" clean exit → 데몬이 60초 백오프로 영구 respawn. Timebox `sync_ble.py`는 이미 display-state fetch에서 갱신하고 있었음(패리티 누락).
+2. **로그 truncate-on-start** — `cli.ts` daemon 백그라운드 fork가 `daemon-std{out,err}.log`를 `'w'`로 열어 재시작마다 이전 로그 소실 → 야간 기기 인시던트("not responding")와 관측성 로그(`back after`/`device log from`)의 며칠치 대조가 구조적으로 불가.
+3. **(로그가 드러낸 별건) TRMNL `/api/setup/` 404** — 패널이 매 wake마다 `returned code is not OK. Code - 404` 보고. 펌웨어 v1.5.12 `getDeviceCredentials()`(bl.cpp:1600)가 **trailing slash 포함** `{base}/api/setup/`을 GET하는데 Node·Swift 허브 모두 exact match(`=== '/api/setup'`)라 404 → api_key 저장이 영영 안 돼 매 wake 재시도 (frames는 `/api/display` soft MAC auth로 정상 렌더).
+
+### 해결
+- **`bridge/src/idotmatrix/sync.py`** — display-state fetch 성공 시(connect 블록 + 1c 루프) `last_bridge_ok` 갱신. 성공한 display-state 응답 = bridge 생존 증거.
+- **`bridge/src/ble-sync-spawn.ts` `createSyncCycleSquelch()`** — 동일 exit 사이클은 처음 2회만 전체 로그, 이후 start/exit 쌍 억제 + 시간당 카운트 요약(`suppressed N repeats … latest:`). 다른 exit(새 에러 텍스트·비정상 code·5분+ 정상 가동 후 재발)은 요약 flush 후 즉시 로그. 사이클 identity는 output tail 기준: hex/숫자 마스킹 + ` | ` 세그먼트 dedupe/sort(링버퍼가 같은 재시도 에러를 1개 또는 2개 캡처해도 동일 사이클). iDotMatrix(모듈 단일)·Timebox(엔트리별) 매니저 양쪽 wiring.
+- **`bridge/src/cli.ts`** — fork 로그를 append(`'a'`)로 열고 5MB 초과 시 `.1`로 rotate. launchd 경로(StandardErrorPath)는 원래 append.
+- **`bridge/src/daemon-server.ts` + `apple/.../Server/HttpServer.swift`** — TRMNL API 라우트 trailing-slash 무시 매칭(Node: `trmnlPath` 정규화, Swift: `route()`에서 normalizedPath 비교). 양 허브 패리티.
+
+### 검증
+- vitest 89파일/1626 pass(신규 `ble-sync-squelch.test.ts` 5케이스), `xcodebuild AgentDeck_macOS` BUILD SUCCEEDED.
+- 라이브: 수정 배포 후 `sync.py` child가 기존 30초 사망 주기를 넘겨 지속 생존; TRMNL 다음 wake부터 setup 404 소멸 확인. Timebox "not found" 루프(기기 꺼짐)는 2회 로그 후 억제.
+- 부수 복구: LaunchAgent plist가 과거 설치 시점의 pnpm Node 22 절대경로를 고정하고 있어 Node 26 업그레이드 후 better-sqlite3 ABI 불일치로 APME가 죽어 있었음 — better-sqlite3를 Node 26으로 재빌드 + `daemon uninstall/install`로 plist 재생성(이제 `agentdeck` shim + PATH 해석), APME/MLX judge 복구.
+
+---
+
 ## 2026-07-02 — 타임라인 이벤트 단위 정합성: OpenClaw 중복 행 제거 + APME 이중 인제스트 차단 + orphan task reaper
 
 ### 문제

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/timeline/TimelineIcons.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/timeline/TimelineIcons.kt
@@ -65,6 +65,7 @@ enum class TimelineIconKey {
  */
 fun timelineIconKey(type: String, status: String? = null): TimelineIconKey = when (type) {
     "task_start", "task_end" -> TimelineIconKey.Task
+    "task_milestone" -> TimelineIconKey.Success
     "chat_start" -> TimelineIconKey.Running
     "chat_end", "chat_response", "model_response" -> TimelineIconKey.Success
     "model_call" -> TimelineIconKey.Model
@@ -84,7 +85,8 @@ fun timelineIconKey(type: String, status: String? = null): TimelineIconKey = whe
 }
 
 /** Whether this entry type carries detail-pane body content (not a hierarchy marker). */
-fun entryHasDetailBody(type: String): Boolean = type != "task_start" && type != "task_end"
+fun entryHasDetailBody(type: String): Boolean =
+    type != "task_start" && type != "task_end" && type != "task_milestone"
 
 /**
  * True when [entry] is a `task_start` whose matching `task_end` (same

--- a/apple/AgentDeck/Daemon/Apme/ApmeCollector.swift
+++ b/apple/AgentDeck/Daemon/Apme/ApmeCollector.swift
@@ -93,6 +93,11 @@ final class ApmeCollector {
         var timelineEmitted: Bool = false
     }
     private var activeTask: ActiveTask?
+    /// Last milestone key (`taskId:turnIndex`) — a turn can carry several
+    /// all-completed TodoWrite calls; surface only the first as a
+    /// `task_milestone` row. Mirrors sessionToLastMilestone in
+    /// bridge/src/apme/collector.ts.
+    private var lastMilestoneKey: String?
     /// runId → next task_index. Lives across task close/open within a run.
     private var runTaskCount: [String: Int] = [:]
     /// Last cumulative usage seen for the active session — ModelEvents are
@@ -353,6 +358,7 @@ final class ApmeCollector {
                 _ = appendSampleEvent(taskId: task.id, runId: task.runId, turnIndex: turnIndex,
                                       kind: "state", core: "todos_complete:\(turnIndex)",
                                       payload: ["state": "todos_completed"])
+                emitTaskMilestoneIfNeeded(task: task, turnIndex: turnIndex)
             }
         }
     }
@@ -587,6 +593,30 @@ final class ApmeCollector {
     /// no-ops once the emit happens. Uses the task's original `startedAt`
     /// as the timeline timestamp so the TASK header anchors above the
     /// first turn it groups instead of jumping in mid-conversation.
+    /// Surface the TodoWrite-all-completed soft hint as a `task_milestone`
+    /// timeline row — non-segmenting (the task stays open), at most once per
+    /// (task, turn). Mirrors `onTaskMilestone` wiring in
+    /// bridge/src/apme/index.ts.
+    private func emitTaskMilestoneIfNeeded(task: ActiveTask, turnIndex: Int) {
+        let key = "\(task.id):\(turnIndex)"
+        if lastMilestoneKey == key { return }
+        lastMilestoneKey = key
+        // The milestone implies a task worth showing — promote the deferred
+        // task_start first so the milestone never renders orphaned.
+        emitDeferredTaskStartIfNeeded()
+        let run = store.getRun(id: task.runId)
+        emitTimelineEntry?(DaemonTimelineEntry(
+            ts: Double(Date().timeIntervalSince1970 * 1000),
+            type: "task_milestone",
+            raw: "Todos done",
+            agentType: run?.agentType,
+            projectName: run?.projectName,
+            sessionId: run?.sessionId,
+            runId: task.runId,
+            taskId: task.id
+        ))
+    }
+
     private func emitDeferredTaskStartIfNeeded() {
         guard var task = activeTask, !task.timelineEmitted else { return }
         let run = store.getRun(id: task.runId)
@@ -687,6 +717,7 @@ final class ApmeCollector {
     private func closeTask(boundarySignal: String) {
         guard let task = activeTask else { return }
         activeTask = nil
+        lastMilestoneKey = nil
         // Always cancel any armed idle-gap timer when a task closes, so a
         // late-firing timer can't reopen a closed-task race.
         idleGapTask?.cancel()

--- a/apple/AgentDeck/Daemon/Server/HTTPServer.swift
+++ b/apple/AgentDeck/Daemon/Server/HTTPServer.swift
@@ -234,9 +234,16 @@ actor HTTPServer {
     /// Route a request to matching handler (used by WebSocketServer for HTTP delegation).
     /// Supports both exact match and prefix match (paths ending with "*").
     func route(_ request: HTTPRequest) async -> HTTPResponse {
+        // Trailing-slash insensitive: TRMNL stock firmware requests `/api/setup/`
+        // (bl.cpp getDeviceCredentials builds `{base}/api/setup/`); an exact-only
+        // match 404s enrollment forever and the panel retries setup every wake.
+        var normalizedPath = request.path
+        while normalizedPath.count > 1 && normalizedPath.hasSuffix("/") {
+            normalizedPath.removeLast()
+        }
         // Exact match first
         for route in routes {
-            if route.method == request.method && route.path == request.path {
+            if route.method == request.method && (route.path == request.path || route.path == normalizedPath) {
                 return await route.handler(request)
             }
         }

--- a/apple/AgentDeck/Daemon/Timeline/DaemonTimelineStore.swift
+++ b/apple/AgentDeck/Daemon/Timeline/DaemonTimelineStore.swift
@@ -64,6 +64,15 @@ struct DaemonTimelineEntry: Codable, Sendable {
 actor DaemonTimelineStore {
     private var entries: [DaemonTimelineEntry] = []
     private let maxEntries = 200
+    /// Separate retention cap for task hierarchy rows — mirrors
+    /// `BridgeTimelineStore.MAX_TASK_ENTRIES`. Task rows are exempt from the
+    /// generic FIFO so a long task's `task_start` doesn't scroll away while
+    /// its turns stream in (which would leave the `task_end` unpaired).
+    private let maxTaskEntries = 60
+
+    static func isTaskRow(_ e: DaemonTimelineEntry) -> Bool {
+        e.type == "task_start" || e.type == "task_end" || e.type == "task_milestone"
+    }
     private let persistFile: URL
     private var dirty = false
     private var persistenceStarted = false
@@ -114,11 +123,37 @@ actor DaemonTimelineStore {
         }
 
         entries.append(entry)
-        if entries.count > maxEntries {
-            entries.removeFirst(entries.count - maxEntries)
+        while entries.count > maxEntries {
+            evictOne()
         }
         dirty = true
         flush()
+    }
+
+    /// Evict a single entry to enforce `maxEntries`, protecting task rows —
+    /// mirrors `BridgeTimelineStore.evictOne`. Task rows only leave under
+    /// their own cap, and an in-flight task's `task_start` (no matching
+    /// `task_end` yet) is never evicted.
+    private func evictOne() {
+        let taskRowCount = entries.lazy.filter { Self.isTaskRow($0) }.count
+        if taskRowCount > maxTaskEntries {
+            let closed = Set(entries.compactMap { $0.type == "task_end" ? $0.taskId : nil })
+            if let idx = entries.firstIndex(where: { e in
+                guard Self.isTaskRow(e) else { return false }
+                if e.type == "task_start", let id = e.taskId, !closed.contains(id) { return false }
+                return true
+            }) {
+                entries.remove(at: idx)
+                return
+            }
+        }
+        if let idx = entries.firstIndex(where: { !Self.isTaskRow($0) }) {
+            entries.remove(at: idx)
+            return
+        }
+        // Pathological: buffer is 100% in-flight task rows — plain FIFO so the
+        // buffer stays bounded.
+        entries.removeFirst()
     }
 
     func upsert(_ entry: DaemonTimelineEntry) {
@@ -159,7 +194,12 @@ actor DaemonTimelineStore {
         let matched = entries.filter {
             ($0.sessionId == sessionId || $0.sessionId == raw) && (since == nil || $0.ts > since!)
         }
-        return Array(matched.suffix(limit))
+        // `limit` applies to the chat/tool stream; task hierarchy rows ride
+        // along in full so a task_start older than the last `limit` rows
+        // doesn't vanish and leave the Detail view an unpaired task_end.
+        let taskRows = matched.filter { Self.isTaskRow($0) }
+        let rest = matched.filter { !Self.isTaskRow($0) }.suffix(limit)
+        return (taskRows + rest).sorted { $0.ts < $1.ts }
     }
 
     /// Returns the last timeline entry matching the given type, or nil if none found.
@@ -189,7 +229,12 @@ actor DaemonTimelineStore {
         guard semaphore.wait(timeout: .now() + .milliseconds(700)) == .success,
               let data = box.get(),
               let loaded = try? JSONDecoder().decode([DaemonTimelineEntry].self, from: data) else { return }
-        entries = Array(loaded.compactMap { Self.normalizeForStorage($0) }.suffix(maxEntries))
+        let normalized = loaded.compactMap { Self.normalizeForStorage($0) }
+        // Task-protected trim (mirrors BridgeTimelineStore.loadPersistedEntries):
+        // task rows keep their own deeper retention on reload.
+        let taskRows = normalized.filter { Self.isTaskRow($0) }.suffix(maxTaskEntries)
+        let rest = normalized.filter { !Self.isTaskRow($0) }.suffix(maxEntries - taskRows.count)
+        entries = (taskRows + rest).sorted { $0.ts < $1.ts }
     }
 
     // Exposed (default internal) so test targets can drive the predicate

--- a/apple/AgentDeck/Model/Timeline.swift
+++ b/apple/AgentDeck/Model/Timeline.swift
@@ -24,6 +24,9 @@ enum TimelineEntryType: Codable, Sendable, Equatable, Hashable {
     case evalResult
     case taskStart
     case taskEnd
+    /// Mid-task completion milestone (TodoWrite-all-completed soft hint) —
+    /// non-segmenting; surfaces WHERE work completed inside a long task.
+    case taskMilestone
     case unknown(String)
 
     var rawValue: String {
@@ -43,6 +46,7 @@ enum TimelineEntryType: Codable, Sendable, Equatable, Hashable {
         case .evalResult: return "eval_result"
         case .taskStart: return "task_start"
         case .taskEnd: return "task_end"
+        case .taskMilestone: return "task_milestone"
         case .unknown(let raw): return raw
         }
     }
@@ -75,6 +79,7 @@ enum TimelineEntryType: Codable, Sendable, Equatable, Hashable {
         case "eval_result": self = .evalResult
         case "task_start": self = .taskStart
         case "task_end": self = .taskEnd
+        case "task_milestone": self = .taskMilestone
         default: self = .unknown(raw)
         }
     }

--- a/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
+++ b/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
@@ -570,7 +570,8 @@ struct TimelineStripView: View {
                 TaskEvalBadge(
                     score: entry.taskScore,
                     outcome: entry.taskOutcome,
-                    fontSize: fontScale.label
+                    fontSize: fontScale.label,
+                    closedAt: entry.endedAt.map { Date(timeIntervalSince1970: $0 / 1000) } ?? entry.date
                 )
             }
             Text(formatTime(entry.date))
@@ -712,7 +713,8 @@ struct TimelineStripView: View {
                         TaskEvalBadge(
                             score: group.entry.taskScore,
                             outcome: group.entry.taskOutcome,
-                            fontSize: fontScale.body
+                            fontSize: fontScale.body,
+                            closedAt: group.entry.endedAt.map { Date(timeIntervalSince1970: $0 / 1000) } ?? group.entry.date
                         )
                         if let cat = group.entry.taskCategory, !cat.isEmpty {
                             Text(cat)
@@ -976,6 +978,7 @@ struct TimelineStripView: View {
         case .evalResult: return "EVAL"
         case .taskStart: return "TASK"
         case .taskEnd: return "TASK ✓"
+        case .taskMilestone: return "TODOS ✓"
         case .unknown(let raw): return raw.uppercased()
         }
     }
@@ -1349,6 +1352,15 @@ private struct TaskEvalBadge: View {
     let score: Double?
     let outcome: String?
     let fontSize: CGFloat
+    /// When the task closed (task_end row timestamp). Drives the pending →
+    /// unscored terminal transition: if the judge hasn't resolved within
+    /// `unscoredAfterSec` of the close, it never will (judge disabled, LLM
+    /// backend down, or the enqueue was lost) — showing "…" forever reads as
+    /// "still working". nil = unknown close time; stays on the pending glyph.
+    var closedAt: Date? = nil
+
+    /// Judges resolve in 5–30 s; 5 minutes is decisively past any real queue.
+    private static let unscoredAfterSec: TimeInterval = 300
 
     var body: some View {
         let glyph: String
@@ -1368,7 +1380,11 @@ private struct TaskEvalBadge: View {
             // masquerade as pending nor read as agent failure.
             glyph = "⊘"; color = DesignTokens.UI.error.opacity(0.55)
         default:
-            glyph = "…"; color = TerrariumHUD.subtext.opacity(0.6)
+            if let closedAt, Date().timeIntervalSince(closedAt) > Self.unscoredAfterSec {
+                glyph = "unscored"; color = TerrariumHUD.subtext.opacity(0.5)
+            } else {
+                glyph = "…"; color = TerrariumHUD.subtext.opacity(0.6)
+            }
         }
         return HStack(spacing: 3) {
             if let score {
@@ -1386,7 +1402,10 @@ private struct TaskEvalBadge: View {
             RoundedRectangle(cornerRadius: 3)
                 .fill(color.opacity(score == nil ? 0.08 : 0.16))
         )
-        .accessibilityLabel(score != nil ? "Task score \(String(format: "%.2f", score!)) \(outcome ?? "")" : "Task eval pending")
+        .accessibilityLabel(
+            score != nil ? "Task score \(String(format: "%.2f", score!)) \(outcome ?? "")"
+                : glyph == "unscored" ? "Task eval unscored" : "Task eval pending"
+        )
     }
 }
 
@@ -1965,6 +1984,8 @@ func timelineIconKey(for type: TimelineEntryType, status: String? = nil) -> Time
     switch type {
     case .taskStart, .taskEnd:
         return .task
+    case .taskMilestone:
+        return .success
     case .chatStart:
         return .running
     case .chatEnd, .chatResponse, .modelResponse:

--- a/bridge/src/__tests__/apme-task-milestone.test.ts
+++ b/bridge/src/__tests__/apme-task-milestone.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ApmeStore } from '../apme/store.js';
+import { ApmeCollector, type OnTaskMilestone } from '../apme/collector.js';
+import { opencodeIdleGapTaskBoundary, OPENCODE_IDLE_GAP_MS } from '../apme/adapters/opencode-hook.js';
+
+async function makeStore(): Promise<ApmeStore> {
+  const dir = mkdtempSync(join(tmpdir(), 'apme-milestone-test-'));
+  const store = new ApmeStore(join(dir, 'apme.sqlite'));
+  const ok = await store.init();
+  if (!ok) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('APME store failed to initialize — is better-sqlite3 installed?');
+  }
+  (store as unknown as { _tmpDir: string })._tmpDir = dir;
+  return store;
+}
+
+function cleanup(store: ApmeStore) {
+  store.close();
+  const dir = (store as unknown as { _tmpDir?: string })._tmpDir;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+}
+
+const ALL_DONE = { tool_input: { todos: [{ status: 'completed', content: 'a' }, { status: 'completed', content: 'b' }] } };
+const IN_PROGRESS = { tool_input: { todos: [{ status: 'completed', content: 'a' }, { status: 'in_progress', content: 'b' }] } };
+
+describe('TodoWrite-all-completed → onTaskMilestone', () => {
+  let store!: ApmeStore;
+
+  beforeEach(async () => { store = await makeStore(); });
+  afterEach(() => { cleanup(store); });
+
+  it('fires once per (task, turn) with attribution; not on partial todos', () => {
+    const collector = new ApmeCollector(store);
+    const fired: Parameters<OnTaskMilestone>[0][] = [];
+    collector.onTaskMilestone = (args) => fired.push(args);
+
+    collector.openRun({ sessionId: 's1', agentType: 'claude-code', projectName: 'demo' });
+    collector.ingestHook('s1', 'UserPromptSubmit', { prompt: 'plan and do' });
+
+    collector.ingestHook('s1', 'PostToolUse', { tool_name: 'TodoWrite', ...IN_PROGRESS });
+    expect(fired).toHaveLength(0); // not all completed — no milestone
+
+    collector.ingestHook('s1', 'PostToolUse', { tool_name: 'TodoWrite', ...ALL_DONE });
+    collector.ingestHook('s1', 'PostToolUse', { tool_name: 'TodoWrite', ...ALL_DONE });
+    expect(fired).toHaveLength(1); // same turn — second all-done is a no-op
+    expect(fired[0].agentType).toBe('claude-code');
+    expect(fired[0].projectName).toBe('demo');
+    expect(fired[0].todoCount).toBe(2);
+    expect(fired[0].taskId).toBeTruthy();
+
+    // A later turn may legitimately complete another batch of todos.
+    collector.ingestHook('s1', 'UserPromptSubmit', { prompt: 'now do more' });
+    collector.ingestHook('s1', 'PostToolUse', { tool_name: 'TodoWrite', ...ALL_DONE });
+    expect(fired).toHaveLength(2);
+    expect(fired[1].taskId).toBe(fired[0].taskId); // still the same open task
+  });
+});
+
+describe('opencodeIdleGapTaskBoundary', () => {
+  it('builds a task_boundary span with the idle_gap signal', () => {
+    const span = opencodeIdleGapTaskBoundary({
+      sessionId: 's1', agentType: 'opencode', cwd: '/tmp/p', traceId: 'trace', activeTurnId: undefined,
+    });
+    expect(span.kind).toBe('task_boundary');
+    expect(span.attributes['agentdeck.boundary_signal']).toBe('idle_gap');
+    expect(span.attributes['agentdeck.agent_type']).toBe('opencode');
+    expect(OPENCODE_IDLE_GAP_MS).toBe(90_000);
+  });
+});

--- a/bridge/src/__tests__/ble-sync-squelch.test.ts
+++ b/bridge/src/__tests__/ble-sync-squelch.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSyncCycleSquelch } from '../ble-sync-spawn.js';
+
+/**
+ * Repeated identical BLE sync respawn cycles (panel powered off, out of range,
+ * nightly disconnect loop) must collapse into a summary instead of flooding
+ * the daemon log, while any novel exit still logs immediately.
+ */
+describe('createSyncCycleSquelch', () => {
+  let lines: string[];
+  const log = (msg: string): void => {
+    lines.push(msg);
+  };
+
+  // The iDotMatrix clean-cycle output tail as the ring buffer captures it:
+  // python log timestamps and the BLE address vary per cycle.
+  const cycleTail = (i: number): string =>
+    `02.07.2026 08:${String(10 + i).padStart(2, '0')}:01 :: INFO :: idotmatrix.connectionManager :: ` +
+    `disconnected from 98A0BE6C-E08A-775F-93A3-FDF25D5E1A6C`;
+  const cycleLine = (i: number): string =>
+    `BLE sync exited (code=0 signal=null); output: ${cycleTail(i)}; respawning in 60s`;
+
+  beforeEach(() => {
+    lines = [];
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-02T08:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('logs the first two occurrences of a cycle, then suppresses identical repeats', () => {
+    const squelch = createSyncCycleSquelch(log);
+    squelch.logStart('Starting BLE sync');
+    squelch.logExit(0, null, 31_000, cycleTail(0), cycleLine(0));
+    squelch.logStart('Starting BLE sync'); // respawn after first exit still logs
+    squelch.logExit(0, null, 31_000, cycleTail(1), cycleLine(1));
+    expect(lines).toHaveLength(4);
+    expect(lines[3]).toContain('repeating cycle; suppressing');
+
+    for (let i = 2; i < 30; i++) {
+      squelch.logStart('Starting BLE sync');
+      squelch.logExit(0, null, 31_000, cycleTail(i), cycleLine(i));
+    }
+    expect(lines).toHaveLength(4); // fully quiet while the cycle repeats
+  });
+
+  it('emits an hourly summary with the repeat count while suppressing', () => {
+    const squelch = createSyncCycleSquelch(log);
+    squelch.logExit(0, null, 31_000, cycleTail(0), cycleLine(0));
+    squelch.logExit(0, null, 31_000, cycleTail(1), cycleLine(1)); // enters suppression
+    for (let i = 2; i < 12; i++) {
+      vi.advanceTimersByTime(90_000);
+      squelch.logExit(0, null, 31_000, cycleTail(i), cycleLine(i));
+    }
+    expect(lines).toHaveLength(2); // 15 minutes in — no summary yet
+
+    vi.advanceTimersByTime(60 * 60_000);
+    squelch.logExit(0, null, 31_000, cycleTail(12), cycleLine(12));
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toMatch(/suppressed 11 repeats of the same sync cycle/);
+    expect(lines[2]).toContain('latest:');
+  });
+
+  it('flushes and logs immediately when a different exit appears', () => {
+    const squelch = createSyncCycleSquelch(log);
+    squelch.logExit(0, null, 31_000, cycleTail(0), cycleLine(0));
+    squelch.logExit(0, null, 31_000, cycleTail(1), cycleLine(1));
+    squelch.logExit(0, null, 31_000, cycleTail(2), cycleLine(2));
+    lines = [];
+
+    const crashTail = 'ModuleNotFoundError: bleak';
+    const crash = `BLE sync exited (code=1 signal=null); output: ${crashTail}; respawning in 5s`;
+    squelch.logExit(1, null, 2_000, crashTail, crash);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/suppressed 1 repeats of the same sync cycle since/);
+    expect(lines[1]).toBe(crash);
+
+    // And the start line after a novel exit logs again.
+    squelch.logStart('Starting BLE sync');
+    expect(lines).toHaveLength(3);
+  });
+
+  it('treats 1x vs 2x captures of the same retry error as the same cycle', () => {
+    // The output ring captures one or two copies of the same "device not
+    // found" line depending on timing; the cycle identity must not flap.
+    const notFound = 'BLE connection error: Device with address 7CF31CA8-84EE-36BB-52AB-CC5515910C34 was not found';
+    const one = notFound;
+    const two = `${notFound} | ${notFound}`;
+    const squelch = createSyncCycleSquelch(log);
+    squelch.logExit(0, null, 12_000, one, `sync exited; output: ${one}; respawning in 5s`);
+    squelch.logExit(0, null, 12_000, two, `sync exited; output: ${two}; respawning in 10s`);
+    squelch.logExit(0, null, 12_000, one, `sync exited; output: ${one}; respawning in 15s`);
+    squelch.logExit(0, null, 12_000, two, `sync exited; output: ${two}; respawning in 20s`);
+    expect(lines).toHaveLength(2); // first + "repeating cycle" note, then quiet
+  });
+
+  it('treats an exit after a long healthy run as a fresh incident', () => {
+    const squelch = createSyncCycleSquelch(log);
+    squelch.logExit(0, null, 31_000, cycleTail(0), cycleLine(0));
+    squelch.logExit(0, null, 31_000, cycleTail(1), cycleLine(1));
+    squelch.logExit(0, null, 31_000, cycleTail(2), cycleLine(2));
+    lines = [];
+
+    // Same exit text, but the child stayed up 6 minutes — the old loop ended.
+    squelch.logExit(0, null, 6 * 60_000, cycleTail(3), cycleLine(3));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/suppressed 1 repeats/);
+    expect(lines[1]).toBe(cycleLine(3));
+  });
+});

--- a/bridge/src/__tests__/fallback-task-timeline.test.ts
+++ b/bridge/src/__tests__/fallback-task-timeline.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { FallbackTaskTimeline } from '../fallback-task-timeline.js';
+import type { TimelineEntry } from '../types.js';
+
+/**
+ * When APME can't load (better-sqlite3 ABI mismatch / missing build tools),
+ * the fallback tracker must still give the timeline its task hierarchy from
+ * boundary hooks alone.
+ */
+describe('FallbackTaskTimeline', () => {
+  it('opens a task on the first prompt and closes it on session end', () => {
+    const rows: TimelineEntry[] = [];
+    const fallback = new FallbackTaskTimeline((e) => rows.push(e), { agentType: 'claude-code' });
+
+    fallback.ingestHook('s1', 'UserPromptSubmit', { prompt: 'do the thing' });
+    fallback.ingestHook('s1', 'UserPromptSubmit', { prompt: 'follow-up' }); // same task — no new row
+    fallback.ingestHook('s1', 'SessionEnd', {});
+
+    expect(rows.map((r) => r.type)).toEqual(['task_start', 'task_end']);
+    expect(rows[0].taskId).toBe(rows[1].taskId);
+    expect(rows[0].raw).toBe('Task 1');
+    expect(rows[1].boundarySignal).toBe('session_end');
+    expect(rows[1].agentType).toBe('claude-code');
+    expect(rows[1].startedAt).toBe(rows[0].ts);
+  });
+
+  it('segments on /clear and numbers the next task', () => {
+    const rows: TimelineEntry[] = [];
+    const fallback = new FallbackTaskTimeline((e) => rows.push(e));
+
+    fallback.ingestHook('s1', 'user_prompt_submit', { message: { content: 'first' } });
+    fallback.ingestHook('s1', 'user_prompt_submit', { message: { content: ' /clear ' } });
+    fallback.ingestHook('s1', 'user_prompt_submit', { message: { content: 'second' } });
+    fallback.ingestHook('s1', 'session_end', {});
+
+    expect(rows.map((r) => r.type)).toEqual(['task_start', 'task_end', 'task_start', 'task_end']);
+    expect(rows[1].boundarySignal).toBe('clear');
+    expect(rows[2].raw).toBe('Task 2');
+    expect(rows[2].taskId).not.toBe(rows[0].taskId);
+  });
+
+  it('ignores session end with no open task and tracks sessions independently', () => {
+    const rows: TimelineEntry[] = [];
+    const fallback = new FallbackTaskTimeline((e) => rows.push(e));
+
+    fallback.ingestHook('s1', 'SessionEnd', {}); // nothing open — no row
+    expect(rows).toHaveLength(0);
+
+    fallback.ingestHook('a', 'UserPromptSubmit', { prompt: 'x' });
+    fallback.ingestHook('b', 'UserPromptSubmit', { prompt: 'y' });
+    fallback.ingestHook('a', 'SessionEnd', {});
+    expect(rows.filter((r) => r.type === 'task_end')).toHaveLength(1);
+    expect(rows.find((r) => r.type === 'task_end')?.sessionId).toBe('a');
+  });
+});

--- a/bridge/src/__tests__/timeline-task-retention.test.ts
+++ b/bridge/src/__tests__/timeline-task-retention.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { BridgeTimelineStore } from '../timeline-store.js';
+import type { TimelineEntry } from '../types.js';
+
+/**
+ * Task hierarchy rows must survive the 200-entry FIFO and the per-session
+ * history window — a long task's `task_start` scrolling away mid-task leaves
+ * its eventual `task_end` rendering as an unpaired orphan.
+ */
+
+let tsCounter = 1_000_000_000_000;
+function entry(partial: Partial<TimelineEntry> & { type: TimelineEntry['type'] }): TimelineEntry {
+  tsCounter += 10_000; // beyond every dedup window
+  return { ts: tsCounter, raw: `row-${tsCounter}`, ...partial } as TimelineEntry;
+}
+
+describe('BridgeTimelineStore task-row retention', () => {
+  it('keeps an in-flight task_start alive through FIFO overflow', () => {
+    const store = new BridgeTimelineStore();
+    store.addEntry(entry({ type: 'task_start', taskId: 'T1', raw: 'Task 1' }));
+    for (let i = 0; i < 400; i++) {
+      store.addEntry(entry({ type: 'chat_response', raw: `turn ${i}` }));
+    }
+    const history = store.getHistory();
+    expect(history.length).toBeLessThanOrEqual(200);
+    expect(history.some((e) => e.type === 'task_start' && e.taskId === 'T1')).toBe(true);
+  });
+
+  it('evicts closed task pairs once the task cap is exceeded, oldest first', () => {
+    const store = new BridgeTimelineStore();
+    // 40 closed pairs = 80 task rows > MAX_TASK_ENTRIES(60).
+    for (let i = 0; i < 40; i++) {
+      store.addEntry(entry({ type: 'task_start', taskId: `T${i}`, raw: `Task ${i}` }));
+      store.addEntry(entry({ type: 'task_end', taskId: `T${i}`, raw: 'Session end · 1s' }));
+    }
+    // Overflow the generic cap with chat rows so eviction has to run.
+    for (let i = 0; i < 250; i++) {
+      store.addEntry(entry({ type: 'chat_response', raw: `turn ${i}` }));
+    }
+    const history = store.getHistory();
+    expect(history.length).toBeLessThanOrEqual(200);
+    // Newest closed pairs survive; the oldest were evicted under the task cap.
+    expect(history.some((e) => e.taskId === 'T39')).toBe(true);
+    expect(history.some((e) => e.taskId === 'T0')).toBe(false);
+  });
+
+  it('getHistoryForSession returns task rows beyond the per-session limit', () => {
+    const store = new BridgeTimelineStore();
+    store.addEntry(entry({ type: 'task_start', taskId: 'T1', sessionId: 's1', raw: 'Task 1' }));
+    for (let i = 0; i < 30; i++) {
+      store.addEntry(entry({ type: 'chat_response', sessionId: 's1', raw: `turn ${i}` }));
+    }
+    store.addEntry(entry({ type: 'task_end', taskId: 'T1', sessionId: 's1', raw: '/clear · 9s' }));
+    const history = store.getHistoryForSession('s1', undefined, 16);
+    // 16 chat rows + both task rows, sorted by ts.
+    expect(history.filter((e) => e.type === 'task_start')).toHaveLength(1);
+    expect(history.filter((e) => e.type === 'task_end')).toHaveLength(1);
+    expect(history[0].type).toBe('task_start');
+    expect(history[history.length - 1].type).toBe('task_end');
+  });
+
+  it('loadPersistedEntries keeps task rows past the generic trim', () => {
+    const store = new BridgeTimelineStore();
+    const rows: TimelineEntry[] = [];
+    rows.push(entry({ type: 'task_start', taskId: 'T1', raw: 'Task 1' }));
+    for (let i = 0; i < 300; i++) rows.push(entry({ type: 'chat_response', raw: `turn ${i}` }));
+    rows.push(entry({ type: 'task_end', taskId: 'T1', raw: 'Session end · 5s' }));
+    store.loadPersistedEntries(rows as unknown[]);
+    const history = store.getHistory();
+    expect(history.length).toBeLessThanOrEqual(200);
+    expect(history.some((e) => e.type === 'task_start' && e.taskId === 'T1')).toBe(true);
+    expect(history.some((e) => e.type === 'task_end' && e.taskId === 'T1')).toBe(true);
+  });
+});

--- a/bridge/src/adapters/opencode-adapter.ts
+++ b/bridge/src/adapters/opencode-adapter.ts
@@ -20,7 +20,12 @@ import { OPENCODE_CAPABILITIES } from '../types.js';
 import { PtyAdapter } from './pty-adapter.js';
 import { randomUUID } from 'crypto';
 import { getApme } from '../apme/index.js';
-import { opencodePartToSpans, opencodeMessageToSpans } from '../apme/adapters/opencode-hook.js';
+import {
+  opencodePartToSpans,
+  opencodeMessageToSpans,
+  opencodeIdleGapTaskBoundary,
+  OPENCODE_IDLE_GAP_MS,
+} from '../apme/adapters/opencode-hook.js';
 
 const log = (...args: unknown[]) => debug('adapter:opencode', ...args);
 
@@ -55,6 +60,11 @@ export class OpenCodeAdapter extends PtyAdapter {
   /** Last seen user prompt — buffered so the assistant's response can be
    *  attached to the matching turn_start span. */
   private lastUserPrompt: string | undefined;
+  /** Idle-gap timer — fires the `task_boundary` (idle_gap) span when no new
+   *  work follows `session.idle` for OPENCODE_IDLE_GAP_MS. Mirrors the
+   *  OpenClaw adapter; without it OpenCode tasks close only on session_end
+   *  (one task per session, defeating per-task evaluation). */
+  private apmeIdleTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected getDefaultCommand(): string {
     return 'opencode';
@@ -137,6 +147,29 @@ export class OpenCodeAdapter extends PtyAdapter {
     }
   }
 
+  /** Reset (or start) the idle-gap timer after a turn completes. */
+  private armIdleGapTimer(): void {
+    this.clearIdleGapTimer();
+    const ctx = this.buildApmeCtx();
+    if (!ctx) return;
+    this.apmeIdleTimer = setTimeout(() => {
+      this.apmeIdleTimer = null;
+      const apme = getApme();
+      if (!apme || !this.apmeSessionId) return;
+      try { apme.collector.ingestSpan(this.apmeSessionId, opencodeIdleGapTaskBoundary(ctx)); }
+      catch (err) { debug('apme:opencode', `idle_gap ingestSpan failed: ${String(err)}`); }
+    }, OPENCODE_IDLE_GAP_MS);
+    // Don't keep the event loop alive just for this timer.
+    this.apmeIdleTimer.unref?.();
+  }
+
+  private clearIdleGapTimer(): void {
+    if (this.apmeIdleTimer) {
+      clearTimeout(this.apmeIdleTimer);
+      this.apmeIdleTimer = null;
+    }
+  }
+
   protected override handleAgentCommand(cmd: PluginCommand): boolean {
     switch (cmd.type) {
       case 'interrupt': {
@@ -158,6 +191,7 @@ export class OpenCodeAdapter extends PtyAdapter {
   }
 
   override async shutdown(): Promise<void> {
+    this.clearIdleGapTimer();
     this.client?.disconnect();
     this.client = null;
     await super.shutdown();
@@ -287,6 +321,8 @@ export class OpenCodeAdapter extends PtyAdapter {
    * the latch so the next turn re-arms.
    */
   private beginChatIfNeeded(): void {
+    // New work arrived — the session is not idle; don't split the task.
+    this.clearIdleGapTimer();
     if (this.chatStarted) return;
     this.chatStarted = true;
     this.chatStartTime = Date.now();
@@ -306,6 +342,9 @@ export class OpenCodeAdapter extends PtyAdapter {
 
     this.finishChat();
     this.emitAdapterEvent({ source: 'parser', event: 'idle' });
+    // Turn complete — arm the idle-gap task boundary (cancelled by the next
+    // work signal via beginChatIfNeeded).
+    this.armIdleGapTimer();
   }
 
   private handleSessionCreated(props: Record<string, unknown>): void {

--- a/bridge/src/apme/adapters/opencode-hook.ts
+++ b/bridge/src/apme/adapters/opencode-hook.ts
@@ -20,7 +20,12 @@
  *      tool name is "todowrite" and whose `state.output` reports every todo
  *      with `status === 'completed'`. OpenCode's todowrite tool is the
  *      analogue of Claude's TodoWrite + Codex's todo manager.
- *   2. (`/clear` and `manual` are reserved for future direct integrations —
+ *   2. `idle_gap` — the adapter arms a timer on `session.idle` and fires
+ *      `opencodeIdleGapTaskBoundary` after OPENCODE_IDLE_GAP_MS with no new
+ *      work (mirrors the OpenClaw idle-gap segmentation). Without it,
+ *      OpenCode tasks close only on `session_end` — one task per session,
+ *      defeating per-task evaluation.
+ *   3. (`/clear` and `manual` are reserved for future direct integrations —
  *      OpenCode doesn't currently surface either via SSE.)
  *
  * Tool calls and tool results map to `tool_call` / `tool_result` spans for
@@ -132,6 +137,29 @@ export function opencodeMessageToSpans(
     spans.push(make('turn_response', { 'agentdeck.response_text': responseText }));
   }
   return spans;
+}
+
+/** How long a session must sit idle (no new work after `session.idle`)
+ *  before the active task closes with an `idle_gap` boundary. Matches
+ *  OPENCLAW_IDLE_GAP_MS — the two adapters segment on the same rhythm. */
+export const OPENCODE_IDLE_GAP_MS = 90_000;
+
+/** Build the `task_boundary` (idle_gap) span the adapter emits when the
+ *  idle-gap timer fires. Mirrors `openclawIdleGapTaskBoundary`. */
+export function opencodeIdleGapTaskBoundary(ctx: AdapterContext): TelemetrySpan {
+  return {
+    traceId: ctx.traceId,
+    spanId: randomUUID(),
+    parentSpanId: ctx.activeTurnId,
+    name: spanNameForKind('task_boundary'),
+    kind: 'task_boundary',
+    ts: Date.now(),
+    attributes: {
+      'agentdeck.agent_type': ctx.agentType,
+      ...(ctx.cwd ? { 'agentdeck.cwd': ctx.cwd } : {}),
+      'agentdeck.boundary_signal': 'idle_gap',
+    },
+  };
 }
 
 /**

--- a/bridge/src/apme/collector.ts
+++ b/bridge/src/apme/collector.ts
@@ -111,6 +111,22 @@ export type OnTaskOpened = (args: {
   startedAt: number;
 }) => void;
 
+/** Callback fired when the agent declares its todos done mid-task (the
+ *  TodoWrite-all-completed soft hint). Non-segmenting — the task stays open —
+ *  but the timeline emitter surfaces it as a `task_milestone` row so long
+ *  sessions show WHERE work units completed without waiting for `/clear` or
+ *  `session_end`. */
+export type OnTaskMilestone = (args: {
+  taskId: string;
+  runId: string;
+  sessionId: string;
+  agentType: AgentType | null;
+  projectName: string | null;
+  turnIndex: number;
+  todoCount: number | null;
+  at: number;
+}) => void;
+
 export class ApmeCollector {
   private readonly sessionToRun = new Map<string, string>(); // sessionId → runId
   private readonly sessionToTurn = new Map<string, ActiveTurn>(); // sessionId → current turn
@@ -130,6 +146,14 @@ export class ApmeCollector {
   /** Optional listener fired after a typed trajectory event is persisted.
    *  The timeline projection (Phase 3) consumes this. */
   public onSampleEvent: OnSampleEvent | null = null;
+
+  /** Optional listener fired on the TodoWrite-all-completed soft hint.
+   *  The timeline emitter wires this to push a `task_milestone` row. */
+  public onTaskMilestone: OnTaskMilestone | null = null;
+
+  /** Last milestone key (`taskId:turnIndex`) per session — a turn can carry
+   *  several all-completed TodoWrite calls; surface only the first. */
+  private readonly sessionToLastMilestone = new Map<string, string>();
 
   constructor(
     private readonly store: ApmeStore,
@@ -323,6 +347,7 @@ export class ApmeCollector {
             { taskId: task.id, runId, turnIndex },
             { kind: 'state', dedupCore: `todos_complete:${turnIndex}:${todos.length}`, payloadObj: { state: 'todos_completed', count: todos.length } },
           );
+          this.fireTaskMilestone(sessionId, task.id, runId, turnIndex, todos.length);
         }
       }
     }
@@ -378,6 +403,37 @@ export class ApmeCollector {
   /** Get the current active task ID for a session (if any). Exposed for tests. */
   getActiveTaskId(sessionId: string): string | null {
     return this.sessionToTask.get(sessionId)?.id ?? null;
+  }
+
+  /** Fire the `onTaskMilestone` listener for a TodoWrite-all-completed hint,
+   *  at most once per (task, turn) — the agent may rewrite an all-completed
+   *  todo list several times inside one turn. */
+  private fireTaskMilestone(
+    sessionId: string,
+    taskId: string,
+    runId: string,
+    turnIndex: number,
+    todoCount: number | null,
+  ): void {
+    if (!this.onTaskMilestone) return;
+    const key = `${taskId}:${turnIndex}`;
+    if (this.sessionToLastMilestone.get(sessionId) === key) return;
+    this.sessionToLastMilestone.set(sessionId, key);
+    const run = this.store.getRun(runId);
+    try {
+      this.onTaskMilestone({
+        taskId,
+        runId,
+        sessionId,
+        agentType: (run?.agentType ?? null) as AgentType | null,
+        projectName: run?.projectName ?? null,
+        turnIndex,
+        todoCount,
+        at: Date.now(),
+      });
+    } catch (err) {
+      debug('APME', `onTaskMilestone listener threw: ${String(err)}`);
+    }
   }
 
   /** Open a new task if none is active for this session. Returns the active
@@ -459,6 +515,7 @@ export class ApmeCollector {
     const task = this.sessionToTask.get(sessionId);
     if (!task) return;
     this.sessionToTask.delete(sessionId);
+    this.sessionToLastMilestone.delete(sessionId);
 
     // Empty task: no turns ever attached. Drop the row so the dashboard
     // doesn't show phantom entries from back-to-back boundary signals.
@@ -761,6 +818,7 @@ export class ApmeCollector {
               { taskId: task.id, runId: task.runId, turnIndex },
               { kind: 'state', dedupCore: `todos_complete:${turnIndex}`, payloadObj: { state: 'todos_completed' } },
             );
+            this.fireTaskMilestone(sessionId, task.id, task.runId, turnIndex, null);
           }
           return;
         }

--- a/bridge/src/apme/index.ts
+++ b/bridge/src/apme/index.ts
@@ -142,6 +142,28 @@ export async function initApme(
     };
   }
 
+  // Wire the mid-task completion milestone. TodoWrite-all-completed is a
+  // non-segmenting soft hint (fires ~18% of the time on Claude Code v2.1), so
+  // it must not split the task — but when it DOES fire it is a strong "the
+  // agent declared this chunk done" signal, and long sessions otherwise show
+  // no completion marks until /clear or session_end.
+  if (emitTimeline) {
+    collector.onTaskMilestone = ({
+      taskId, runId, sessionId, agentType, projectName, todoCount, at,
+    }) => {
+      emitTimeline({
+        ts: at,
+        type: 'task_milestone',
+        raw: todoCount ? `Todos done (${todoCount})` : 'Todos done',
+        agentType: agentType ?? undefined,
+        projectName: projectName ?? undefined,
+        sessionId,
+        runId,
+        taskId,
+      });
+    };
+  }
+
   // Wire task-eval completion → re-emit `task_end` with score + outcome.
   // The original `task_end` (above) fires synchronously on closeTask so the
   // boundary is visible immediately; the judge runs async and may take

--- a/bridge/src/ble-sync-spawn.ts
+++ b/bridge/src/ble-sync-spawn.ts
@@ -76,6 +76,106 @@ export function spawnPythonSync(
   };
 }
 
+/** Emit a repeated-cycle summary at most this often while suppressing. */
+const SQUELCH_SUMMARY_INTERVAL_MS = 60 * 60_000;
+/** A run this long means the previous respawn loop ended; the next exit logs fresh. */
+const SQUELCH_RESET_UPTIME_MS = 5 * 60_000;
+
+/**
+ * Collapse variable parts so consecutive exits from the same failure loop
+ * compare equal: timestamps/addresses/hashes are masked, and the ` | `-joined
+ * output tail is reduced to its set of distinct lines — the ring buffer
+ * captures 1 or 2 copies of the same retry error depending on timing, which
+ * must not read as a different cycle.
+ */
+function cycleSignature(code: number | null, signal: NodeJS.Signals | null, tail: string): string {
+  const masked = tail.replace(/[0-9A-Fa-f]{4,}/g, '#').replace(/\d+/g, '#');
+  const segments = [...new Set(masked.split(' | ').map((s) => s.trim()))].sort();
+  return `${code}|${signal}|${segments.join(' | ')}`;
+}
+
+export interface SyncCycleSquelch {
+  /** Log a spawn line, unless we're inside a suppressed repeating cycle. */
+  logStart(line: string): void;
+  /**
+   * Log an exit line, or absorb it into the repeating-cycle summary.
+   * `tail` is the captured child output alone (no prefix/backoff suffix) —
+   * it is what identifies the cycle.
+   */
+  logExit(code: number | null, signal: NodeJS.Signals | null, uptimeMs: number, tail: string, line: string): void;
+}
+
+/**
+ * Log gate for the respawn loop of a managed BLE sync child.
+ *
+ * A powered-off or out-of-range panel makes the sync child exit the same way
+ * every backoff period, all night — thousands of identical start/exit pairs in
+ * the daemon log. The gate logs the first two occurrences of an exit cycle in
+ * full, then suppresses identical repeats (including their respawn start
+ * lines), emitting an hourly count summary instead. Any *different* exit —
+ * new error text, non-zero code, a crash after a long healthy run — flushes
+ * the summary and logs immediately, so novel failures are never hidden.
+ */
+export function createSyncCycleSquelch(log: (msg: string) => void): SyncCycleSquelch {
+  let lastSignature: string | null = null;
+  let repeats = 0; // suppressed repeats of lastSignature (beyond the logged first occurrence)
+  let suppressedSinceSummary = 0;
+  let suppressedSince = 0;
+  let lastSummaryAt = 0;
+  let lastLine = '';
+
+  const flush = (): void => {
+    if (suppressedSinceSummary > 0) {
+      log(
+        `suppressed ${suppressedSinceSummary} repeats of the same sync cycle since ` +
+          `${new Date(suppressedSince).toISOString()}; latest: ${lastLine}`,
+      );
+    }
+    lastSignature = null;
+    repeats = 0;
+    suppressedSinceSummary = 0;
+  };
+
+  return {
+    logStart(line: string): void {
+      if (repeats > 0) return; // inside a suppressed repeating cycle
+      log(line);
+    },
+    logExit(code, signal, uptimeMs, tail, line): void {
+      // A long healthy run means the old loop ended; whatever exits next is a
+      // fresh incident even if the text matches the old one.
+      if (uptimeMs >= SQUELCH_RESET_UPTIME_MS) flush();
+      const signature = cycleSignature(code, signal, tail);
+      if (signature !== lastSignature) {
+        flush();
+        lastSignature = signature;
+        log(line);
+        return;
+      }
+      repeats += 1;
+      suppressedSinceSummary += 1;
+      lastLine = line;
+      const now = Date.now();
+      if (repeats === 1) {
+        // Second identical cycle: log it once more, then go quiet.
+        suppressedSinceSummary = 0;
+        suppressedSince = now;
+        lastSummaryAt = now;
+        log(`${line} — repeating cycle; suppressing identical start/exit logs (hourly summary, a different exit logs immediately)`);
+        return;
+      }
+      if (now - lastSummaryAt >= SQUELCH_SUMMARY_INTERVAL_MS) {
+        log(
+          `suppressed ${suppressedSinceSummary} repeats of the same sync cycle in the last ` +
+            `${Math.round((now - lastSummaryAt) / 60_000)}m; latest: ${lastLine}`,
+        );
+        lastSummaryAt = now;
+        suppressedSinceSummary = 0;
+      }
+    },
+  };
+}
+
 /**
  * SIGTERM a managed sync child and wait (bounded) for it to exit, so the child's
  * OFFLINE / blank farewell frame finishes painting before the daemon process

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -298,7 +298,7 @@ daemon
 
     // Background fork unless --foreground
     if (!opts.foreground) {
-      const { openSync } = await import('fs');
+      const { openSync, statSync, renameSync } = await import('fs');
       const logDir = join(homedir(), '.agentdeck');
       const scriptPath = fileURLToPath(import.meta.url);
       const args = [scriptPath, 'daemon', 'start', '--foreground'];
@@ -307,8 +307,20 @@ daemon
       if (opts.wakeWord) args.push('--wake-word');
 
       // Use log files instead of 'ignore' — preserves device access (mic, etc.)
-      const out = openSync(join(logDir, 'daemon-stdout.log'), 'w');
-      const err = openSync(join(logDir, 'daemon-stderr.log'), 'w');
+      // Append (never truncate) so multi-day history survives restarts —
+      // overnight device incidents can only be correlated against logs that
+      // are still there in the morning. Rotate once past 5MB instead.
+      const openDaemonLog = (name: string): number => {
+        const path = join(logDir, name);
+        try {
+          if (statSync(path).size > 5 * 1024 * 1024) renameSync(path, `${path}.1`);
+        } catch {
+          /* first run — no log yet */
+        }
+        return openSync(path, 'a');
+      };
+      const out = openDaemonLog('daemon-stdout.log');
+      const err = openDaemonLog('daemon-stderr.log');
 
       const child = spawn(process.execPath, args, {
         detached: true,

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -48,6 +48,7 @@ import { triggerMdnsRecovery } from './mdns.js';
 import { rgbToBmp, pixooLiveHtml } from './hook-server.js';
 import { enableDebugLog, debug } from './logger.js';
 import { initApme, isTimelineProjectionEnabled, loadApmeConfig, type ApmeModule } from './apme/index.js';
+import { FallbackTaskTimeline } from './fallback-task-timeline.js';
 import { handleApmeRequest } from './apme/http.js';
 import { readModelFromTranscript } from './apme/claude-transcript-reader.js';
 import { transcriptTimelineForSession } from './session-transcript-timeline.js';
@@ -445,6 +446,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
   // ===== APME (lazy — may be null if better-sqlite3 isn't installed) =====
   let apme: ApmeModule | null = null;
+  // Fallback task-row emitter, created only when initApme() returns null —
+  // keeps task_start/task_end rows on the timeline without the collector.
+  let fallbackTasks: FallbackTaskTimeline | null = null;
 
   // Declare early — HTTP /health handler references this in its closure.
   // Must be declared before the HTTP server so it's initialized (not in TDZ)
@@ -712,6 +716,14 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           if (mapped === 'session_end') {
             apme.collector.closeRun(hookSessionId);
           }
+        } else if (fallbackTasks) {
+          // APME is down — keep the timeline's task hierarchy alive from the
+          // boundary hooks alone. Prefer the hook's real session id so rows
+          // attribute per session (the shared 'daemon-hook' bucket would
+          // interleave concurrent direct-claude sessions).
+          const fallbackSessionId =
+            typeof json.session_id === 'string' && json.session_id ? json.session_id : 'daemon-hook';
+          fallbackTasks.ingestHook(fallbackSessionId, mapped, json);
         }
 
         // ── Response ──
@@ -1111,6 +1123,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     // line tells the user where to look + what's lost so the gap doesn't pass
     // for "everything's fine, just no /apme/ routes".
     log('[agentdeck] APME unavailable — no run/turn/task evals will be recorded for sessions on this daemon.');
+    // Keep the timeline's task hierarchy alive without APME: emit fallback
+    // task_start/task_end rows from the hook boundary signals so the device
+    // timeline doesn't degrade to a flat chat/tool stream.
+    fallbackTasks = new FallbackTaskTimeline(
+      (entry) => core.bridgeTimeline.addEntry(entry),
+      { agentType: 'claude-code' },
+    );
   }
 
   // Register session

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -622,15 +622,20 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       return;
     }
     // --- TRMNL BYOS (e-ink panel pulls rendered dashboard over WiFi) ---
-    if (req.method === 'GET' && pathname === '/api/setup') {
+    // Stock firmware requests `/api/setup/` WITH a trailing slash
+    // (bl.cpp getDeviceCredentials builds `{base}/api/setup/`), so match these
+    // routes slash-insensitively — an exact match 404s enrollment forever and
+    // the panel retries setup on every wake.
+    const trmnlPath = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+    if (req.method === 'GET' && trmnlPath === '/api/setup') {
       handleTrmnlSetup(req, res);
       return;
     }
-    if (req.method === 'GET' && pathname === '/api/display') {
+    if (req.method === 'GET' && trmnlPath === '/api/display') {
       handleTrmnlDisplay(req, res);
       return;
     }
-    if (req.method === 'POST' && pathname === '/api/log') {
+    if (req.method === 'POST' && trmnlPath === '/api/log') {
       handleTrmnlLog(req, res);
       return;
     }

--- a/bridge/src/fallback-task-timeline.ts
+++ b/bridge/src/fallback-task-timeline.ts
@@ -1,0 +1,107 @@
+/**
+ * Fallback task-row emitter for APME-disabled daemons.
+ *
+ * task_start / task_end timeline rows are normally minted by the APME
+ * collector (bridge/src/apme/index.ts wires them to emitTimeline). When
+ * better-sqlite3 can't load (`initApme()` → null — Node ABI mismatch, missing
+ * build tools on a fresh install), the whole task hierarchy vanishes and the
+ * device timeline degrades to a flat chat/tool stream with no work-unit
+ * structure at all.
+ *
+ * This tracker mirrors ONLY the collector's boundary state machine — open a
+ * task on the first user prompt, close it on `/clear` or session end — and
+ * emits the same timeline rows with synthetic taskIds. No storage, no eval:
+ * task_end rows never receive a judge verdict (the dashboard badge settles to
+ * "unscored"), and taskIndex resets when the daemon restarts. Good enough to
+ * keep the timeline structurally intact until APME is repaired.
+ */
+
+import { randomUUID } from 'crypto';
+import type { TimelineEntry } from '@agentdeck/shared';
+
+interface ActiveFallbackTask {
+  taskId: string;
+  startedAt: number;
+  index: number;
+}
+
+export class FallbackTaskTimeline {
+  /** sessionId → in-flight task. */
+  private readonly active = new Map<string, ActiveFallbackTask>();
+  /** sessionId → next task index (mirrors the collector's per-run counter). */
+  private readonly counts = new Map<string, number>();
+
+  constructor(
+    private readonly emit: (entry: TimelineEntry) => void,
+    private readonly meta: { agentType?: string } = {},
+  ) {}
+
+  /**
+   * Feed a hook event. Accepts both the PascalCase hook names the session
+   * bridge forwards (`UserPromptSubmit`) and the snake_case names the daemon
+   * hook endpoint maps to (`user_prompt_submit`).
+   */
+  ingestHook(sessionId: string, event: string, data: Record<string, unknown>): void {
+    const e = event.toLowerCase().replace(/_/g, '');
+    if (e === 'userpromptsubmit') {
+      const prompt = readPrompt(data);
+      if (prompt && /^\s*\/clear\s*$/i.test(prompt)) {
+        this.close(sessionId, 'clear');
+        return;
+      }
+      this.openIfNone(sessionId);
+      return;
+    }
+    if (e === 'sessionend') {
+      this.close(sessionId, 'session_end');
+    }
+  }
+
+  private openIfNone(sessionId: string): void {
+    if (this.active.has(sessionId)) return;
+    const index = this.counts.get(sessionId) ?? 0;
+    this.counts.set(sessionId, index + 1);
+    const task: ActiveFallbackTask = { taskId: randomUUID(), startedAt: Date.now(), index };
+    this.active.set(sessionId, task);
+    this.emit({
+      ts: task.startedAt,
+      type: 'task_start',
+      raw: `Task ${index + 1}`,
+      sessionId,
+      taskId: task.taskId,
+      startedAt: task.startedAt,
+      ...(this.meta.agentType ? { agentType: this.meta.agentType } : {}),
+    });
+  }
+
+  private close(sessionId: string, boundarySignal: 'clear' | 'session_end'): void {
+    const task = this.active.get(sessionId);
+    if (!task) return;
+    this.active.delete(sessionId);
+    const endedAt = Date.now();
+    const durationSec = Math.max(0, Math.round((endedAt - task.startedAt) / 1000));
+    const signalLabel = boundarySignal === 'clear' ? '/clear' : 'Session end';
+    this.emit({
+      ts: endedAt,
+      type: 'task_end',
+      raw: `${signalLabel} · ${durationSec}s`,
+      sessionId,
+      taskId: task.taskId,
+      boundarySignal,
+      startedAt: task.startedAt,
+      endedAt,
+      ...(this.meta.agentType ? { agentType: this.meta.agentType } : {}),
+    });
+  }
+}
+
+/** Claude Code sends { message: { content } } via spans, raw hooks send { prompt }. */
+function readPrompt(data: Record<string, unknown>): string | null {
+  if (typeof data.prompt === 'string') return data.prompt;
+  const message = data.message;
+  if (message && typeof message === 'object') {
+    const content = (message as Record<string, unknown>).content;
+    if (typeof content === 'string') return content;
+  }
+  return null;
+}

--- a/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
+++ b/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
@@ -21,7 +21,7 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { loadIDotMatrixDevices, type IDotMatrixDevice } from './idotmatrix-settings.js';
-import { spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
+import { createSyncCycleSquelch, spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
 
 let child: ChildProcess | null = null;
 let stopping = false;
@@ -45,6 +45,10 @@ function log(msg: string): void {
   // Match the daemon's `[agentdeck]` stderr prefix.
   console.error(`[agentdeck] [idotmatrix] ${msg}`);
 }
+
+// Repeated identical respawn cycles (panel off/out of range) collapse into an
+// hourly summary instead of flooding the daemon log all night.
+const squelch = createSyncCycleSquelch(log);
 
 function resolvePaths(): { venvPython: string; syncScript: string } {
   // This file compiles to bridge/dist/idotmatrix/idotmatrix-daemon-sync.js, so
@@ -102,7 +106,7 @@ function spawnSync(venvPython: string, syncScript: string, httpPort: number): vo
   const brightness = device.brightness ?? 100;
   const url = `http://127.0.0.1:${httpPort}`;
 
-  log(`Starting BLE sync for ${device.name ?? addr} (bridge ${url}, brightness ${brightness}%)`);
+  squelch.logStart(`Starting BLE sync for ${device.name ?? addr} (bridge ${url}, brightness ${brightness}%)`);
   startedAt = Date.now();
   runningKey = deviceKey(device);
   // iDotMatrix software brightness boost canonical = 1.6 — keep in sync:
@@ -125,12 +129,19 @@ function spawnSync(venvPython: string, syncScript: string, httpPort: number): vo
     // Clean code=0 exits are abnormal for daemon-managed sync children (normal
     // shutdown is gated by `stopping` above), so repeated BLE disconnect exits
     // must still escalate instead of flapping every 5 seconds forever.
-    if (code !== 0 && Date.now() - startedAt > HEALTHY_UPTIME_MS) consecutiveFailures = 0;
+    const uptimeMs = Date.now() - startedAt;
+    if (code !== 0 && uptimeMs > HEALTHY_UPTIME_MS) consecutiveFailures = 0;
     consecutiveFailures += 1;
     const delay = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * consecutiveFailures);
     const tail = stderrTail() || outputTail();
     const why = tail ? `; output: ${tail}` : '';
-    log(`BLE sync exited (code=${code} signal=${signal})${why}; respawning in ${Math.round(delay / 1000)}s`);
+    squelch.logExit(
+      code,
+      signal,
+      uptimeMs,
+      tail,
+      `BLE sync exited (code=${code} signal=${signal})${why}; respawning in ${Math.round(delay / 1000)}s`,
+    );
     respawnTimer = setTimeout(() => spawnSync(venvPython, syncScript, httpPort), delay);
     if (respawnTimer.unref) respawnTimer.unref();
   });

--- a/bridge/src/idotmatrix/sync.py
+++ b/bridge/src/idotmatrix/sync.py
@@ -175,6 +175,7 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
 
                 try:
                     display_state = await fetch_display_state(url)
+                    last_bridge_ok = time.monotonic()
                     current_hw_brightness, display_dimmed, last_display_signature = resolve_display_brightness(display_state, brightness)
                 except Exception:
                     current_hw_brightness = brightness
@@ -211,6 +212,12 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
             # same display_state that Pixoo/D200H/ESP32 receive over WS/serial.
             try:
                 display_state = await fetch_display_state(url)
+                # A successful display-state fetch proves the bridge is alive.
+                # Without this the dimmed path below (which skips the frame
+                # fetch) starves the bridge-gone watchdog and the sync exits
+                # cleanly every BRIDGE_GONE_EXIT_SEC while the host display
+                # sleeps — the daemon then respawns it forever at 60s cadence.
+                last_bridge_ok = time.monotonic()
                 target_brightness, target_dimmed, signature = resolve_display_brightness(display_state, brightness)
                 if signature != last_display_signature or target_brightness != current_hw_brightness:
                     print(f"Host display {'off' if target_dimmed else 'on'} — setting hardware brightness to {target_brightness}%")

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -8,6 +8,7 @@
 import { BridgeCore } from './bridge-core.js';
 import { buildDisplayStateEvent } from './display-dim.js';
 import { initApme, isTimelineProjectionEnabled } from './apme/index.js';
+import { FallbackTaskTimeline } from './fallback-task-timeline.js';
 import { readLastTurn as readClaudeTranscriptLastTurn } from './apme/claude-transcript-reader.js';
 import { claudeHookToSpans } from './apme/adapters/claude-hook.js';
 import { codexHookToSpans } from './apme/adapters/codex-hook.js';
@@ -254,6 +255,15 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     // activity log only). Scores are stored in apme.sqlite and surfaced via the
     // scorecard / `apme_eval` WS event, keeping the timeline noise-free.
   }
+  // APME down (better-sqlite3 failed to load): keep the timeline's task
+  // hierarchy alive by minting fallback task_start/task_end rows from the
+  // hook boundary signals. No storage, no eval — structure only.
+  const fallbackTasks = apme
+    ? null
+    : new FallbackTaskTimeline(
+        (entry) => core.bridgeTimeline.addEntry(entry),
+        { agentType },
+      );
 
   // ===== Session-specific components =====
   const voiceManager = new VoiceManager();
@@ -524,6 +534,8 @@ export async function startSession(opts: SessionOptions): Promise<void> {
           }
         }
         if (evt.event === 'Stop') pendingPtyResponse = null; // Stop has cleaner response
+        // APME-off fallback: task rows from boundary hooks alone.
+        if (fallbackTasks) fallbackTasks.ingestHook(core.sessionId, evt.event, evt.data ?? {});
         if (evt.event === 'shutdown') {
           shutdown();
           return;

--- a/bridge/src/timebox/timebox-daemon-sync.ts
+++ b/bridge/src/timebox/timebox-daemon-sync.ts
@@ -11,7 +11,7 @@ import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { deviceId, loadTimeboxDevices, type TimeboxDevice } from './timebox-settings.js';
-import { spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
+import { createSyncCycleSquelch, spawnPythonSync, terminateSyncChild, type SyncCycleSquelch } from '../ble-sync-spawn.js';
 
 interface SyncEntry {
   device: TimeboxDevice;
@@ -20,6 +20,8 @@ interface SyncEntry {
   respawnTimer: ReturnType<typeof setTimeout> | null;
   consecutiveFailures: number;
   startedAt: number;
+  /** Collapses repeated identical respawn cycles into an hourly summary. */
+  squelch: SyncCycleSquelch;
 }
 
 const entries = new Map<string, SyncEntry>();
@@ -66,6 +68,7 @@ export function startTimeboxSync(httpPort: number): void {
       respawnTimer: null,
       consecutiveFailures: 0,
       startedAt: 0,
+      squelch: createSyncCycleSquelch(log),
     };
     entries.set(id, entry);
     spawnSync(entry, venvPython, bleScript, httpPort);
@@ -80,7 +83,7 @@ function spawnSync(entry: SyncEntry, venvPython: string, syncScript: string, htt
   const brightness = Math.max(0, Math.min(100, Math.round(device.brightness ?? 100)));
   const args = [syncScript, '--address', device.address, '--url', url, '--brightness', String(brightness)];
 
-  log(
+  entry.squelch.logStart(
     `Starting BLE sync for ${device.name ?? 'Timebox Mini'} (${id}, bridge ${url}, brightness ${brightness}%)`,
   );
   entry.startedAt = Date.now();
@@ -101,12 +104,19 @@ function spawnSync(entry: SyncEntry, venvPython: string, syncScript: string, htt
     // gated by `entry.stopping` above. Do not reset backoff for repeated
     // "device not found" / BLE disconnect exits just because they lasted long
     // enough to cross the healthy-uptime threshold.
-    if (code !== 0 && Date.now() - entry.startedAt > HEALTHY_UPTIME_MS) entry.consecutiveFailures = 0;
+    const uptimeMs = Date.now() - entry.startedAt;
+    if (code !== 0 && uptimeMs > HEALTHY_UPTIME_MS) entry.consecutiveFailures = 0;
     entry.consecutiveFailures += 1;
     const delay = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * entry.consecutiveFailures);
     const tail = stderrTail() || outputTail();
     const why = tail ? `; output: ${tail}` : '';
-    log(`sync for ${id} exited (code=${code} signal=${signal})${why}; respawning in ${Math.round(delay / 1000)}s`);
+    entry.squelch.logExit(
+      code,
+      signal,
+      uptimeMs,
+      tail,
+      `sync for ${id} exited (code=${code} signal=${signal})${why}; respawning in ${Math.round(delay / 1000)}s`,
+    );
     entry.respawnTimer = setTimeout(() => spawnSync(entry, venvPython, syncScript, httpPort), delay);
     if (entry.respawnTimer.unref) entry.respawnTimer.unref();
   });

--- a/bridge/src/timeline-store.ts
+++ b/bridge/src/timeline-store.ts
@@ -16,6 +16,15 @@ type EntryListener = (entry: TimelineEntry, upsert?: boolean) => void;
 type EntryAttributor = (entry: TimelineEntry) => TimelineEntry;
 
 const MAX_ENTRIES = 200;
+/** Separate retention cap for task hierarchy rows (task_start/task_end/
+ *  task_milestone). Task rows are exempt from the generic FIFO shift —
+ *  a long task's `task_start` must not scroll away while its turns stream
+ *  in, or the eventual `task_end` renders as an unpaired orphan. ~30 pairs. */
+const MAX_TASK_ENTRIES = 60;
+
+function isTaskRow(e: Pick<TimelineEntry, 'type'>): boolean {
+  return e.type === 'task_start' || e.type === 'task_end' || e.type === 'task_milestone';
+}
 
 /** Chat/tool entry types that, in projection mode, come from the SessionSample
  *  projection instead of the adapters' direct emitters. Locally-emitted entries
@@ -102,9 +111,40 @@ export class BridgeTimelineStore {
     // history replay carry attribution from the time of creation.
     this.entries.push(result.entry);
     if (this.entries.length > MAX_ENTRIES) {
-      this.entries.shift();
+      this.evictOne();
     }
     for (const cb of this.listeners) cb(result.entry);
+  }
+
+  /** Evict a single entry to enforce MAX_ENTRIES, protecting task rows.
+   *
+   *  Task rows only leave under their own cap (MAX_TASK_ENTRIES), and an
+   *  in-flight task's `task_start` (no matching `task_end` yet) is never
+   *  evicted — otherwise a long task's start scrolls away mid-task and the
+   *  pair splits. Everything else FIFOs as before. */
+  private evictOne(): void {
+    const taskRowCount = this.entries.reduce((n, e) => n + (isTaskRow(e) ? 1 : 0), 0);
+    if (taskRowCount > MAX_TASK_ENTRIES) {
+      const closed = new Set<string>();
+      for (const e of this.entries) {
+        if (e.type === 'task_end' && e.taskId) closed.add(e.taskId);
+      }
+      const idx = this.entries.findIndex(
+        (e) => isTaskRow(e) && !(e.type === 'task_start' && e.taskId && !closed.has(e.taskId)),
+      );
+      if (idx >= 0) {
+        this.entries.splice(idx, 1);
+        return;
+      }
+    }
+    const idx = this.entries.findIndex((e) => !isTaskRow(e));
+    if (idx >= 0) {
+      this.entries.splice(idx, 1);
+      return;
+    }
+    // Pathological: buffer is 100% task rows — fall back to plain FIFO so the
+    // buffer stays bounded.
+    this.entries.shift();
   }
 
   getHistory(since?: number): TimelineEntry[] {
@@ -151,9 +191,13 @@ export class BridgeTimelineStore {
     for (const entry of [...this.entries, ...normalized].sort((a, b) => a.ts - b.ts)) {
       byKey.set(`${entry.ts}:${entry.type}:${entry.raw}`, entry);
     }
-    this.entries = Array.from(byKey.values())
-      .sort((a, b) => a.ts - b.ts)
-      .slice(-MAX_ENTRIES);
+    const merged = Array.from(byKey.values()).sort((a, b) => a.ts - b.ts);
+    // Trim with the same task-row protection as live eviction: task rows keep
+    // their own (deeper) retention so start/end pairs survive a reload even
+    // when chat/tool rows overflowed the generic cap.
+    const taskRows = merged.filter(isTaskRow).slice(-MAX_TASK_ENTRIES);
+    const rest = merged.filter((e) => !isTaskRow(e)).slice(-(MAX_ENTRIES - taskRows.length));
+    this.entries = [...taskRows, ...rest].sort((a, b) => a.ts - b.ts);
   }
 
   /** Node mirror of the Swift daemon's orphan reaper
@@ -205,9 +249,14 @@ export class BridgeTimelineStore {
     const matched = this.entries.filter(
       (e) => (e.sessionId === sessionId || e.sessionId === raw) && (since == null || e.ts > since),
     );
-    return matched
-      .sort((a, b) => a.ts - b.ts)
-      .slice(-limit);
+    matched.sort((a, b) => a.ts - b.ts);
+    // `limit` applies to the chat/tool stream; task hierarchy rows ride along
+    // in full so a long task's start/end pair never splits at the per-session
+    // window (a task_start older than the last `limit` rows used to vanish,
+    // leaving the Detail view an unpaired task_end).
+    const taskRows = matched.filter(isTaskRow);
+    const rest = matched.filter((e) => !isTaskRow(e)).slice(-limit);
+    return [...taskRows, ...rest].sort((a, b) => a.ts - b.ts);
   }
 
   updateEntryStatus(approvalId: string, status: 'approved' | 'denied'): void {

--- a/generated/protocol/BridgeEvent.kt
+++ b/generated/protocol/BridgeEvent.kt
@@ -388,6 +388,12 @@ data class ApmeRecommendation (
  */
 data class CodexRateLimits (
     /**
+     * ISO-8601 mtime of the rollout file this snapshot was read from. A secondary freshness
+     * anchor — the per-window `stale` flag is the authoritative signal.
+     */
+    val capturedAt: String? = null,
+
+    /**
      * Credit balance for credit-based plans (present when windows are null).
      */
     val credits: CodexCredits? = null,
@@ -441,6 +447,15 @@ data class CodexRateLimitWindow (
      * ISO-8601 reset instant (converted from the rollout's unix `resets_at`).
      */
     val resetsAt: String? = null,
+
+    /**
+     * True when this window's snapshot has expired (its `resets_at` slid into the past with no
+     * fresher Codex activity). The passive rollout read is frozen, so the percent is
+     * last-known-only — renderers should dim the gauge and show a "stale" marker instead of a
+     * misleading "now" countdown. Set centrally in `buildUsageEvent`; `resetsAt` is cleared at
+     * the same time so no formatter prints "now".
+     */
+    val stale: Boolean? = null,
 
     val usedPercent: Double,
 
@@ -672,6 +687,7 @@ enum class TimelineEntryType(val value: String) {
     ModelResponse("model_response"),
     Scheduled("scheduled"),
     TaskEnd("task_end"),
+    TaskMilestone("task_milestone"),
     TaskStart("task_start"),
     ToolExec("tool_exec"),
     ToolRequest("tool_request"),
@@ -690,6 +706,7 @@ enum class TimelineEntryType(val value: String) {
             "model_response" -> ModelResponse
             "scheduled"      -> Scheduled
             "task_end"       -> TaskEnd
+            "task_milestone" -> TaskMilestone
             "task_start"     -> TaskStart
             "tool_exec"      -> ToolExec
             "tool_request"   -> ToolRequest

--- a/generated/protocol/BridgeEvent.swift
+++ b/generated/protocol/BridgeEvent.swift
@@ -781,6 +781,9 @@ extension ADApmeRecommendation {
 /// `limitId` instead.
 // MARK: - ADCodexRateLimits
 struct ADCodexRateLimits: Codable, Equatable {
+    /// ISO-8601 mtime of the rollout file this snapshot was read from. A secondary freshness
+    /// anchor — the per-window `stale` flag is the authoritative signal.
+    var capturedAt: String?
     /// Credit balance for credit-based plans (present when windows are null).
     var credits: ADCodexCredits?
     /// Limit identifier reported by Codex (e.g. "premium" for credit-based plans).
@@ -791,6 +794,7 @@ struct ADCodexRateLimits: Codable, Equatable {
     var secondary: ADCodexRateLimitWindow?
 
     enum CodingKeys: String, CodingKey {
+        case capturedAt = "capturedAt"
         case credits = "credits"
         case limitId = "limitId"
         case planType = "planType"
@@ -818,6 +822,7 @@ extension ADCodexRateLimits {
     }
 
     func with(
+        capturedAt: String?? = nil,
         credits: ADCodexCredits?? = nil,
         limitId: String?? = nil,
         planType: String?? = nil,
@@ -825,6 +830,7 @@ extension ADCodexRateLimits {
         secondary: ADCodexRateLimitWindow?? = nil
     ) -> ADCodexRateLimits {
         return ADCodexRateLimits(
+            capturedAt: capturedAt ?? self.capturedAt,
             credits: credits ?? self.credits,
             limitId: limitId ?? self.limitId,
             planType: planType ?? self.planType,
@@ -921,12 +927,19 @@ extension ADCodexCredits {
 struct ADCodexRateLimitWindow: Codable, Equatable {
     /// ISO-8601 reset instant (converted from the rollout's unix `resets_at`).
     var resetsAt: String?
+    /// True when this window's snapshot has expired (its `resets_at` slid into the past with no
+    /// fresher Codex activity). The passive rollout read is frozen, so the percent is
+    /// last-known-only — renderers should dim the gauge and show a "stale" marker instead of a
+    /// misleading "now" countdown. Set centrally in `buildUsageEvent`; `resetsAt` is cleared at
+    /// the same time so no formatter prints "now".
+    var stale: Bool?
     var usedPercent: Double
     /// Rolling window length in minutes (primary ≈ 300 = 5h, secondary ≈ 10080 = 7d).
     var windowMinutes: Double
 
     enum CodingKeys: String, CodingKey {
         case resetsAt = "resetsAt"
+        case stale = "stale"
         case usedPercent = "usedPercent"
         case windowMinutes = "windowMinutes"
     }
@@ -952,11 +965,13 @@ extension ADCodexRateLimitWindow {
 
     func with(
         resetsAt: String?? = nil,
+        stale: Bool?? = nil,
         usedPercent: Double? = nil,
         windowMinutes: Double? = nil
     ) -> ADCodexRateLimitWindow {
         return ADCodexRateLimitWindow(
             resetsAt: resetsAt ?? self.resetsAt,
+            stale: stale ?? self.stale,
             usedPercent: usedPercent ?? self.usedPercent,
             windowMinutes: windowMinutes ?? self.windowMinutes
         )
@@ -1344,6 +1359,7 @@ enum ADTimelineEntryType: String, Codable, Equatable {
     case modelResponse = "model_response"
     case scheduled = "scheduled"
     case taskEnd = "task_end"
+    case taskMilestone = "task_milestone"
     case taskStart = "task_start"
     case toolExec = "tool_exec"
     case toolRequest = "tool_request"

--- a/generated/protocol/bridge-event-schema.json
+++ b/generated/protocol/bridge-event-schema.json
@@ -492,6 +492,10 @@
           "description": "ISO-8601 reset instant (converted from the rollout's unix `resets_at`).",
           "type": "string"
         },
+        "stale": {
+          "description": "True when this window's snapshot has expired (its `resets_at` slid into the past with no fresher Codex activity). The passive rollout read is frozen, so the percent is last-known-only — renderers should dim the gauge and show a \"stale\" marker instead of a misleading \"now\" countdown. Set centrally in `buildUsageEvent`; `resetsAt` is cleared at the same time so no formatter prints \"now\".",
+          "type": "boolean"
+        },
         "usedPercent": {
           "type": "number"
         },
@@ -510,6 +514,10 @@
       "additionalProperties": false,
       "description": "Codex usage limits parsed from local rollout files. `primary` is the short (5h-style) window, `secondary` the long (weekly) window — same idea as the Claude 5h/7d gauges. Credit-based plans report `primary`/`secondary` as null and convey usage via `credits` + `limitId` instead.",
       "properties": {
+        "capturedAt": {
+          "description": "ISO-8601 mtime of the rollout file this snapshot was read from. A secondary freshness anchor — the per-window `stale` flag is the authoritative signal.",
+          "type": "string"
+        },
         "credits": {
           "$ref": "#/definitions/CodexCredits",
           "description": "Credit balance for credit-based plans (present when windows are null)."
@@ -1338,7 +1346,8 @@
         "tool_exec",
         "eval_result",
         "task_start",
-        "task_end"
+        "task_end",
+        "task_milestone"
       ],
       "type": "string"
     },

--- a/shared/src/timeline-icons.ts
+++ b/shared/src/timeline-icons.ts
@@ -35,6 +35,8 @@ export function timelineIconKey(entry: Pick<TimelineEntry, 'type' | 'status'>): 
     case 'task_start':
     case 'task_end':
       return 'task';
+    case 'task_milestone':
+      return 'success';
     case 'chat_start':
       return 'running';
     case 'chat_end':
@@ -126,9 +128,9 @@ export const EINK_ICON_GLYPHS: Record<TimelineIconKey, string> = {
 
 /**
  * Whether a timeline entry type carries a content body worth showing in the
- * detail pane. task_start/task_end are hierarchy markers — their `raw` is the
- * task summary, no extra detail expected.
+ * detail pane. task_start/task_end/task_milestone are hierarchy markers —
+ * their `raw` is the summary, no extra detail expected.
  */
 export function entryHasDetailBody(type: TimelineEntryType): boolean {
-  return type !== 'task_start' && type !== 'task_end';
+  return type !== 'task_start' && type !== 'task_end' && type !== 'task_milestone';
 }

--- a/shared/src/timeline.ts
+++ b/shared/src/timeline.ts
@@ -10,7 +10,11 @@ export type TimelineEntryType =
   | 'eval_result'
   // Task hierarchy — emitted by APME collector when a task opens/closes.
   // A task spans one or more turns and represents an evaluable unit of work.
-  | 'task_start' | 'task_end';
+  | 'task_start' | 'task_end'
+  // Mid-task completion milestone — the agent declared its todos all done
+  // (TodoWrite-all-completed soft hint). Non-segmenting: the task stays open;
+  // this row only makes the completion visible inside long tasks.
+  | 'task_milestone';
 
 // TaskBoundarySignal is defined in eval-schema.ts (single source of truth);
 // imported below for use on TimelineEntry.boundarySignal.


### PR DESCRIPTION
## Summary

Three commits closing two work streams: daemon log hygiene (with root-cause fixes the log spam was hiding) and the five timeline task-completeness gaps confirmed in the dd43efd2 follow-up.

### fix(devices): stop iDotMatrix 60s respawn loop and squelch repeated BLE sync log cycles
- **Root cause**: `sync.py`'s bridge-gone watchdog (30s) only fed `last_bridge_ok` from the frame fetch; the display-dimmed path skips frames, so the child exited cleanly every 30s and the daemon respawned it forever at 60s cadence (4k+ identical log lines). Successful display-state fetches now feed the watchdog (parity with `sync_ble.py`).
- `createSyncCycleSquelch` (shared by iDotMatrix/Timebox managers): first two occurrences of an exit cycle log in full, identical repeats collapse into an hourly summary, any novel exit flushes and logs immediately. Cycle identity = masked output tail with `|`-segment dedupe (ring buffer captures 1–2 copies of the same retry error).
- Daemon fork logs open append-mode with 5MB rotation instead of truncating on every start — multi-day incident correlation is now possible.

### fix(trmnl): accept /api/setup/ with trailing slash on both hubs
Stock TRMNL firmware (`getDeviceCredentials`, bl.cpp) requests `{base}/api/setup/` **with** a trailing slash; both hubs matched exactly → enrollment 404'd forever, the panel never saved an api_key, retried setup every wake, and reported `Code - 404` each cycle. Node `daemon-server.ts` normalizes the path; Swift `HttpServer.route()` compares a trailing-slash-normalized path.

### feat(timeline): close the five task-completeness gaps
1. `task_milestone` rows — TodoWrite-all-completed soft hint surfaces as a non-segmenting milestone (Node collector callback + Swift ApmeCollector parity + icon/label mappings on all render surfaces; unaware clients degrade gracefully).
2. OpenCode idle-gap boundary (90s, mirrors OpenClaw) — ends the one-task-per-session collapse.
3. Task-row FIFO protection — task rows leave the 200-entry buffer only under their own 60-row cap, never while in flight; per-session history carries task rows past the 16-row window. Node + Swift store parity.
4. APME-off fallback (`fallback-task-timeline.ts`) — task rows from hook boundary signals alone when better-sqlite3 can't load.
5. Eval badge settles to "unscored" 5 minutes after task_end without a judge verdict (no more eternal "…").

## Verification
- vitest: 92 files / 1635 tests green (14 new cases: squelch 5, task retention 4, fallback 3, milestone+idle-gap 2)
- `xcodebuild AgentDeck_macOS` BUILD SUCCEEDED; Android `compileDebugKotlin` OK; `pnpm generate-protocol` regenerated
- Live-verified on the running daemon: sync.py child survives past the old 30s death cycle, Timebox not-found loop goes quiet after 2 logged cycles, TRMNL panel stopped reporting 404 on the first wake after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i3JJYJXkATyjvcKkWQSC9