### PR TITLE
Address PR #40 review: task_milestone dedup bypass + fallback counter leak

### DIFF
--- a/apple/AgentDeck/Daemon/Timeline/DaemonTimelineStore.swift
+++ b/apple/AgentDeck/Daemon/Timeline/DaemonTimelineStore.swift
@@ -112,14 +112,20 @@ actor DaemonTimelineStore {
         }
         guard let entry = Self.normalizeForStorage(entry) else { return }
 
-        // Exact dedup: same ts + type + raw within 8s.
-        // Window matches shared/src/timeline.ts deduplicateEntry — covers the
-        // PTY-fallback / Stop-hook race that can leak two identical chat_response
-        // entries when Claude Code's transcript flush lags spinner_stop by a few
-        // seconds.
-        let recentWindow = entry.ts - 8000
-        if entries.last(where: { $0.ts > recentWindow && $0.type == entry.type && $0.raw == entry.raw }) != nil {
-            return
+        // Task hierarchy rows bypass exact dedup — they're keyed by taskId, not
+        // content, so two `task_milestone` rows carrying identical raw
+        // ("Todos done") from different tasks within the 8s window must not
+        // collapse. Mirrors the bypass in shared/src/timeline.ts deduplicateEntry.
+        if !Self.isTaskRow(entry) {
+            // Exact dedup: same ts + type + raw within 8s.
+            // Window matches shared/src/timeline.ts deduplicateEntry — covers the
+            // PTY-fallback / Stop-hook race that can leak two identical chat_response
+            // entries when Claude Code's transcript flush lags spinner_stop by a few
+            // seconds.
+            let recentWindow = entry.ts - 8000
+            if entries.last(where: { $0.ts > recentWindow && $0.type == entry.type && $0.raw == entry.raw }) != nil {
+                return
+            }
         }
 
         entries.append(entry)

--- a/bridge/src/__tests__/fallback-task-timeline.test.ts
+++ b/bridge/src/__tests__/fallback-task-timeline.test.ts
@@ -52,4 +52,24 @@ describe('FallbackTaskTimeline', () => {
     expect(rows.filter((r) => r.type === 'task_end')).toHaveLength(1);
     expect(rows.find((r) => r.type === 'task_end')?.sessionId).toBe('a');
   });
+
+  it('drops the per-session counter on session_end so counts cannot grow unbounded', () => {
+    const rows: TimelineEntry[] = [];
+    const fallback = new FallbackTaskTimeline((e) => rows.push(e));
+    const counts = (fallback as unknown as { counts: Map<string, number> }).counts;
+
+    // /clear keeps the counter → next task numbers up within the session.
+    fallback.ingestHook('s1', 'UserPromptSubmit', { prompt: 'a' });
+    fallback.ingestHook('s1', 'UserPromptSubmit', { prompt: '/clear' });
+    fallback.ingestHook('s1', 'UserPromptSubmit', { prompt: 'b' });
+    expect(counts.get('s1')).toBe(2);
+
+    // session_end evicts the counter entirely.
+    fallback.ingestHook('s1', 'SessionEnd', {});
+    expect(counts.has('s1')).toBe(false);
+
+    // A brand-new session after session_end restarts at Task 1.
+    fallback.ingestHook('s2', 'UserPromptSubmit', { prompt: 'c' });
+    expect(rows.filter((r) => r.type === 'task_start').at(-1)?.raw).toBe('Task 1');
+  });
 });

--- a/bridge/src/fallback-task-timeline.ts
+++ b/bridge/src/fallback-task-timeline.ts
@@ -75,6 +75,11 @@ export class FallbackTaskTimeline {
   }
 
   private close(sessionId: string, boundarySignal: 'clear' | 'session_end'): void {
+    // `/clear` keeps the per-session counter so the next task numbers as
+    // "Task N+1"; session_end ends the session for good, so drop the counter
+    // too — otherwise `counts` grows unbounded across every session the daemon
+    // ever sees (session ids are unique, so numbering is never reused).
+    if (boundarySignal === 'session_end') this.counts.delete(sessionId);
     const task = this.active.get(sessionId);
     if (!task) return;
     this.active.delete(sessionId);

--- a/shared/src/__tests__/timeline-task-hierarchy.test.ts
+++ b/shared/src/__tests__/timeline-task-hierarchy.test.ts
@@ -48,6 +48,22 @@ describe('deduplicateEntry — task hierarchy', () => {
     expect(result.action).toBe('add');
   });
 
+  it('always adds task_milestone even with identical raw within 8s', () => {
+    // Two tasks can both declare "Todos done" (no count) seconds apart; the
+    // milestone rows are keyed by taskId, not content, so neither may collapse.
+    const existing: TimelineEntry[] = [
+      baseEntry({ type: 'task_milestone', raw: 'Todos done', taskId: 'task-a' }),
+    ];
+    const next = baseEntry({
+      ts: 1_003_000,
+      type: 'task_milestone',
+      raw: 'Todos done',
+      taskId: 'task-b',
+    });
+    const result = deduplicateEntry(next, existing);
+    expect(result.action).toBe('add');
+  });
+
   it('still dedupes ordinary chat_start within 8s', () => {
     const existing: TimelineEntry[] = [
       { ts: 1_000_000, type: 'chat_start', raw: 'hello' },

--- a/shared/src/timeline.ts
+++ b/shared/src/timeline.ts
@@ -512,8 +512,10 @@ export function deduplicateEntry(
   if (entry.detail) entry = { ...entry, detail: cleanNopMarkers(entry.detail) };
 
   // Task hierarchy entries bypass dedup — they're hierarchy markers keyed by
-  // taskId, not content. Two adjacent task_starts are legitimately distinct.
-  if (entry.type === 'task_start' || entry.type === 'task_end') {
+  // taskId, not content. Two adjacent task_starts are legitimately distinct,
+  // and two `task_milestone` rows carrying identical raw ("Todos done") but
+  // different taskIds within the 8s exact-dedup window must not collapse.
+  if (entry.type === 'task_start' || entry.type === 'task_end' || entry.type === 'task_milestone') {
     return { action: 'add', entry };
   }
 


### PR DESCRIPTION
Two minor, non-blocking follow-ups surfaced during the #40 review.

## 1. `task_milestone` now bypasses exact-dedup
`deduplicateEntry` (Node) and `DaemonTimelineStore.add` (Swift) only exempted `task_start`/`task_end` from the 8s exact-dedup by (type, raw). A `task_milestone` row carries identical `raw` (`"Todos done"`, no count) regardless of task, so two tasks each declaring their todos done within the window would collapse to one row. Task-hierarchy rows are keyed by taskId, not content — `task_milestone` now joins the bypass.

## 2. `FallbackTaskTimeline` counter no longer leaks
The per-session `counts` map (used only when APME is disabled) survived `/clear` deliberately, so the next task numbers as "Task N+1" — but it was never cleared on `session_end`, growing unbounded across every session the daemon ever saw. It's now dropped on `session_end` (kept on `/clear`); session ids are unique, so numbering is never reused.

## Verification
- vitest: 92 files / 1637 tests green (2 new cases: milestone dedup bypass, counter eviction)
- `xcodebuild AgentDeck_macOS` BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i3JJYJXkATyjvcKkWQSC9