### PR TITLE
fix(codex): Windows support for Codex hooks (PowerShell lifecycle hooks + working notify fallback)

### DIFF
--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -179,6 +179,7 @@ program
         const result = installCodexHooksIfNeeded();
         if (result.installed) {
           log('Codex lifecycle hooks ready in ~/.codex/config.toml');
+          if (result.warning) log(`Codex hooks degraded: ${result.warning}`);
         } else if (result.reason) {
           log(`Codex hooks skipped: ${result.reason}`);
         }
@@ -424,6 +425,7 @@ daemon
         const result = installCodexHooksIfNeeded();
         if (result.installed) {
           log('Codex lifecycle hooks installed in ~/.codex/config.toml');
+          if (result.warning) log(`Codex hooks degraded: ${result.warning}`);
         } else if (result.reason) {
           log(`Codex hooks skipped: ${result.reason}`);
         }

--- a/hooks/src/__tests__/codex-install.test.ts
+++ b/hooks/src/__tests__/codex-install.test.ts
@@ -209,6 +209,7 @@ describe('codex-install: managedBlockBody', () => {
       includeNotify: true,
       includeOtel: true,
       otelEndpoint: 'http://127.0.0.1:9120/otel/v1/traces',
+      platform: 'linux',
     });
     const withFence = applyManagedBlock(original, body);
     const stripped = removeManagedBlock(withFence);
@@ -220,6 +221,7 @@ describe('codex-install: managedBlockBody', () => {
       includeNotify: true,
       includeOtel: true,
       otelEndpoint: 'http://127.0.0.1:9120/otel/v1/traces',
+      platform: 'linux',
     });
     const withFence = applyManagedBlock('', body);
     expect(withFence).toContain('[features]');
