### PR TITLE
fix(daemon): follow ESP32 WiFi OTA across a mid-transfer WS reconnect

### DIFF
--- a/bridge/src/__tests__/esp32-wifi-ota-reconnect.test.ts
+++ b/bridge/src/__tests__/esp32-wifi-ota-reconnect.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WebSocket } from 'ws';
+import type { BridgeCore } from '../bridge-core.js';
+import {
+  __setOtaTimeoutsForTest,
+  __resetWifiEsp32OtaState,
+  __wifiOtaTestApi,
+} from '../daemon-server.js';
+
+// ─── WiFi OTA reconnect-follow ───────────────────────────────────────────────
+// Serial-backtrace diagnosis of the TTGO 2.5MB WiFi OTA proved the board does
+// NOT reset/brownout/watchdog mid-transfer: under classic single-core ESP32
+// WiFi-flash coexistence the TCP task is briefly starved, the *WebSocket* drops,
+// the board survives and re-registers a NEW socket under the same board:ip key
+// ~3-4s later. The old sender captured the socket once and streamed into the
+// dead one, so the transfer stalled and failed on the chunk-ack timeout. This
+// verifies the fix: the sender follows the board to its reconnected socket and
+// resends the not-yet-acked chunk (acks route by otaId; the firmware keeps its
+// otaRx cursor), so the transfer completes across a mid-flight disconnect. The
+// hardware drop is probabilistic, so this reproduces it deterministically.
+
+const KEY_DEVICE = { board: 'ttgo_t_display', ip: '192.168.68.73', version: '0.1.2', otaSupported: true, otaSlotSize: 6291456 };
+const CHUNK = 1024;
+
+function fakeWs(): WebSocket {
+  // Only readyState is read by the sender's liveSocket() (WebSocket.OPEN === 1).
+  return { readyState: 1 } as unknown as WebSocket;
+}
+
+function writeFirmware(bytes: number): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'ota-fw-'));
+  const path = join(dir, 'firmware.bin');
+  writeFileSync(path, Buffer.alloc(bytes, 0xab));
+  return { dir, path };
+}
+
+/**
+ * Fake BridgeCore whose wsServer.sendTo drives OTA acks by otaId. `dropSeq`, if
+ * set, makes the FIRST chunk with that seq silently vanish on `socketA` (the
+ * dropped socket) and simultaneously simulates the board reconnecting on
+ * `socketB`; every other frame is acked on whatever socket it was sent to. Acks
+ * are deferred (setImmediate) so the sender's waitForOtaAck registers first.
+ */
+function makeCore(opts: {
+  socketA: WebSocket;
+  socketB?: WebSocket;
+  dropSeq?: number;
+  onDrop?: () => void;
+}): { core: BridgeCore; sends: Array<{ sock: WebSocket; evt: any }> } {
+  const sends: Array<{ sock: WebSocket; evt: any }> = [];
+  let dropped = false;
+  const ack = (evt: any, stage: string, seq?: number) =>
+    setImmediate(() =>
+      __wifiOtaTestApi.handleEsp32OtaReply({
+        type: 'esp32_ota_ack',
+        otaId: evt.otaId,
+        stage,
+        seq,
+        offset: evt.offset ?? 0,
+        written: (evt.offset ?? 0) + CHUNK,
+      }),
+    );
+  const sendTo = (sock: WebSocket, evt: any) => {
+    sends.push({ sock, evt });
+    if (evt.type === 'esp32_ota_begin') return ack(evt, 'begin');
+    if (evt.type === 'esp32_ota_end') return ack(evt, 'end');
+    if (evt.type === 'esp32_ota_chunk') {
+      if (!dropped && opts.dropSeq === evt.seq && sock === opts.socketA) {
+        // Socket died right as this chunk was sent — no ack. Simulate the board
+        // reconnecting on a fresh socket (same board:ip key).
+        dropped = true;
+        opts.onDrop?.();
+        return;
+      }
+      return ack(evt, 'chunk', evt.seq);
+    }
+    // esp32_ota_abort — no ack needed
+    return;
+  };
+  const core = { wsServer: { sendTo } } as unknown as BridgeCore;
+  return { core, sends };
+}
+
+afterEach(() => __resetWifiEsp32OtaState());
+
+describe('WiFi OTA reconnect-follow', () => {
+  it('completes a transfer across a mid-flight WS disconnect by resending on the reconnected socket', async () => {
+    __setOtaTimeoutsForTest({ begin: 200, chunk: 50, end: 200, reconnectWait: 1000 });
+    const { dir, path } = writeFirmware(8 * CHUNK); // 8 chunks: seq 0..7
+    try {
+      const socketA = fakeWs();
+      const socketB = fakeWs();
+      const { core, sends } = makeCore({
+        socketA,
+        socketB,
+        dropSeq: 4,
+        onDrop: () => {
+          __wifiOtaTestApi.unregisterWifiEsp32Socket(socketA);
+          __wifiOtaTestApi.registerWifiEsp32(KEY_DEVICE, socketB);
+        },
+      });
+      __wifiOtaTestApi.registerWifiEsp32(KEY_DEVICE, socketA);
+
+      const res = await __wifiOtaTestApi.performWifiEsp32Ota(core, 'ttgo_t_display', path);
+
+      expect(res.ok).toBe(true);
+      expect(res.chunks).toBe(8);
+      expect(res.reconnectResends).toBe(1);
+      // seq 4 was sent twice: once into the dead socketA, once into socketB.
+      const seq4 = sends.filter((s) => s.evt.type === 'esp32_ota_chunk' && s.evt.seq === 4);
+      expect(seq4).toHaveLength(2);
+      expect(seq4[0].sock).toBe(socketA);
+      expect(seq4[1].sock).toBe(socketB);
+      // The end frame lands on the reconnected socket.
+      expect(sends.find((s) => s.evt.type === 'esp32_ota_end')?.sock).toBe(socketB);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails fast when the board drops mid-OTA and never reconnects', async () => {
+    __setOtaTimeoutsForTest({ begin: 200, chunk: 50, end: 200, reconnectWait: 300 });
+    const { dir, path } = writeFirmware(8 * CHUNK);
+    try {
+      const socketA = fakeWs();
+      const { core } = makeCore({
+        socketA,
+        dropSeq: 3,
+        onDrop: () => __wifiOtaTestApi.unregisterWifiEsp32Socket(socketA), // gone, no reconnect
+      });
+      __wifiOtaTestApi.registerWifiEsp32(KEY_DEVICE, socketA);
+
+      await expect(
+        __wifiOtaTestApi.performWifiEsp32Ota(core, 'ttgo_t_display', path),
+      ).rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a clean transfer (no disconnect) completes with zero reconnect-resends', async () => {
+    __setOtaTimeoutsForTest({ begin: 200, chunk: 50, end: 200, reconnectWait: 1000 });
+    const { dir, path } = writeFirmware(5 * CHUNK);
+    try {
+      const socketA = fakeWs();
+      const { core } = makeCore({ socketA });
+      __wifiOtaTestApi.registerWifiEsp32(KEY_DEVICE, socketA);
+
+      const res = await __wifiOtaTestApi.performWifiEsp32Ota(core, 'ttgo_t_display', path);
+      expect(res.ok).toBe(true);
+      expect(res.chunks).toBe(5);
+      expect(res.reconnectResends).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -239,15 +239,66 @@ async function readJsonBody(req: import('http').IncomingMessage, maxBytes = 64 *
 // flash-sector erase or a brief WiFi-stack starvation) or the WiFi link briefly
 // blipped and TCP is retransmitting. Both recover if we wait, so the timeouts
 // are generous: a healthy board still acks in milliseconds, and these only cap
-// how long we ride out a stall before declaring the transfer dead. Resending a
-// chunk would be wrong here — it desyncs the firmware's strict seq/offset cursor
-// (see handleOtaChunk → "unexpected_offset").
-const OTA_BEGIN_ACK_TIMEOUT_MS = 15_000; // erasing/preparing the target OTA slot
-const OTA_CHUNK_ACK_TIMEOUT_MS = 30_000; // slow classic-ESP32 flash write / WiFi stall
-const OTA_END_ACK_TIMEOUT_MS = 30_000;   // whole-image MD5 verify + set-boot-partition
+// how long we ride out a stall before declaring the transfer dead. Resending on
+// the SAME live socket would be wrong — it desyncs the firmware's strict
+// seq/offset cursor (handleOtaChunk → "unexpected_offset"); a timeout followed
+// by a board RECONNECT is the one case where resend is correct (see
+// performWifiEsp32Ota — the board never processed the lost chunk, and its otaRx
+// cursor persisted across the reconnect). `let` (not const) so tests can shrink
+// them via __setOtaTimeoutsForTest; production never mutates them.
+let OTA_BEGIN_ACK_TIMEOUT_MS = 15_000; // erasing/preparing the target OTA slot
+let OTA_CHUNK_ACK_TIMEOUT_MS = 30_000; // slow classic-ESP32 flash write / WiFi stall
+let OTA_END_ACK_TIMEOUT_MS = 30_000;   // whole-image MD5 verify + set-boot-partition
+
+// How long to wait for a board to re-register a live WS after it drops its
+// socket mid-OTA, and the cap on such reconnect-driven resends per transfer.
+// Serial-backtrace diagnosis of the TTGO 2.5MB WiFi OTA showed the board does
+// NOT reset/brownout/watchdog mid-transfer — it survives, prints "[WS]
+// Disconnected", and re-registers under the SAME board:ip key with a NEW socket
+// ~3-4s later (classic single-core ESP32 WiFi-flash coexistence briefly starves
+// the TCP task → the connection drops, not the board). The old code captured the
+// socket once and kept sending into the dead one, so the transfer stalled at the
+// disconnect and failed 30s later on the chunk-ack timeout. Following the board
+// to its reconnected socket lets the transfer resume where it stalled, because
+// acks route by otaId (socket-independent) and the firmware keeps its otaRx
+// cursor across the reconnect.
+let OTA_RECONNECT_WAIT_MS = 20_000;
+const OTA_MAX_RECONNECT_RESENDS = 12;
+
+// ── Test-only seams for the WiFi-OTA reconnect-follow path ───────────────────
+// The reconnect-follow bug is a socket-lifecycle race that hardware reproduces
+// only probabilistically (a WiFi-flash coexistence drop). These exports let a
+// deterministic unit test register/replace a board's socket mid-transfer and
+// drive acks by otaId, with the ack timeouts shrunk so the drop→timeout→resend
+// cycle runs in milliseconds. Not used by production code.
+/** @internal */
+export function __setOtaTimeoutsForTest(t: { begin?: number; chunk?: number; end?: number; reconnectWait?: number }): void {
+  if (t.begin != null) OTA_BEGIN_ACK_TIMEOUT_MS = t.begin;
+  if (t.chunk != null) OTA_CHUNK_ACK_TIMEOUT_MS = t.chunk;
+  if (t.end != null) OTA_END_ACK_TIMEOUT_MS = t.end;
+  if (t.reconnectWait != null) OTA_RECONNECT_WAIT_MS = t.reconnectWait;
+}
+/** @internal */
+export function __resetWifiEsp32OtaState(): void {
+  for (const [, w] of otaWaiters) clearTimeout(w.timer);
+  otaWaiters.clear();
+  wifiEsp32Devices.clear();
+  wifiEsp32Sockets.clear();
+  OTA_BEGIN_ACK_TIMEOUT_MS = 15_000;
+  OTA_CHUNK_ACK_TIMEOUT_MS = 30_000;
+  OTA_END_ACK_TIMEOUT_MS = 30_000;
+  OTA_RECONNECT_WAIT_MS = 20_000;
+}
+/** @internal */
+export const __wifiOtaTestApi = {
+  registerWifiEsp32,
+  unregisterWifiEsp32Socket,
+  handleEsp32OtaReply,
+  performWifiEsp32Ota,
+};
 
 async function performWifiEsp32Ota(core: BridgeCore, target: string, firmwarePath: string): Promise<Record<string, unknown>> {
-  const { key, device, ws } = findWifiOtaTarget(target);
+  const { key, device } = findWifiOtaTarget(target);
   if (device.otaSupported !== true) {
     throw new Error(`Target ${key} does not report OTA support${device.otaReason ? ` (${device.otaReason})` : ''}`);
   }
@@ -259,45 +310,87 @@ async function performWifiEsp32Ota(core: BridgeCore, target: string, firmwarePat
 
   const otaId = randomUUID();
   const md5 = createHash('md5').update(firmware).digest('hex');
-  const send = (evt: BridgeEvent) => core.wsServer.sendTo(ws, evt);
 
-  send({ type: 'esp32_ota_begin', otaId, size: firmware.length, md5 } as BridgeEvent);
-  await waitForOtaAck(otaId, 'begin', undefined, OTA_BEGIN_ACK_TIMEOUT_MS);
+  // Always resolve the board's CURRENTLY-registered socket, never a captured
+  // reference — the board re-registers a fresh socket on a mid-OTA reconnect.
+  const liveSocket = (): WebSocket | undefined => {
+    const s = wifiEsp32Sockets.get(key);
+    return s && s.readyState === WebSocket.OPEN ? s : undefined;
+  };
+  // Wait up to ms for a live socket (rides out the ~3-4s reconnect gap).
+  const awaitLiveSocket = async (ms: number): Promise<WebSocket | undefined> => {
+    const deadline = Date.now() + ms;
+    let s = liveSocket();
+    while (!s && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 200));
+      s = liveSocket();
+    }
+    return s;
+  };
+  const sendVia = (sock: WebSocket, evt: BridgeEvent) => core.wsServer.sendTo(sock, evt);
 
-  const chunkSize = 1024;
-  let offset = 0;
-  let seq = 0;
+  let reconnectResends = 0;
+  // Send one OTA frame and wait for its ack, following the board to a fresh
+  // socket if it reconnects mid-flight. On an ack timeout, if a NEW live socket
+  // has appeared (the board reconnected), the frame was lost to the dead socket
+  // — resend the same seq on the new socket once. The firmware's otaRx cursor
+  // persists across the reconnect, so a resend of the not-yet-processed seq is
+  // accepted; a genuinely-gone board still fails after OTA_RECONNECT_WAIT_MS.
+  const sendAndAck = async (evt: BridgeEvent, stage: string, seq: number | undefined, timeoutMs: number): Promise<void> => {
+    let sock = await awaitLiveSocket(OTA_RECONNECT_WAIT_MS);
+    if (!sock) throw new Error(`OTA ${stage}${seq != null ? ` #${seq}` : ''}: board ${key} offline (no live WS)`);
+    sendVia(sock, evt);
+    try {
+      await waitForOtaAck(otaId, stage, seq, timeoutMs);
+    } catch (ackErr) {
+      const fresh = await awaitLiveSocket(OTA_RECONNECT_WAIT_MS);
+      if (fresh && fresh !== sock && reconnectResends < OTA_MAX_RECONNECT_RESENDS) {
+        reconnectResends++;
+        debug('daemon', `OTA ${key}: ${stage}${seq != null ? ` #${seq}` : ''} ack lost on dropped socket — resending on reconnected WS (resend ${reconnectResends})`);
+        sendVia(fresh, evt);
+        await waitForOtaAck(otaId, stage, seq, timeoutMs);
+        return;
+      }
+      throw ackErr;
+    }
+  };
+
   try {
+    await sendAndAck({ type: 'esp32_ota_begin', otaId, size: firmware.length, md5 } as BridgeEvent, 'begin', undefined, OTA_BEGIN_ACK_TIMEOUT_MS);
+
+    const chunkSize = 1024;
+    let offset = 0;
+    let seq = 0;
     while (offset < firmware.length) {
       const chunk = firmware.subarray(offset, Math.min(offset + chunkSize, firmware.length));
-      send({
+      await sendAndAck({
         type: 'esp32_ota_chunk',
         otaId,
         seq,
         offset,
         data: chunk.toString('base64'),
-      } as BridgeEvent);
-      await waitForOtaAck(otaId, 'chunk', seq, OTA_CHUNK_ACK_TIMEOUT_MS);
+      } as BridgeEvent, 'chunk', seq, OTA_CHUNK_ACK_TIMEOUT_MS);
       offset += chunk.length;
       seq++;
     }
-    send({ type: 'esp32_ota_end', otaId } as BridgeEvent);
-    await waitForOtaAck(otaId, 'end', undefined, OTA_END_ACK_TIMEOUT_MS);
+    await sendAndAck({ type: 'esp32_ota_end', otaId } as BridgeEvent, 'end', undefined, OTA_END_ACK_TIMEOUT_MS);
     wifiEsp32Sockets.delete(key);
     wifiEsp32Devices.delete(key);
+
+    return {
+      ok: true,
+      target: key,
+      board: device.board,
+      bytes: firmware.length,
+      chunks: seq,
+      reconnectResends,
+      md5,
+    };
   } catch (err) {
-    try { send({ type: 'esp32_ota_abort', otaId } as BridgeEvent); } catch { /* best effort */ }
+    const sock = liveSocket();
+    if (sock) { try { sendVia(sock, { type: 'esp32_ota_abort', otaId } as BridgeEvent); } catch { /* best effort */ } }
     throw err;
   }
-
-  return {
-    ok: true,
-    target: key,
-    board: device.board,
-    bytes: firmware.length,
-    chunks: seq,
-    md5,
-  };
 }
 
 function loadDaemonSettings(): Record<string, unknown> {
@@ -1293,11 +1386,17 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
   // mDNS + device modules
   const deviceModules = createDefaultModules('daemon' as any);
+  // AGENTDECK_DAEMON_NO_SERIAL=1 leaves the daemon fully functional over WiFi
+  // (mDNS, WiFi WS, WiFi OTA) but never opens the USB serial ports. This frees
+  // a board's /dev/cu.* for an exclusive external serial capture (e.g. reading a
+  // panic backtrace during a WiFi OTA) that otherwise fights the daemon's serial
+  // reader for bytes. Diagnostic gate only; normal daemons keep serial on.
+  const serialMode = process.env.AGENTDECK_DAEMON_NO_SERIAL === '1' ? false : 'auto';
   const startedModules = await initModules(
     deviceModules,
     // d200h: false — direct-HID fallback retired. The D200H is driven exclusively
     // by the Ulanzi Studio plugin (`ulanzi-plugin`); the daemon never opens it over HID.
-    { mdns: true, broadcast: true, adb: 'auto', serial: 'auto', pixoo: 'auto', timebox: 'auto', idotmatrix: 'auto', d200h: false },
+    { mdns: true, broadcast: true, adb: 'auto', serial: serialMode, pixoo: 'auto', timebox: 'auto', idotmatrix: 'auto', d200h: false },
     { port, authToken: core.authToken, projectName: 'AgentDeck', wsServer: core.wsServer },
   );
 


### PR DESCRIPTION
## Summary

Serial-backtrace diagnosis of the **TTGO T-Display 2.5 MB WiFi OTA** overturns the long-standing "board resets mid-transfer" theory, and fixes the actual failure.

I captured the board's own serial (`/dev/cu.wchusbserial…` @ 115200) while triggering the WiFi OTA — with the daemon's serial module disabled so the capture owned the port exclusively. Across repeated runs, **every** failure shows exactly this on the board's serial:

```
… seq N ack  →  [WS] Disconnected  →  [mDNS] Found bridge  →  [WS] Connected
             →  device_info (SAME buildHash, no ROM banner)
```

i.e. **no `rst:0x`, no `Guru Meditation`, no `task_wdt`, no `Brownout`, no backtrace.** The board does **not** crash/reboot. Under classic single-core ESP32 WiFi-flash coexistence the TCP task is briefly starved, the **WebSocket drops**, and the board survives and re-registers a **new** socket under the same `board:ip` key ~3–4 s later. The failing chunk is random (observed **#115, #1610, #1722**) — a probabilistic coexistence drop, not a deterministic fault. The only `rst:0x` ever seen is `SW_CPU_RESET` on **success** — the intended post-OTA reboot.

| run | result | serial disconnects | serial resets |
|----|--------|:--:|:--:|
| diag #1 | FAIL @ #1610 | **1** | 0 |
| diag #2 | SUCCESS | 0 | 1 (`SW_CPU_RESET`) |
| diag #3 | FAIL @ #115 | **1** | 0 |

## Root cause of the transfer failure

`performWifiEsp32Ota` captured the WebSocket **once** and kept streaming chunks into the **dead** socket after the board reconnected, so it stalled at the drop and failed 30 s later on the chunk-ack timeout. Acks already route by `otaId` (socket-independent) and the firmware keeps its `otaRx` cursor across the reconnect — so the **only** defect was the stale socket reference.

PR #44's loosened ack timeout only rode out flash-erase **stalls** (hence the occasional pre-fix success) but could never revive a **dropped** socket.

## Fix (daemon-only, firmware untouched)

- Resolve the board's **currently-registered live socket before every OTA frame**.
- On a chunk-ack timeout where a **new** live socket has appeared (the board reconnected), **resend the not-yet-processed seq on it once** (capped at 12). The firmware accepts it because its `otaRx` cursor persisted.
- The transfer now **resumes across a mid-flight disconnect** instead of failing. Makes TTGO (and any flaky-WiFi board) WiFi OTA reliable.

Also adds **`AGENTDECK_DAEMON_NO_SERIAL=1`** — starts the daemon fully functional over WiFi (mDNS/WS/OTA) but without opening USB serial ports, so an external capture can own a board's `/dev/cu.*` to read a panic/boot log during an OTA. This is the diagnostic that was previously blocked by the daemon holding the port (flagged as the unsolved "real next step" in prior notes).

## Tests

`bridge/src/__tests__/esp32-wifi-ota-reconnect.test.ts` deterministically reproduces the probabilistic hardware drop:
- completes across a mid-flight socket swap (resends on the reconnected socket; end frame lands on the new socket),
- fails fast when the board never reconnects,
- a clean transfer needs **zero** resends.

Timeouts are test-injectable so the drop→timeout→resend cycle runs in ms.

- `pnpm vitest run bridge/` → **1134 pass** (65 files), incl. the new suite.
- Hardware: the fixed daemon completed the 2.5 MB TTGO OTA **4/4** in a clean WiFi spell — no regression to the happy path. (The reconnect path itself is proven by the deterministic unit test; the hardware drop is probabilistic and didn't recur during the verify window.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)