### PR TITLE
feat(ui): unify offline/connection-state copy across all device surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -294,6 +294,7 @@ Each panel has its own pixel grid, dynamic range, and refresh rate. Designs MUST
 - **Korean**: 격식체 안 씁니다 — relaxed but precise. `~합니다` only for legal/footer. `~해요` and noun phrases everywhere else.
 - **Japanese**: です/ます 体, but trim particles for kickers.
 - **Numbers**: tabular nums in mono runs; never zero‑pad in display copy ("3 sessions", not "03").
+- **Connection-state lexicon**: daemon-link status copy is fixed per device class — SSOT + full table in [`shared/src/connection-status.ts`](shared/src/connection-status.ts). Self-connecting clients (Apple/Android apps, ESP32, TUI) name the phase they are actually in: `Searching for AgentDeck...` (compact `Searching...`) / `Connecting...` / `Reconnecting...` / `No WiFi`; retry button `Search Again`. Daemon-rendered passive displays (Stream Deck, D200H, Pixoo, Timebox, iDotMatrix, TRMNL) show only the terminal `OFFLINE` (+ `Open AgentDeck` CTA) — they never claim Connecting/Reconnecting they can't perform. Swift/Kotlin mirrors (`ConnectionLexicon`) must be updated with the TS SSOT in the same commit.
 
 ---
 

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -6,6 +6,27 @@
 
 ---
 
+## 2026-07-03 — 기기 표면 offline UI 일관성: connection-state lexicon SSOT + ESP32 재연결 라벨 수정
+
+### 문제
+데몬 링크가 끊겼을 때 표면마다 표기가 제각각: SD/D200H/Pixoo는 "OFFLINE", 앱은 "Searching for bridges..."/"Connecting..."/"Reconnecting...", Apple만 "Retry Discovery" 버튼, ESP32는 splash가 "Searching for bridges..."인데 aquarium 오버레이는 SEARCHING·RECONNECTING **둘 다 "Connecting"**(같은 기기 안 불일치 + 재연결 단계 구분 소실).
+
+### 설계 — 기기 특성별 2클래스 어휘
+- **자가연결 클라이언트**(Apple/Android 앱, ESP32, TUI): 실제 단계를 표기 — `Searching for AgentDeck...`(소형 패널 압축형 `Searching...`) / `Connecting...` / `Reconnecting...` / `No WiFi`, 재시도 버튼 `Search Again`, 빈 발견 힌트 `No AgentDeck found on this network`. 내부 용어 "bridges"는 사용자 카피에서 제거.
+- **데몬-구동 수동 표면**(SD, D200H, Pixoo, Timebox, iDotMatrix, TRMNL): 스스로 탐색 못 하므로 터미널 상태 `OFFLINE`(+`Open AgentDeck` CTA)만 — 수행할 수 없는 Connecting/Reconnecting을 주장하지 않음.
+
+### 구현
+- **SSOT**: 신규 `shared/src/connection-status.ts` — `DaemonLinkPhase` + `DAEMON_LINK_LABELS(_COMPACT)` + `PASSIVE_OFFLINE_LABEL`/`OPEN_AGENTDECK_LABEL` 등. TS 소비자(session-slot-renderer, display-tile, session-slot-button, d200h-layout, trmnl-layout, pixoo-renderer) 리터럴을 상수로 교체.
+- **ESP32**: aquarium 오버레이 SEARCHING→"Searching...", RECONNECTING→"Reconnecting..."(기존 둘 다 "Connecting"); splash 상태 "Searching for AgentDeck..."(compactStatus가 전 보드에서 "Searching..."으로 압축).
+- **Apple**: `ConnectionOverlay.swift`에 `ConnectionLexicon` 미러 enum; "Retry Discovery"→"Search Again", "No bridges found on network"→lexicon, SettingsScreen 검색 라벨 포함.
+- **Android**: `ConnectionComponents.kt`에 `ConnectionLexicon` object; MonitorScreen/EinkMonitorScreen/StatusBadge 라벨 전부 lexicon 참조.
+- **문서**: DESIGN.md §9 Voice & copy에 lexicon 규칙 추가(mirrors 동시 갱신 규칙 포함).
+
+### 검증
+vitest 92파일/1637 pass, `pnpm build` OK, `xcodebuild AgentDeck_macOS` OK, Android `compileDebugKotlin` OK, ESP32 `pio run -e ips35` OK. 코드 전역에서 "Searching for bridges"/"Retry Discovery" 리터럴 0건 확인.
+
+---
+
 ## 2026-07-02 — 타임라인 완결성 후속: 갭 5건 구현 (마일스톤 행 · OpenCode idle-gap · task 행 FIFO 보호 · APME-off fallback · unscored 종결)
 
 ### 배경

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -25,6 +25,9 @@
 ### 검증
 vitest 92파일/1637 pass, `pnpm build` OK, `xcodebuild AgentDeck_macOS` OK, Android `compileDebugKotlin` OK, ESP32 `pio run -e ips35` OK. 코드 전역에서 "Searching for bridges"/"Retry Discovery" 리터럴 0건 확인.
 