@@ -239,6 +241,36 @@ describe('codex-install: managedBlockBody', () => {
     expect(withFence).toContain('protocol = "json"');
     // Dummy 4th element so the JSON payload Codex appends lands at $1.
     expect(withFence).toContain('"agentdeck-notify"');
+  });
+
+  it('uses PowerShell command hooks on Windows', () => {
+    const body = managedBlockBody({
+      includeNotify: true,
+      includeOtel: true,
+      otelEndpoint: 'http://127.0.0.1:9120/otel/v1/traces',
+      platform: 'win32',
+    });
+    const withFence = applyManagedBlock('', body);
+    expect(withFence).toContain('command = "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ');
+    expect(withFence).toContain('notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command"');
+
+    const decodedLifecycleCommands = [...withFence.matchAll(/-EncodedCommand ([A-Za-z0-9+/=]+)"/g)]
+      .map((match) => Buffer.from(match[1], 'base64').toString('utf16le'));
+    expect(decodedLifecycleCommands).toHaveLength(5);
+    const decoded = decodedLifecycleCommands.join('\n');
+    expect(decoded).toContain('/hooks/codex_user_prompt_submit');
+    expect(decoded).toContain('/hooks/codex_tool_start');
+    expect(decoded).toContain('/hooks/codex_tool_end');
+    expect(decoded).toContain('/hooks/codex_stop');
+    expect(decoded).toContain("$ProgressPreference = 'SilentlyContinue'");
+    expect(decoded).toContain('exit 0');
+
+    for (const line of withFence.split('\n').filter((value) => value.startsWith('command = '))) {
+      expect(line).not.toContain('$ErrorActionPreference');
+      expect(line).not.toContain('$port');
+    }
+    expect(withFence).not.toContain('command = "sh -c');
+    expect(withFence).not.toContain('notify = ["sh"');
   });
 
   it('omits conflicting optional channels when asked', () => {
@@ -272,7 +304,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
   });
 
   it('creates config with fence when file is absent', () => {
-    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'linux' });
     expect(result.installed).toBe(true);
     const text = readFileSync(configPath, 'utf-8');
     expect(text).toContain(OPEN_FENCE);
@@ -326,6 +358,15 @@ describe('codex-install: install / uninstall (file I/O)', () => {
     const managed = text.split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
     expect(managed).not.toContain('[otel.trace_exporter.otlp-http]');
     expect(managed).toContain('hooks = true');
+  });
+
+  it('omits OTel by default on Windows installs', () => {
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32' });
+    const text = readFileSync(configPath, 'utf-8');
+    const managed = text.split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
+    expect(managed).toContain('hooks = true');
+    expect(managed).toContain('powershell.exe');
+    expect(managed).not.toContain('[otel.trace_exporter.otlp-http]');
   });
 
   it('uninstall strips fence and preserves user content', () => {

--- a/hooks/src/__tests__/codex-install.test.ts
+++ b/hooks/src/__tests__/codex-install.test.ts
@@ -15,6 +15,7 @@ import {
   managedBlockBody,
   installCodexHooksIfNeeded,
   uninstallCodexHooks,
+  windowsNotifyScriptContent,
 } from '../codex-install.js';
 
 // ─── codex-mini-toml ────────────────────────────────────────────────────
@@ -249,10 +250,15 @@ describe('codex-install: managedBlockBody', () => {
       includeOtel: true,
       otelEndpoint: 'http://127.0.0.1:9120/otel/v1/traces',
       platform: 'win32',
+      notifyScriptPath: 'C:\\Users\\me\\.agentdeck\\codex-notify.ps1',
     });
     const withFence = applyManagedBlock('', body);
     expect(withFence).toContain('command = "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ');
-    expect(withFence).toContain('notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command"');
+    // notify must exec the sidecar via -File: Codex appends the JSON
+    // payload as trailing argv, which -Command cannot bind into $args.
+    expect(withFence).toContain('notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "C:\\\\Users\\\\me\\\\.agentdeck\\\\codex-notify.ps1"]');
+    expect(withFence).not.toContain('"-Command"');
+    expect(withFence).not.toContain('"agentdeck-notify"');
 
     const decodedLifecycleCommands = [...withFence.matchAll(/-EncodedCommand ([A-Za-z0-9+/=]+)"/g)]
       .map((match) => Buffer.from(match[1], 'base64').toString('utf16le'));
@@ -264,6 +270,10 @@ describe('codex-install: managedBlockBody', () => {
     expect(decoded).toContain('/hooks/codex_stop');
     expect(decoded).toContain("$ProgressPreference = 'SilentlyContinue'");
     expect(decoded).toContain('exit 0');
+    // Stdin must be read as UTF-8 ([Console]::In decodes with the OEM
+    // codepage) and posted as UTF-8 bytes (string bodies get ISO-8859-1).
+    expect(decoded).toContain('StreamReader([Console]::OpenStandardInput(), [System.Text.Encoding]::UTF8)');
+    expect(decoded).toContain('[System.Text.Encoding]::UTF8.GetBytes');
 
     for (const line of withFence.split('\n').filter((value) => value.startsWith('command = '))) {
       expect(line).not.toContain('$ErrorActionPreference');
@@ -271,6 +281,21 @@ describe('codex-install: managedBlockBody', () => {
     }
     expect(withFence).not.toContain('command = "sh -c');
     expect(withFence).not.toContain('notify = ["sh"');
+  });
+
+  it('windows notify sidecar reads payload from $args and posts codex_turn_complete', () => {
+    const script = windowsNotifyScriptContent();
+    expect(script).toContain('$args[$args.Count - 1]');
+    expect(script).toContain('/hooks/codex_turn_complete');
+    expect(script).toContain('$env:AGENTDECK_PORT');
+    expect(script).toContain("$port = '9120'");
+    expect(script).toContain('exit 0');
+    // String bodies get ISO-8859-1-encoded by Invoke-RestMethod, mangling
+    // non-ASCII payload text — the script must post UTF-8 bytes.
+    expect(script).toContain('[System.Text.Encoding]::UTF8.GetBytes');
+    // PowerShell 5.1 reads BOM-less scripts as ANSI — keep content ASCII
+    // so both interpretations are byte-identical.
+    expect(/^[\x00-\x7F]*$/.test(script)).toBe(true);
   });
 
   it('omits conflicting optional channels when asked', () => {
@@ -291,10 +316,15 @@ describe('codex-install: managedBlockBody', () => {
 describe('codex-install: install / uninstall (file I/O)', () => {
   let tmp: string;
   let configPath: string;
+  // Every install/uninstall call must pass this override: the suite may
+  // run with a win32 default platform, where the sidecar would otherwise
+  // be written to (or deleted from) the real ~/.agentdeck.
+  let notifyScriptPath: string;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'codex-install-test-'));
     configPath = join(tmp, 'config.toml');
+    notifyScriptPath = join(tmp, 'codex-notify.ps1');
     delete process.env.AGENTDECK_NO_CODEX_HOOKS;
   });
 
@@ -315,7 +345,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
   it('preserves user content when installing into existing config', () => {
     const userText = `model = "gpt-5"\n[profiles.work]\nprovider = "openai"\n`;
     writeFileSync(configPath, userText, 'utf-8');
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const text = readFileSync(configPath, 'utf-8');
     expect(text).toContain('model = "gpt-5"');
     expect(text).toContain('[profiles.work]');
@@ -325,21 +355,21 @@ describe('codex-install: install / uninstall (file I/O)', () => {
 
   it('skips when user already has [features] table outside fence', () => {
     writeFileSync(configPath, `[features]\nhooks = true\n`, 'utf-8');
-    const result = installCodexHooksIfNeeded({ configPath });
+    const result = installCodexHooksIfNeeded({ configPath, notifyScriptPath });
     expect(result.installed).toBe(false);
     expect(result.reason).toContain('[features]');
   });
 
   it('skips when user already has [hooks] table outside fence', () => {
     writeFileSync(configPath, `[[hooks.Stop]]\nmatcher = ""\n`, 'utf-8');
-    const result = installCodexHooksIfNeeded({ configPath });
+    const result = installCodexHooksIfNeeded({ configPath, notifyScriptPath });
     expect(result.installed).toBe(false);
     expect(result.reason).toContain('[hooks]');
   });
 
   it('omits notify when user has top-level notify', () => {
     writeFileSync(configPath, `notify = ["python3", "/x.py"]\nmodel = "gpt-5"\n`, 'utf-8');
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const text = readFileSync(configPath, 'utf-8');
     // User notify preserved
     expect(text).toContain('"python3", "/x.py"');
@@ -352,7 +382,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
 
   it('omits OTel when user has [otel] table', () => {
     writeFileSync(configPath, `[otel]\nexporter = "otlp-grpc"\n`, 'utf-8');
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const text = readFileSync(configPath, 'utf-8');
     expect(text).toContain('exporter = "otlp-grpc"');
     const managed = text.split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
@@ -361,7 +391,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
   });
 
   it('omits OTel by default on Windows installs', () => {
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32' });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32', notifyScriptPath });
     const text = readFileSync(configPath, 'utf-8');
     const managed = text.split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
     expect(managed).toContain('hooks = true');
@@ -369,11 +399,37 @@ describe('codex-install: install / uninstall (file I/O)', () => {
     expect(managed).not.toContain('[otel.trace_exporter.otlp-http]');
   });
 
+  it('writes the notify sidecar script on Windows and removes it on uninstall', () => {
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32', notifyScriptPath });
+
+    expect(readFileSync(notifyScriptPath, 'utf-8')).toBe(windowsNotifyScriptContent());
+    const text = readFileSync(configPath, 'utf-8');
+    expect(text).toContain('"-File"');
+    expect(text).toContain('codex-notify.ps1');
+
+    // Reinstall keeps both files byte-identical (idempotence).
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32', notifyScriptPath });
+    expect(readFileSync(configPath, 'utf-8')).toBe(text);
+
+    uninstallCodexHooks({ configPath, notifyScriptPath });
+    expect(existsSync(notifyScriptPath)).toBe(false);
+    expect(readFileSync(configPath, 'utf-8')).not.toContain(OPEN_FENCE);
+  });
+
+  it('skips notify on Windows when user has top-level notify (no sidecar written)', () => {
+    writeFileSync(configPath, `notify = ["python3", "/x.py"]\n`, 'utf-8');
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32', notifyScriptPath });
+    expect(existsSync(notifyScriptPath)).toBe(false);
+    const managed = readFileSync(configPath, 'utf-8').split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
+    expect(managed).not.toContain('notify =');
+    expect(managed).toContain('hooks = true');
+  });
+
   it('uninstall strips fence and preserves user content', () => {
     const userText = `model = "gpt-5"\n[profiles.work]\nprovider = "openai"\n`;
     writeFileSync(configPath, userText, 'utf-8');
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
-    uninstallCodexHooks({ configPath });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
+    uninstallCodexHooks({ configPath, notifyScriptPath });
     const text = readFileSync(configPath, 'utf-8');
     expect(text).not.toContain(OPEN_FENCE);
     expect(text).not.toContain('hooks = true');
@@ -382,28 +438,28 @@ describe('codex-install: install / uninstall (file I/O)', () => {
   });
 
   it('uninstall is idempotent when no config exists', () => {
-    expect(() => uninstallCodexHooks({ configPath })).not.toThrow();
+    expect(() => uninstallCodexHooks({ configPath, notifyScriptPath })).not.toThrow();
     expect(existsSync(configPath)).toBe(false);
   });
 
   it('honours AGENTDECK_NO_CODEX_HOOKS=1 opt-out', () => {
     process.env.AGENTDECK_NO_CODEX_HOOKS = '1';
-    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     expect(result.installed).toBe(false);
     expect(result.reason).toContain('AGENTDECK_NO_CODEX_HOOKS');
     expect(existsSync(configPath)).toBe(false);
   });
 
   it('install is idempotent (same port → no rewrite)', () => {
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const firstStat = readFileSync(configPath, 'utf-8');
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const secondStat = readFileSync(configPath, 'utf-8');
     expect(secondStat).toBe(firstStat);
   });
 
   it('preserves Codex hook trust state across reinstall', () => {
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     const withStateInsideFence = readFileSync(configPath, 'utf-8').replace(
       CLOSE_FENCE,
       [
@@ -417,7 +473,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
     );
     writeFileSync(configPath, withStateInsideFence, 'utf-8');
 
-    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    const result = installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     expect(result.installed).toBe(true);
 
     const text = readFileSync(configPath, 'utf-8');
@@ -426,7 +482,7 @@ describe('codex-install: install / uninstall (file I/O)', () => {
     expect(managed).not.toContain('[hooks.state]');
     expect(outside).toContain('trusted_hash = "sha256:abc"');
 
-    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120 });
+    installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, notifyScriptPath });
     expect(readFileSync(configPath, 'utf-8')).toBe(text);
   });
 });

--- a/hooks/src/__tests__/codex-install.test.ts
+++ b/hooks/src/__tests__/codex-install.test.ts
@@ -416,6 +416,23 @@ describe('codex-install: install / uninstall (file I/O)', () => {
     expect(readFileSync(configPath, 'utf-8')).not.toContain(OPEN_FENCE);
   });
 
+  it('downgrades to lifecycle-only with a warning when the sidecar write fails', () => {
+    // Parent of the sidecar path is a regular file, so mkdir/write fails.
+    const blocker = join(tmp, 'blocker');
+    writeFileSync(blocker, 'not a directory', 'utf-8');
+    const result = installCodexHooksIfNeeded({
+      configPath,
+      daemonHttpPort: 9120,
+      platform: 'win32',
+      notifyScriptPath: join(blocker, 'codex-notify.ps1'),
+    });
+    expect(result.installed).toBe(true);
+    expect(result.warning).toContain('notify sidecar write failed');
+    const managed = readFileSync(configPath, 'utf-8').split(OPEN_FENCE)[1].split(CLOSE_FENCE)[0];
+    expect(managed).not.toContain('notify =');
+    expect(managed).toContain('hooks = true');
+  });
+
   it('skips notify on Windows when user has top-level notify (no sidecar written)', () => {
     writeFileSync(configPath, `notify = ["python3", "/x.py"]\n`, 'utf-8');
     installCodexHooksIfNeeded({ configPath, daemonHttpPort: 9120, platform: 'win32', notifyScriptPath });

--- a/hooks/src/codex-install.ts
+++ b/hooks/src/codex-install.ts
@@ -53,6 +53,9 @@ export interface InstallResult {
   installed: boolean;
   /** Human-readable reason when `installed === false`. */
   reason?: string;
+  /** Non-fatal degradation while `installed === true` (e.g. the Windows
+   *  notify sidecar could not be written, so notify was omitted). */
+  warning?: string;
 }
 
 /** Honour `AGENTDECK_NO_CODEX_HOOKS=1` from the environment. Callers
@@ -348,14 +351,18 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
 
   const platform = opts.platform ?? process.platform;
   let includeNotify = !hasTopLevelKeyOutsideFence(original, 'notify');
+  // OTel exporter stays POSIX-only for now — deliberately omitted on
+  // win32 (unverified there); lifecycle hooks + notify carry the signal.
   const includeOtel = platform !== 'win32' && !hasTableOutsideFence(original, 'otel');
 
+  let warning: string | undefined;
   const notifyScriptPath = opts.notifyScriptPath ?? DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH;
   if (includeNotify && platform === 'win32') {
     // The Stop lifecycle hook already reports turn-complete, so a failed
     // sidecar write downgrades to lifecycle-only rather than aborting.
     if (!writeScriptIfChanged(windowsNotifyScriptContent(), notifyScriptPath)) {
       includeNotify = false;
+      warning = `notify sidecar write failed (${notifyScriptPath}) — notify fallback omitted`;
     }
   }
 
@@ -371,11 +378,11 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
   const updated = applyManagedBlock(original, body);
 
   if (updated === original) {
-    return { installed: true };
+    return { installed: true, warning };
   }
 
   if (writeTextAtomic(updated, path)) {
-    return { installed: true };
+    return { installed: true, warning };
   }
   return { installed: false, reason: `write failed: ${path}` };
 }

--- a/hooks/src/codex-install.ts
+++ b/hooks/src/codex-install.ts
@@ -16,7 +16,7 @@
 // MUST stay in sync with apple/AgentDeck/Daemon/Core/CodexConfigInstaller.swift
 // (managedBlockBody schema + lifecycle hook table layout).
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { dirname, join } from 'path';
 import { homedir } from 'os';
 import {
@@ -28,6 +28,13 @@ import {
 } from './codex-mini-toml.js';
 
 export const DEFAULT_CODEX_CONFIG_PATH = join(homedir(), '.codex', 'config.toml');
+/** Sidecar script for the Windows notify fallback. Codex execs `notify`
+ *  as a bare argv array (no shell) and appends the JSON payload as the
+ *  last element; `powershell -File` is the only Windows invocation that
+ *  binds trailing argv into `$args` (`-Command` concatenates them into
+ *  the command text and `-EncodedCommand` rejects them outright), and
+ *  `-File` requires a real script on disk. */
+export const DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH = join(homedir(), '.agentdeck', 'codex-notify.ps1');
 const DEFAULT_DAEMON_PORT = 9120;
 
 export interface InstallOptions {
@@ -38,6 +45,8 @@ export interface InstallOptions {
   daemonHttpPort?: number;
   /** Override platform for tests. Defaults to process.platform. */
   platform?: NodeJS.Platform;
+  /** Override the Windows notify sidecar script path (tests). */
+  notifyScriptPath?: string;
 }
 
 export interface InstallResult {
@@ -82,6 +91,7 @@ interface ManagedBlockOptions {
   otelEndpoint?: string;
   daemonHttpPort?: number;
   platform?: NodeJS.Platform;
+  notifyScriptPath?: string;
 }
 
 /** Assemble the body of the AgentDeck-managed fence. Tests call this
@@ -105,9 +115,15 @@ export function managedBlockBody(opts: ManagedBlockOptions = {}): string {
   if (includeNotify) {
     lines.push('');
     lines.push('# Optional turn-complete notification fallback.');
-    lines.push('# Codex appends the JSON payload as the last argv entry,');
-    lines.push('# so the 4th array element acts as $0 and payload lands at $1.');
-    lines.push(buildNotifyAssignment('codex_turn_complete', platform));
+    if (platform === 'win32') {
+      lines.push('# Codex appends the JSON payload as the last argv entry;');
+      lines.push('# powershell -File binds it into $args. (-Command cannot:');
+      lines.push('# it concatenates trailing argv into the command text.)');
+    } else {
+      lines.push('# Codex appends the JSON payload as the last argv entry,');
+      lines.push('# so the 4th array element acts as $0 and payload lands at $1.');
+    }
+    lines.push(buildNotifyAssignment('codex_turn_complete', platform, opts.notifyScriptPath));
   }
 
   if (includeOtel) {
@@ -130,9 +146,10 @@ export function managedBlockBody(opts: ManagedBlockOptions = {}): string {
  *       Without our 4th element, `sh -c "<snippet>" <json>` would assign
  *       `<json>` to `$0` and leave `$1` empty. With the dummy in place,
  *       `<json>` lands at `$1` as the snippet expects. */
-function buildNotifyAssignment(event: string, platform: NodeJS.Platform): string {
+function buildNotifyAssignment(event: string, platform: NodeJS.Platform, notifyScriptPath?: string): string {
   if (platform === 'win32') {
-    return `notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", ${quoted(buildWindowsNotifySnippet(event))}, "agentdeck-notify"]`;
+    const scriptPath = notifyScriptPath ?? DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH;
+    return `notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", ${quoted(scriptPath)}]`;
   }
   return `notify = ["sh", "-c", ${quoted(buildNotifySnippet(event))}, "agentdeck-notify"]`;
 }
@@ -222,11 +239,20 @@ function buildWindowsLifecycleHookCommand(event: string): string {
 }
 
 function buildWindowsStdinPostSnippet(event: string): string {
-  return buildWindowsPostSnippet(event, '[Console]::In.ReadToEnd()');
+  // Read raw stdin as UTF-8: [Console]::In decodes with the console's OEM
+  // codepage (e.g. CP949) and would garble non-ASCII payload text.
+  return buildWindowsPostSnippet(
+    event,
+    '(New-Object System.IO.StreamReader([Console]::OpenStandardInput(), [System.Text.Encoding]::UTF8)).ReadToEnd()'
+  );
 }
 
-function buildWindowsNotifySnippet(event: string): string {
-  return buildWindowsPostSnippet(event, `$(if ($args.Count -gt 0) { $args[$args.Count - 1] } else { '' })`);
+/** Body of the Windows notify sidecar script (`-File` execution binds
+ *  Codex's appended payload argv into `$args`; take the last element to
+ *  mirror POSIX `$1`). ASCII-only so PowerShell 5.1's BOM-less ANSI
+ *  fallback reads it identically to UTF-8. Exported for tests. */
+export function windowsNotifyScriptContent(event = 'codex_turn_complete'): string {
+  return buildWindowsPostSnippet(event, `$(if ($args.Count -gt 0) { [string]$args[$args.Count - 1] } else { '' })`) + '\n';
 }
 
 function buildWindowsPostSnippet(event: string, bodyExpression: string): string {
@@ -248,7 +274,11 @@ function buildWindowsPostSnippet(event: string, bodyExpression: string): string 
     `}`,
     `if ([string]::IsNullOrWhiteSpace($port)) { $port = '9120' }`,
     `$body = ${bodyExpression}`,
-    `try { Invoke-RestMethod -Method Post -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $port + '/hooks/${event}') -ContentType 'application/json' -Body $body | Out-Null } catch {}`,
+    // Post UTF-8 bytes: Invoke-RestMethod encodes string bodies as
+    // ISO-8859-1 when the content type carries no charset, replacing
+    // non-ASCII payload characters with '?'.
+    `$bytes = [System.Text.Encoding]::UTF8.GetBytes([string]$body)`,
+    `try { Invoke-RestMethod -Method Post -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $port + '/hooks/${event}') -ContentType 'application/json; charset=utf-8' -Body $bytes | Out-Null } catch {}`,
     `exit 0`,
   ].join('\n');
 }
@@ -266,6 +296,16 @@ function readText(path: string): string {
   } catch {
     return '';
   }
+}
+
+/** Write the notify sidecar only when its content changed, so repeated
+ *  installs stay idempotent (no mtime churn). Returns false when the
+ *  script cannot be guaranteed on disk. */
+function writeScriptIfChanged(content: string, path: string): boolean {
+  try {
+    if (existsSync(path) && readFileSync(path, 'utf-8') === content) return true;
+  } catch { /* unreadable — fall through to rewrite */ }
+  return writeTextAtomic(content, path);
 }
 
 function writeTextAtomic(text: string, path: string): boolean {
@@ -307,8 +347,17 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
   }
 
   const platform = opts.platform ?? process.platform;
-  const includeNotify = !hasTopLevelKeyOutsideFence(original, 'notify');
+  let includeNotify = !hasTopLevelKeyOutsideFence(original, 'notify');
   const includeOtel = platform !== 'win32' && !hasTableOutsideFence(original, 'otel');
+
+  const notifyScriptPath = opts.notifyScriptPath ?? DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH;
+  if (includeNotify && platform === 'win32') {
+    // The Stop lifecycle hook already reports turn-complete, so a failed
+    // sidecar write downgrades to lifecycle-only rather than aborting.
+    if (!writeScriptIfChanged(windowsNotifyScriptContent(), notifyScriptPath)) {
+      includeNotify = false;
+    }
+  }
 
   const otelEndpoint = includeOtel ? buildOtelEndpoint(opts.daemonHttpPort) : undefined;
   const body = managedBlockBody({
@@ -317,6 +366,7 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
     otelEndpoint,
     daemonHttpPort: opts.daemonHttpPort,
     platform,
+    notifyScriptPath,
   });
   const updated = applyManagedBlock(original, body);
 
@@ -333,7 +383,10 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
 /** Strip the AgentDeck-managed fence. Idempotent — no-op when the fence
  *  is absent. Does not delete the config file even if it becomes empty
  *  (Codex may rely on its existence). */
-export function uninstallCodexHooks(opts: { configPath?: string } = {}): void {
+export function uninstallCodexHooks(opts: { configPath?: string; notifyScriptPath?: string } = {}): void {
+  try {
+    unlinkSync(opts.notifyScriptPath ?? DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH);
+  } catch { /* absent on POSIX installs — nothing to remove */ }
   const path = opts.configPath ?? DEFAULT_CODEX_CONFIG_PATH;
   if (!existsSync(path)) return;
   const original = readText(path);

--- a/hooks/src/codex-install.ts
+++ b/hooks/src/codex-install.ts
@@ -36,6 +36,8 @@ export interface InstallOptions {
   /** Daemon HTTP port to bake into the OTel exporter endpoint. If
    *  omitted, the installer reads `~/.agentdeck/daemon.json`. */
   daemonHttpPort?: number;
+  /** Override platform for tests. Defaults to process.platform. */
+  platform?: NodeJS.Platform;
 }
 
 export interface InstallResult {
@@ -79,6 +81,7 @@ interface ManagedBlockOptions {
   includeOtel?: boolean;
   otelEndpoint?: string;
   daemonHttpPort?: number;
+  platform?: NodeJS.Platform;
 }
 
 /** Assemble the body of the AgentDeck-managed fence. Tests call this
@@ -87,6 +90,7 @@ interface ManagedBlockOptions {
 export function managedBlockBody(opts: ManagedBlockOptions = {}): string {
   const includeNotify = opts.includeNotify ?? true;
   const includeOtel = opts.includeOtel ?? true;
+  const platform = opts.platform ?? process.platform;
 
   const lines: string[] = [
     '# Codex lifecycle hooks. Command hooks receive JSON on stdin;',
@@ -96,14 +100,14 @@ export function managedBlockBody(opts: ManagedBlockOptions = {}): string {
   ];
 
   lines.push('');
-  lines.push(...buildLifecycleHookTables());
+  lines.push(...buildLifecycleHookTables(platform));
 
   if (includeNotify) {
     lines.push('');
     lines.push('# Optional turn-complete notification fallback.');
     lines.push('# Codex appends the JSON payload as the last argv entry,');
     lines.push('# so the 4th array element acts as $0 and payload lands at $1.');
-    lines.push(buildNotifyAssignment('codex_turn_complete'));
+    lines.push(buildNotifyAssignment('codex_turn_complete', platform));
   }
 
   if (includeOtel) {
@@ -126,7 +130,10 @@ export function managedBlockBody(opts: ManagedBlockOptions = {}): string {
  *       Without our 4th element, `sh -c "<snippet>" <json>` would assign
  *       `<json>` to `$0` and leave `$1` empty. With the dummy in place,
  *       `<json>` lands at `$1` as the snippet expects. */
-function buildNotifyAssignment(event: string): string {
+function buildNotifyAssignment(event: string, platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return `notify = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", ${quoted(buildWindowsNotifySnippet(event))}, "agentdeck-notify"]`;
+  }
   return `notify = ["sh", "-c", ${quoted(buildNotifySnippet(event))}, "agentdeck-notify"]`;
 }
 
@@ -164,7 +171,7 @@ const LIFECYCLE_HOOKS: LifecycleHook[] = [
   { codexEvent: 'Stop',             agentDeckEvent: 'codex_stop',               matcher: null },
 ];
 
-function buildLifecycleHookTables(): string[] {
+function buildLifecycleHookTables(platform: NodeJS.Platform): string[] {
   const lines: string[] = [];
   for (let idx = 0; idx < LIFECYCLE_HOOKS.length; idx++) {
     const hook = LIFECYCLE_HOOKS[idx];
@@ -175,7 +182,7 @@ function buildLifecycleHookTables(): string[] {
     }
     lines.push(`[[hooks.${hook.codexEvent}.hooks]]`);
     lines.push(`type = "command"`);
-    lines.push(`command = ${quoted(buildLifecycleHookCommand(hook.agentDeckEvent))}`);
+    lines.push(`command = ${quoted(buildLifecycleHookCommand(hook.agentDeckEvent, platform))}`);
     lines.push(`timeout = 5`);
   }
   return lines;
@@ -184,7 +191,10 @@ function buildLifecycleHookTables(): string[] {
 /** Official Codex lifecycle hooks pass their JSON payload on stdin.
  *  Keep stdout quiet so Stop / UserPromptSubmit hooks do not accidentally
  *  feed the daemon's acknowledgement back into Codex as hook output. */
-function buildLifecycleHookCommand(event: string): string {
+function buildLifecycleHookCommand(event: string, platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return buildWindowsLifecycleHookCommand(event);
+  }
   return `sh -c ${shellSingleQuoted(buildStdinPostSnippet(event))}`;
 }
 
@@ -205,6 +215,46 @@ function buildStdinPostSnippet(event: string): string {
 
 function shellSingleQuoted(s: string): string {
   return `'${s.replace(/'/g, "'\"'\"'")}'`;
+}
+
+function buildWindowsLifecycleHookCommand(event: string): string {
+  return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${windowsEncodedCommand(buildWindowsStdinPostSnippet(event))}`;
+}
+
+function buildWindowsStdinPostSnippet(event: string): string {
+  return buildWindowsPostSnippet(event, '[Console]::In.ReadToEnd()');
+}
+
+function buildWindowsNotifySnippet(event: string): string {
+  return buildWindowsPostSnippet(event, `$(if ($args.Count -gt 0) { $args[$args.Count - 1] } else { '' })`);
+}
+
+function buildWindowsPostSnippet(event: string, bodyExpression: string): string {
+  return [
+    `$ErrorActionPreference = 'SilentlyContinue'`,
+    `$ProgressPreference = 'SilentlyContinue'`,
+    `$port = $env:AGENTDECK_PORT`,
+    `if ([string]::IsNullOrWhiteSpace($port)) {`,
+    `  $daemonFile = Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'`,
+    `  if (Test-Path -LiteralPath $daemonFile) {`,
+    `    try {`,
+    `      $daemon = Get-Content -LiteralPath $daemonFile -Raw | ConvertFrom-Json`,
+    `      $candidate = if ($daemon.httpPort) { $daemon.httpPort } else { $daemon.port }`,
+    `      if ($candidate) {`,
+    `        try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $candidate + '/health') | Out-Null; $port = [string]$candidate } catch {}`,
+    `      }`,
+    `    } catch {}`,
+    `  }`,
+    `}`,
+    `if ([string]::IsNullOrWhiteSpace($port)) { $port = '9120' }`,
+    `$body = ${bodyExpression}`,
+    `try { Invoke-RestMethod -Method Post -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $port + '/hooks/${event}') -ContentType 'application/json' -Body $body | Out-Null } catch {}`,
+    `exit 0`,
+  ].join('\n');
+}
+
+function windowsEncodedCommand(s: string): string {
+  return Buffer.from(s, 'utf16le').toString('base64');
 }
 
 // ─── File I/O ───────────────────────────────────────────────────────────
@@ -256,8 +306,9 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
     return { installed: false, reason: 'user-authored [hooks] present' };
   }
 
+  const platform = opts.platform ?? process.platform;
   const includeNotify = !hasTopLevelKeyOutsideFence(original, 'notify');
-  const includeOtel = !hasTableOutsideFence(original, 'otel');
+  const includeOtel = platform !== 'win32' && !hasTableOutsideFence(original, 'otel');
 
   const otelEndpoint = includeOtel ? buildOtelEndpoint(opts.daemonHttpPort) : undefined;
   const body = managedBlockBody({
@@ -265,6 +316,7 @@ export function installCodexHooksIfNeeded(opts: InstallOptions = {}): InstallRes
     includeOtel,
     otelEndpoint,
     daemonHttpPort: opts.daemonHttpPort,
+    platform,
   });
   const updated = applyManagedBlock(original, body);
 


### PR DESCRIPTION
## Problem

Codex observation hooks did not work on Windows: the managed block in `~/.codex/config.toml` invoked every hook via `sh -c`, which does not exist on Windows. (The equivalent Claude Code hooks already work — they deliver payloads over stdin and the installer emits a PowerShell one-liner on win32.)

## What this does

**Lifecycle hooks (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop)** — on win32 each hook command becomes `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand <b64>`, reading the payload from stdin and POSTing it to the daemon, with the same `AGENTDECK_PORT` override → `daemon.json` probe → 9120 fallback port resolution as the POSIX snippet. OTel exporter config is omitted on Windows (now marked deliberate in a comment).

**notify fallback** — Codex execs `notify` as a bare argv array and appends the JSON payload as the last element. PowerShell cannot receive that through `-Command` (trailing argv is concatenated into the command text, so the payload is lost and every turn produced a parse error) nor `-EncodedCommand` (rejects trailing argv outright). The only invocation that binds trailing argv into `$args` is `-File`, which requires a real script on disk. The installer therefore writes a sidecar `~/.agentdeck/codex-notify.ps1` (idempotent — rewritten only when content changes; removed on uninstall) and emits:

```toml
notify = [powershell.exe, -NoProfile, -NonInteractive, -ExecutionPolicy, Bypass, -File, C:\\Users\\me\\.agentdeck\\codex-notify.ps1]
```

If the sidecar cannot be written, the install downgrades to lifecycle-only (Stop already covers turn-complete) and reports it via a new `InstallResult.warning`, which the CLI logs at session start and `agentdeck daemon install`.

**UTF-8 correctness (both Windows paths)** — two latent encoding bugs surfaced during E2E verification with non-ASCII payloads:
- `[Console]::In.ReadToEnd()` decodes piped stdin with the console OEM codepage (e.g. CP949), garbling non-ASCII payload text. Lifecycle hooks now read stdin through a UTF-8 `StreamReader`.
- `Invoke-RestMethod -Body <string>` encodes the body as ISO-8859-1 when the content type has no charset, replacing non-ASCII characters with `?`. Both paths now post UTF-8 bytes with `application/json; charset=utf-8`.

## Verification

- `pnpm build` + full `pnpm vitest run`: 92 files, 1641 passed / 2 skipped (8 new win32 tests/assertions in `hooks/src/__tests__/codex-install.test.ts`).
- End-to-end on Windows 11, simulating Codex exactly (argv-array exec, payload appended for notify / piped to stdin for lifecycle) against a mock daemon:
  - notify → `POST /hooks/codex_turn_complete`, body byte-identical to the payload (including Korean text, embedded quotes, `$`, backticks), exit 0.
  - SessionStart lifecycle → `POST /hooks/codex_session_start`, body byte-identical, exit 0.
- Empirically confirmed the `-Command`/`-EncodedCommand` argv-binding behavior on Windows PowerShell 5.1 that motivates the `-File` sidecar.
- Multi-angle code review of the branch was run before opening this PR; the `warning` surfacing and OTel comment came out of it.

## Known follow-up (not in this PR)

The Claude Code Windows one-liner (`hooks/src/install.ts:buildHookCommandWin`) has the same two encoding bugs fixed here for Codex (`[Console]::In.ReadToEnd()` OEM decode + string `-Body`), so non-ASCII Claude hook payloads are mangled on Windows. `applyHooks` replaces AgentDeck entries on reinstall, so a follow-up fix will self-migrate.

The macOS Swift installer (`CodexConfigInstaller.swift`) is unaffected — it never produces win32 config; the shared fence sentinels and POSIX snippets remain byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)