+### 후속(실기 배포 중 발견) — Android "Connecting..." 두 줄 중복 제거
+실기 APK 반영 후 CONNECTING 상태에서 "Connecting..."이 두 줄로 뜨는 게 드러남. MonitorScreen/EinkMonitorScreen 모두 상태 부제(status subtitle)가 이미 CONNECTING→"Connecting..."을 렌더하는데, 그 아래 별도 블록이 같은 문자열을 한 번 더 표시하던 **기존 중복**. lexicon 상수화로 두 줄이 정확히 같아지며 눈에 띔. 별도 CONNECTING 블록 제거(부제 한 줄만 유지). **참고**: 사용자가 함께 본 "daemon-9120 + AgentDeck-9121 두 개 발견"은 코드 버그가 아니라 **같은 머신에 데몬 2개 공존**(macOS 앱 Swift 데몬 project=daemon/v=3/9120 + CLI Node 데몬 project=AgentDeck/v=1/9121 fallback)이 각각 mDNS 광고한 것 — 한쪽 데몬 정지로 해소.
+
 ---
 
 ## 2026-07-02 — 타임라인 완결성 후속: 갭 5건 구현 (마일스톤 행 · OpenCode idle-gap · task 행 FIFO 보호 · APME-off fallback · unscored 종결)

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/common/ConnectionComponents.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/common/ConnectionComponents.kt
@@ -39,6 +39,17 @@ import dev.agentdeck.net.DiscoveredBridge
 import dev.agentdeck.ui.theme.AgentDeckColors
 import dev.agentdeck.ui.theme.LocalIsEink
 
+// ── Connection-state lexicon ──────────────────────────────────────────
+// Kotlin mirror of shared/src/connection-status.ts. Self-connecting clients
+// (this app, Apple app, ESP32) surface the phase they are actually in;
+// update the TS SSOT and all mirrors together when copy changes.
+object ConnectionLexicon {
+    const val SEARCHING = "Searching for AgentDeck..."
+    const val SEARCHING_COMPACT = "Searching..."
+    const val CONNECTING = "Connecting..."
+    const val RECONNECTING = "Reconnecting..."
+}
+
 // ── Status Badge ──────────────────────────────────────────────────────
 
 @Composable
@@ -52,8 +63,8 @@ fun ConnectionStatusBadge(
         Text(
             text = when (connectionStatus) {
                 ConnectionStatus.CONNECTED -> "\u25CF Connected"
-                ConnectionStatus.CONNECTING -> "\u25CB Connecting..."
-                ConnectionStatus.DISCONNECTED -> "\u25CB Searching..."
+                ConnectionStatus.CONNECTING -> "\u25CB ${ConnectionLexicon.CONNECTING}"
+                ConnectionStatus.DISCONNECTED -> "\u25CB ${ConnectionLexicon.SEARCHING_COMPACT}"
             },
             style = MaterialTheme.typography.bodyMedium,
             color = if (isEink) {
@@ -220,7 +231,7 @@ fun DiscoveredBridgeList(
             }
         } else {
             Text(
-                text = "Searching for bridges...",
+                text = ConnectionLexicon.SEARCHING,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -401,14 +401,6 @@ private fun ConnectionOverlay(
                 )
             }
 
-            if (connectionStatus == ConnectionStatus.CONNECTING && !isReconnecting) {
-                Text(
-                    text = ConnectionLexicon.CONNECTING,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = AgentDeckColors.Amber,
-                )
-            }
-
             // Show connection options when not actively connecting (or when reconnecting with alternatives)
             if (connectionStatus == ConnectionStatus.DISCONNECTED || isReconnecting) {
                 Spacer(modifier = Modifier.height(4.dp))

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -1,6 +1,7 @@
 package dev.agentdeck.ui.monitor
 
 import android.content.res.Configuration
+import dev.agentdeck.ui.common.ConnectionLexicon
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -366,9 +367,9 @@ private fun ConnectionOverlay(
 
             Text(
                 text = when {
-                    isReconnecting -> "Reconnecting..."
-                    connectionStatus == ConnectionStatus.DISCONNECTED -> "Searching for bridges..."
-                    connectionStatus == ConnectionStatus.CONNECTING -> "Connecting..."
+                    isReconnecting -> ConnectionLexicon.RECONNECTING
+                    connectionStatus == ConnectionStatus.DISCONNECTED -> ConnectionLexicon.SEARCHING
+                    connectionStatus == ConnectionStatus.CONNECTING -> ConnectionLexicon.CONNECTING
                     else -> "Connected"
                 },
                 style = MaterialTheme.typography.bodyMedium,
@@ -402,7 +403,7 @@ private fun ConnectionOverlay(
 
             if (connectionStatus == ConnectionStatus.CONNECTING && !isReconnecting) {
                 Text(
-                    text = "Connecting...",
+                    text = ConnectionLexicon.CONNECTING,
                     style = MaterialTheme.typography.bodyMedium,
                     color = AgentDeckColors.Amber,
                 )
@@ -437,7 +438,7 @@ private fun ConnectionOverlay(
                     }
                 } else if (!isReconnecting) {
                     Text(
-                        text = "Searching for bridges...",
+                        text = ConnectionLexicon.SEARCHING,
                         style = MaterialTheme.typography.bodySmall,
                         color = AgentDeckColors.SlateText,
                     )

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
@@ -760,14 +760,6 @@ private fun EinkNotConnectedScreen(
             Spacer(modifier = Modifier.height(16.dp))
         }
 
-        if (connectionStatus == ConnectionStatus.CONNECTING) {
-            Text(
-                text = ConnectionLexicon.CONNECTING,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
         if (connectionStatus == ConnectionStatus.DISCONNECTED) {
             // USB (adb reverse) quick connect
             Surface(

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
@@ -1,6 +1,7 @@
 package dev.agentdeck.ui.screen
 
 import android.content.res.Configuration
+import dev.agentdeck.ui.common.ConnectionLexicon
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -739,8 +740,8 @@ private fun EinkNotConnectedScreen(
 
         Text(
             text = when (connectionStatus) {
-                ConnectionStatus.DISCONNECTED -> "Searching for bridges..."
-                ConnectionStatus.CONNECTING -> "Connecting..."
+                ConnectionStatus.DISCONNECTED -> ConnectionLexicon.SEARCHING
+                ConnectionStatus.CONNECTING -> ConnectionLexicon.CONNECTING
                 ConnectionStatus.CONNECTED -> "Connected"
             },
             style = MaterialTheme.typography.bodyMedium,
@@ -761,7 +762,7 @@ private fun EinkNotConnectedScreen(
 
         if (connectionStatus == ConnectionStatus.CONNECTING) {
             Text(
-                text = "Connecting...",
+                text = ConnectionLexicon.CONNECTING,
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -827,7 +828,7 @@ private fun EinkNotConnectedScreen(
                 }
             } else {
                 Text(
-                    text = "Searching for bridges...",
+                    text = ConnectionLexicon.SEARCHING,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -881,7 +882,7 @@ private fun EinkReconnectingScreen(
         Spacer(modifier = Modifier.height(4.dp))
 
         Text(
-            text = "Reconnecting...",
+            text = ConnectionLexicon.RECONNECTING,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/apple/AgentDeck/UI/Monitor/ConnectionOverlay.swift
+++ b/apple/AgentDeck/UI/Monitor/ConnectionOverlay.swift
@@ -2,6 +2,17 @@
 
 import SwiftUI
 
+/// Connection-state lexicon — Swift mirror of shared/src/connection-status.ts.
+/// Self-connecting clients (this app, Android, ESP32) surface the phase they
+/// are actually in; update the TS SSOT and all mirrors together when copy changes.
+enum ConnectionLexicon {
+    static let searching = "Searching for AgentDeck..."
+    static let connecting = "Connecting..."
+    static let reconnecting = "Reconnecting..."
+    static let searchAgain = "Search Again"
+    static let nothingDiscovered = "No AgentDeck found on this network"
+}
+
 struct ConnectionOverlay: View {
     @EnvironmentObject private var stateHolder: AgentStateHolder
     @State private var manualUrl = ""
@@ -83,7 +94,7 @@ struct ConnectionOverlay: View {
                                 Button {
                                     stateHolder.startConnectionWaterfall()
                                 } label: {
-                                    Text("Retry Discovery")
+                                    Text(ConnectionLexicon.searchAgain)
                                         .font(.subheadline.bold())
                                         .foregroundStyle(.white)
                                         .frame(maxWidth: .infinity)
@@ -124,7 +135,7 @@ struct ConnectionOverlay: View {
                             // Hint after 10 seconds of no results
                             if searchingElapsed >= 10 {
                                 VStack(spacing: 4) {
-                                    Text("No bridges found on network")
+                                    Text(ConnectionLexicon.nothingDiscovered)
                                         .font(.caption)
                                         .foregroundStyle(slateText)
                                     Text("Enter URL manually or check local network permission.")
@@ -240,11 +251,11 @@ struct ConnectionOverlay: View {
 
     private var statusText: String {
         if isReconnecting {
-            return "Reconnecting..."
+            return ConnectionLexicon.reconnecting
         } else if stateHolder.isAutoConnecting || stateHolder.connection.status == .connecting {
-            return "Connecting..."
+            return ConnectionLexicon.connecting
         } else {
-            return "Searching for bridges..."
+            return ConnectionLexicon.searching
         }
     }
 

--- a/apple/AgentDeck/UI/Settings/SettingsScreen.swift
+++ b/apple/AgentDeck/UI/Settings/SettingsScreen.swift
@@ -699,7 +699,7 @@ struct SettingsScreen: View {
             }
 
             if stateHolder.discovery.bridges.isEmpty {
-                Text("Searching for bridges...")
+                Text(ConnectionLexicon.searching)
                     .font(.system(size: 11))
                     .foregroundStyle(TerrariumHUD.subtext)
             } else {

--- a/bridge/src/pixoo/pixoo-renderer.ts
+++ b/bridge/src/pixoo/pixoo-renderer.ts
@@ -19,6 +19,7 @@
  */
 
 import { State } from '../types.js';
+import { PASSIVE_OFFLINE_LABEL } from '@agentdeck/shared';
 import type { StateUpdateEvent, UsageEvent } from '../types.js';
 import type { SessionInfo } from '@agentdeck/shared/protocol';
 import { hasOpenClawSession } from '@agentdeck/shared';
@@ -1006,7 +1007,7 @@ export function renderFrame(
 /** Render a static black frame with centered grey "OFFLINE" text. */
 export function renderDisconnectedFrame(): Uint8Array {
   const buf = new Uint8Array(64 * 64 * 3); // black
-  drawTextCentered(buf, 29, 'OFFLINE', '#555555');
+  drawTextCentered(buf, 29, PASSIVE_OFFLINE_LABEL, '#555555');
   return buf;
 }
 

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -213,7 +213,7 @@ static void uiTask(void* param) {
     // Create screens
     scrSplash = Screens::splashCreate();
     lv_screen_load(scrSplash);
-    Screens::splashSetStatus("Searching for bridges...");
+    Screens::splashSetStatus("Searching for AgentDeck...");
 
     scrAquarium = Screens::aquariumCreate();
     Screens::permissionCreate(scrAquarium);
@@ -383,7 +383,7 @@ static void uiTask(void* param) {
                 if (!Net::wifiConnected() && !Net::serialConnected()) {
                     Screens::splashSetStatus("No WiFi");
                 } else {
-                    Screens::splashSetStatus("Searching for bridges...");
+                    Screens::splashSetStatus("Searching for AgentDeck...");
                 }
             }
         }

--- a/esp32/src/ui/screens/aquarium.cpp
+++ b/esp32/src/ui/screens/aquarium.cpp
@@ -262,11 +262,14 @@ void aquariumSetConnectionStatus(ConnOverlayStatus status) {
         case ConnOverlayStatus::NO_WIFI:
             lv_label_set_text(connStatusLabel, "No WiFi");
             break;
+        // Labels follow the connection-state lexicon (shared/src/connection-status.ts):
+        // never-connected discovery reads "Searching...", a lost link reads
+        // "Reconnecting..." — the two phases must stay distinguishable.
         case ConnOverlayStatus::SEARCHING:
-            lv_label_set_text(connStatusLabel, "Connecting");
+            lv_label_set_text(connStatusLabel, "Searching...");
             break;
         case ConnOverlayStatus::RECONNECTING:
-            lv_label_set_text(connStatusLabel, "Connecting");
+            lv_label_set_text(connStatusLabel, "Reconnecting...");
             break;
         default:
             break;

--- a/esp32/src/ui/screens/splash.cpp
+++ b/esp32/src/ui/screens/splash.cpp
@@ -11,9 +11,11 @@ static lv_obj_t* lblStatus = nullptr;
 static lv_obj_t* lblWifiStatus = nullptr;
 
 static const char* compactStatus(const char* text) {
-    if (!text) return "Connecting";
+    if (!text) return "Searching...";
     if (strstr(text, "No WiFi")) return "No WiFi";
-    return "Connecting";
+    // Small panels compact "Searching for AgentDeck..." to the lexicon's
+    // short form (shared/src/connection-status.ts).
+    return "Searching...";
 }
 
 static void set_logo_opa_cb(void* var, int32_t val) {
@@ -63,7 +65,7 @@ lv_obj_t* splashCreate() {
     lblStatus = lv_label_create(screen);
     lv_obj_set_style_text_color(lblStatus, lv_color_hex(Theme::HUDDim), 0);
     lv_obj_set_style_text_font(lblStatus, &lv_font_montserrat_16, 0);
-    lv_label_set_text(lblStatus, "Connecting");
+    lv_label_set_text(lblStatus, "Searching...");
 #if defined(BOARD_TTGO) || defined(BOARD_ESP32_C6_147)
     lv_obj_align(lblStatus, LV_ALIGN_CENTER, 0, 18);
 #else

--- a/plugin/src/actions/session-slot-button.ts
+++ b/plugin/src/actions/session-slot-button.ts
@@ -12,7 +12,7 @@ import streamDeck, {
   WillAppearEvent,
   WillDisappearEvent,
 } from '@elgato/streamdeck';
-import { State } from '@agentdeck/shared';
+import { State, PASSIVE_OFFLINE_LABEL, OPEN_AGENTDECK_LABEL } from '@agentdeck/shared';
 import type { SessionInfo, PromptOption, CodexRateLimits } from '@agentdeck/shared';
 import { SessionSlotManager, type DeckLayout, type SessionSlotConfig } from '../session-slot-manager.js';
 import { computeCenterCluster } from '../center-slot.js';
@@ -220,8 +220,8 @@ function getDisconnectedSlotConfig(slot: number, layout: DeckLayout): Disconnect
   const row = Math.floor(slot / cols);
   return {
     kind: 'open-app',
-    label: 'OFFLINE',
-    subtitle: 'Open AgentDeck',
+    label: PASSIVE_OFFLINE_LABEL,
+    subtitle: OPEN_AGENTDECK_LABEL,
     col,
     row,
     cols,

--- a/plugin/src/renderers/display-tile.ts
+++ b/plugin/src/renderers/display-tile.ts
@@ -19,7 +19,7 @@
  * shared) because the shared renderers are owned elsewhere.
  */
 import type { AgentType, SessionInfo, StatusCardTone, State } from '@agentdeck/shared';
-import { stateColor, formatModelEffort, escSvgText } from '@agentdeck/shared';
+import { stateColor, formatModelEffort, escSvgText, PASSIVE_OFFLINE_LABEL } from '@agentdeck/shared';
 
 const SIZE = 144;
 const FONT = 'Inter, -apple-system, system-ui, Helvetica Neue, sans-serif';
@@ -165,7 +165,7 @@ export function renderSessionReadout(
 }
 
 function stateLabelFor(state: string | undefined, agent: AgentType): string {
-  if (!state) return 'OFFLINE';
+  if (!state) return PASSIVE_OFFLINE_LABEL;
   if (agent === 'openclaw') {
     if (state === 'idle') return 'STANDBY';
     if (state === 'processing') return 'ROUTING';

--- a/shared/src/connection-status.ts
+++ b/shared/src/connection-status.ts
@@ -1,0 +1,65 @@
+/**
+ * Connection-state lexicon — canonical user-facing copy for every surface's
+ * daemon-link status. SSOT for the words; per-platform mirrors must match.
+ *
+ * Two device classes, two vocabularies:
+ *
+ * 1. Self-connecting clients (Apple app, Android app, ESP32 WiFi panels, TUI)
+ *    own their link to the daemon: they discover via mDNS, connect, and
+ *    auto-reconnect. They surface the *phase* they are actually in:
+ *      - SEARCHING     "Searching for AgentDeck..."  (mDNS discovery, no target yet)
+ *      - CONNECTING    "Connecting..."               (attempt to a known address)
+ *      - RECONNECTING  "Reconnecting..."             (established link lost, auto-retry)
+ *      - NO_NETWORK    "No WiFi"                     (ESP32 only — no link layer at all)
+ *    Retry affordance (button): "Search Again". Empty-discovery hint:
+ *    "No AgentDeck found on this network".
+ *
+ * 2. Daemon-rendered passive displays (Stream Deck keys/encoders, D200H,
+ *    Pixoo, Timebox, iDotMatrix, TRMNL) are painted BY the daemon/plugin and
+ *    cannot search on their own. When the link is down they show a single
+ *    terminal state: "OFFLINE" (optionally with the "Open AgentDeck"
+ *    call-to-action subtitle). They never claim Connecting/Reconnecting.
+ *
+ * Mirrors (update together — grep the literal when changing copy):
+ *  - Swift:  apple/AgentDeck/UI/Monitor/ConnectionOverlay.swift (ConnectionLexicon)
+ *  - Kotlin: android/.../ui/common/ConnectionComponents.kt (ConnectionLexicon)
+ *  - C++:    esp32/src/ui/screens/aquarium.cpp + splash.cpp + main.cpp
+ */
+
+/** Daemon-link phase of a self-connecting client surface. */
+export type DaemonLinkPhase =
+  | 'searching'
+  | 'connecting'
+  | 'reconnecting'
+  | 'no_network'
+  | 'connected';
+
+/** Canonical labels for self-connecting clients (device class 1). */
+export const DAEMON_LINK_LABELS: Record<DaemonLinkPhase, string> = {
+  searching: 'Searching for AgentDeck...',
+  connecting: 'Connecting...',
+  reconnecting: 'Reconnecting...',
+  no_network: 'No WiFi',
+  connected: 'Connected',
+};
+
+/** Compact variants for small panels (ESP32 overlays, tiny widgets). */
+export const DAEMON_LINK_LABELS_COMPACT: Record<DaemonLinkPhase, string> = {
+  searching: 'Searching...',
+  connecting: 'Connecting...',
+  reconnecting: 'Reconnecting...',
+  no_network: 'No WiFi',
+  connected: 'Connected',
+};
+
+/** Retry affordance (button label) after discovery/connect failure. */
+export const SEARCH_AGAIN_LABEL = 'Search Again';
+
+/** Hint when mDNS discovery has run for a while with zero results. */
+export const NOTHING_DISCOVERED_HINT = 'No AgentDeck found on this network';
+
+/** Terminal label for daemon-rendered passive displays (device class 2). */
+export const PASSIVE_OFFLINE_LABEL = 'OFFLINE';
+
+/** Call-to-action subtitle paired with the passive OFFLINE card. */
+export const OPEN_AGENTDECK_LABEL = 'Open AgentDeck';

--- a/shared/src/d200h-layout.ts
+++ b/shared/src/d200h-layout.ts
@@ -25,6 +25,7 @@ import {
 import { State, type PromptOption } from './states.js';
 import type { SessionInfo, SubscriptionInfo, CodexRateLimits } from './protocol.js';
 import { Brand } from './design-tokens.js';
+import { PASSIVE_OFFLINE_LABEL, OPEN_AGENTDECK_LABEL } from './connection-status.js';
 import { CLAUDE_LOGO_PATH, CODEX_LOGO_PATH } from './svg-renderers/agent-logos.js';
 
 /** Command dispatched when a key is pressed. `null` = inert tile (info/empty). */
@@ -389,8 +390,8 @@ function renderOfflineSlot(hero = false): string {
   if (hero) {
     const colors = { bg: '#07170f', text: '#dcfce7', sub: '#86efac' };
     const elements = [
-      `<text x="72" y="54" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="${colors.text}">OFFLINE</text>`,
-      `<text x="72" y="82" text-anchor="middle" font-family="Arial,sans-serif" font-size="11" fill="${colors.sub}">Open AgentDeck</text>`,
+      `<text x="72" y="54" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="${colors.text}">${PASSIVE_OFFLINE_LABEL}</text>`,
+      `<text x="72" y="82" text-anchor="middle" font-family="Arial,sans-serif" font-size="11" fill="${colors.sub}">${OPEN_AGENTDECK_LABEL}</text>`,
     ].join('');
     return svgFrame(colors.bg, elements);
   }
@@ -628,7 +629,7 @@ export function buildSessionDeck(stateEvt: any, view: DeckView, positions: strin
   if ((state.state === 'DISCONNECTED' || state.state === 'disconnected') && state.allSessions.length === 0) {
     const hero = Math.floor(slots.length / 2);
     slots.forEach((pos, i) => out.set(pos, {
-      svg: i === hero ? renderInfoSlot('OFFLINE', 'Open AgentDeck', 'activity', 'info', 'npx @agentdeck/setup') : renderEmptySlot(),
+      svg: i === hero ? renderInfoSlot(PASSIVE_OFFLINE_LABEL, OPEN_AGENTDECK_LABEL, 'activity', 'info', 'npx @agentdeck/setup') : renderEmptySlot(),
       action: { kind: 'launch' },
     }));
     return out;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -12,6 +12,7 @@ export * from './format-utils.js';
 export * from './timeline-summarizer.js';
 export * from './session-utils.js';
 export * from './state-colors.js';
+export * from './connection-status.js';
 export * from './design-tokens.js';
 export * from './svg-renderers/index.js';
 export * from './d200h-layout.js';

--- a/shared/src/svg-renderers/session-slot-renderer.ts
+++ b/shared/src/svg-renderers/session-slot-renderer.ts
@@ -9,6 +9,7 @@ import type { SessionInfo } from '../protocol.js';
 import type { PromptOption } from '../states.js';
 import { State } from '../states.js';
 import { stateColor } from '../state-colors.js';
+import { PASSIVE_OFFLINE_LABEL, OPEN_AGENTDECK_LABEL } from '../connection-status.js';
 import { agentLogoIcon } from './agent-logos.js';
 import { wrapTextByWidth, escSvgText } from './text-utils.js';
 
@@ -104,7 +105,7 @@ export function aliasModelName(name: string): string {
 }
 
 function stateLabel(state?: string, agentType?: AgentType): string {
-  if (!state) return 'OFFLINE';
+  if (!state) return PASSIVE_OFFLINE_LABEL;
   if (agentType === 'openclaw') {
     if (state === 'idle') return 'STANDBY';
     if (state === 'processing') return 'ROUTING';
@@ -384,14 +385,14 @@ export function renderDisconnectedSlot(config: DisconnectedSlotConfig): string {
       config.row,
       config.cols,
       config.rows,
-      config.label ?? 'OFFLINE',
-      config.subtitle ?? 'Open AgentDeck'
+      config.label ?? PASSIVE_OFFLINE_LABEL,
+      config.subtitle ?? OPEN_AGENTDECK_LABEL
     );
   }
   if (config.quadrant) {
-    return renderOpenAppQuadrant(config.quadrant, config.label ?? 'OFFLINE', config.subtitle ?? 'Open AgentDeck');
+    return renderOpenAppQuadrant(config.quadrant, config.label ?? PASSIVE_OFFLINE_LABEL, config.subtitle ?? OPEN_AGENTDECK_LABEL);
   }
-  return renderStatusCard({ icon: 'open-app', label: config.label ?? 'OFFLINE', subtitle: config.subtitle ?? 'Open AgentDeck', detail: config.detail, tone: 'action' });
+  return renderStatusCard({ icon: 'open-app', label: config.label ?? PASSIVE_OFFLINE_LABEL, subtitle: config.subtitle ?? OPEN_AGENTDECK_LABEL, detail: config.detail, tone: 'action' });
 }
 
 /**
@@ -401,7 +402,7 @@ export function renderDisconnectedSlot(config: DisconnectedSlotConfig): string {
  * cluster reads as one card visually, with the inner panel + glyph + text
  * spanning all four keys while each key keeps its own outer rounded bezel.
  */
-export function renderOpenAppQuadrant(quadrant: ClusterQuadrant, label = 'OFFLINE', subtitle = 'Open AgentDeck'): string {
+export function renderOpenAppQuadrant(quadrant: ClusterQuadrant, label = PASSIVE_OFFLINE_LABEL, subtitle = OPEN_AGENTDECK_LABEL): string {
   const colors = toneColors('action');
   const fontFam = 'Inter, -apple-system, system-ui, Helvetica Neue, sans-serif';
   const offsetX = (quadrant === 'tr' || quadrant === 'br') ? -SIZE : 0;
@@ -530,8 +531,8 @@ export function renderOpenAppGrid(
   row: number,
   cols: number,
   rows: number,
-  label = 'OFFLINE',
-  subtitle = 'Open AgentDeck',
+  label = PASSIVE_OFFLINE_LABEL,
+  subtitle = OPEN_AGENTDECK_LABEL,
 ): string {
   const colors = toneColors('action');
   const fontFam = 'Inter, -apple-system, system-ui, Helvetica Neue, sans-serif';

--- a/shared/src/trmnl-layout.ts
+++ b/shared/src/trmnl-layout.ts
@@ -15,6 +15,7 @@
  * CJK-aware truncation.
  */
 import { parseState, type DashState } from './d200h-layout.js';
+import { PASSIVE_OFFLINE_LABEL } from './connection-status.js';
 import { measureTextWidth, sliceByPx, escSvgText } from './svg-renderers/text-utils.js';
 import { agentGlyphMono } from './svg-renderers/agent-logos.js';
 import type { SessionInfo, SubscriptionInfo } from './protocol.js';
@@ -59,7 +60,7 @@ function statusLabel(state?: string): string {
   const s = (state ?? '').toLowerCase();
   if (s.startsWith('awaiting')) return 'AWAITING';
   if (s === 'processing') return 'WORKING';
-  if (s === 'disconnected') return 'OFFLINE';
+  if (s === 'disconnected') return PASSIVE_OFFLINE_LABEL;
   if (s === 'idle') return 'IDLE';
   if (!s) return 'IDLE';
   return s.toUpperCase().slice(0, 9);


### PR DESCRIPTION
## What

Daemon-link status read differently on every surface — `OFFLINE` vs `Connecting` vs `Reconnecting` vs Apple's `Retry Discovery` button — and ESP32 showed **both** first-search and lost-link as `Connecting`, losing the phase distinction.

Introduces a **connection-state lexicon SSOT** (`shared/src/connection-status.ts`) with two device classes:

- **Self-connecting clients** (Apple/Android apps, ESP32, TUI) name the phase they're actually in: `Searching for AgentDeck...` (compact `Searching...`) / `Connecting...` / `Reconnecting...` / `No WiFi`; retry button `Search Again`; empty-discovery hint `No AgentDeck found on this network`. Internal term "bridges" removed from user copy.
- **Daemon-rendered passive displays** (Stream Deck, D200H, Pixoo, Timebox, iDotMatrix, TRMNL) show only the terminal `OFFLINE` (+ `Open AgentDeck` CTA) — they never claim a Connecting/Reconnecting they can't perform.

## Changes

- SSOT + TS consumers wired (session-slot-renderer, display-tile, session-slot-button, d200h-layout, trmnl-layout, pixoo-renderer)
- **ESP32 bugfix**: aquarium overlay `SEARCHING`→`Searching...`, `RECONNECTING`→`Reconnecting...` (were both `Connecting`); splash wording
- Apple `ConnectionLexicon` mirror enum; Android `ConnectionLexicon` object
- DESIGN.md §9 lexicon rule (mirrors-update-together)

## Verification

vitest 1637/1637, `pnpm build`, `xcodebuild AgentDeck_macOS`, Android `compileDebugKotlin`+`assembleRelease`, ESP32 `ttgo`/`box_86`/`ips10` builds — all green. Deployed to attached hardware (SD plugin, 3 ESP32 LVGL boards, 3 Android devices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)