### PR TITLE
fix(dashboard): cap standing-creature overlap at ~50% with proportional shrink

### DIFF
--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
@@ -28,6 +28,7 @@ fun layoutOctopuses(count: Int): List<CreatureSlot> {
         singleRowLimit = 4,
         baseScale = 1.0f,
         minScale = 0.58f,
+        creatureWidth = 0.11f,
     )
 }
 
@@ -61,6 +62,7 @@ fun layoutCloudCreatures(count: Int): List<CreatureSlot> {
         singleRowLimit = 3,
         baseScale = 0.98f,
         minScale = 0.56f,
+        creatureWidth = 0.080f,
     )
 }
 
@@ -78,6 +80,7 @@ fun layoutOpenCodeCreatures(count: Int): List<CreatureSlot> {
         singleRowLimit = 3,
         baseScale = 0.96f,
         minScale = 0.56f,
+        creatureWidth = 0.078f,
     )
 }
 
@@ -95,8 +98,22 @@ fun layoutAntigravityCreatures(count: Int): List<CreatureSlot> {
         singleRowLimit = 3,
         baseScale = 0.96f,
         minScale = 0.56f,
+        creatureWidth = 0.096f,
     )
 }
+
+/**
+ * Hard floor for the crowd-driven shrink. Below the per-band [minScale] so
+ * tightly packed bands can still shrink enough to honor the overlap cap before
+ * we give up and accept brief overlap.
+ */
+private const val CROWDED_MIN_SCALE = 0.40f
+
+/**
+ * Max fraction of a creature's width that two neighbors may overlap. 0.5 →
+ * centers stay at least half a body-width apart (≤50% overlap).
+ */
+private const val MAX_OVERLAP_FRACTION = 0.5f
 
 private fun layoutBand(
     count: Int,
@@ -107,6 +124,7 @@ private fun layoutBand(
     singleRowLimit: Int,
     baseScale: Float,
     minScale: Float,
+    creatureWidth: Float,
 ): List<CreatureSlot> {
     if (count <= 0) return emptyList()
 
@@ -130,12 +148,25 @@ private fun layoutBand(
         val rowInset = 0.015f + row * 0.02f
         val rowMinX = xMin + rowInset
         val rowMaxX = xMax - rowInset
-        val rowScale = max(minScale, scale - row * 0.04f)
+        // Alternating jitter magnitude — constant within a row.
+        val spread = max(0.003f, minOf(0.012f, (rowMaxX - rowMinX) / (rowCount * 5).coerceAtLeast(1)))
+
+        // Overlap cap: keep neighbor center-spacing ≥ MAX_OVERLAP_FRACTION of
+        // the on-screen body width so creatures never overlap by more than
+        // ~half. When the band is too tight to honor that at the count-based
+        // scale, shrink every creature in the row by the same ratio (down to
+        // CROWDED_MIN_SCALE) instead of letting them pile up.
+        var rowScale = max(minScale, scale - row * 0.04f)
+        if (rowCount >= 2) {
+            // Worst-case gap after the alternating jitter squeezes a pair.
+            val spacing = (rowMaxX - rowMinX) / (rowCount - 1).toFloat() - 2 * spread
+            val overlapCapScale = max(0f, spacing) / (MAX_OVERLAP_FRACTION * creatureWidth)
+            rowScale = max(CROWDED_MIN_SCALE, minOf(rowScale, overlapCapScale))
+        }
 
         for (col in 0 until rowCount) {
             val t = if (rowCount == 1) 0.5f else col.toFloat() / (rowCount - 1).toFloat()
             val baseX = rowMinX + (rowMaxX - rowMinX) * t
-            val spread = max(0.003f, minOf(0.012f, (rowMaxX - rowMinX) / (rowCount * 5).coerceAtLeast(1)))
             val phase = if ((absoluteIndex + row) % 2 == 0) -1f else 1f
             val x = (baseX + spread * phase).coerceIn(xMin, xMax)
             val yJitter = ((absoluteIndex % 3) - 1) * 0.008f

--- a/android/app/src/test/kotlin/dev/agentdeck/terrarium/CreatureLayoutTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/terrarium/CreatureLayoutTest.kt
@@ -1,0 +1,68 @@
+package dev.agentdeck.terrarium
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression lock for the ≤50% overlap cap in [layoutBand] (shared line-for-line
+ * with apple/AgentDeck/Terrarium/CreatureLayout.swift). Neighbors standing in the
+ * same row must never overlap by more than ~half a body width; when the band is
+ * too tight the creatures shrink by the same ratio instead of piling up.
+ */
+class CreatureLayoutTest {
+
+    // On-screen body-width fractions (must match the creatureWidth args in the
+    // layoutXxx functions). Overlap is measured against width * slot.scaleFactor.
+    private val octopusWidth = 0.11f
+    private val cloudWidth = 0.080f
+    private val openCodeWidth = 0.078f
+    private val antigravityWidth = 0.096f
+
+    /**
+     * Worst overlap fraction between creatures standing in the same row. Rows
+     * aren't tagged on the slot, but within-row Y spread (jitter ≤0.016) is far
+     * below the ≥0.05 gap between rows, so a 0.03 Y threshold cleanly separates
+     * them. Overlap of a pair = (bodyWidth - centerGap) / bodyWidth.
+     */
+    private fun worstOverlap(slots: List<CreatureSlot>, width: Float): Float {
+        var worst = 0f
+        for (i in slots.indices) {
+            for (j in i + 1 until slots.size) {
+                val a = slots[i]
+                val b = slots[j]
+                if (kotlin.math.abs(a.centerYFraction - b.centerYFraction) >= 0.03f) continue
+                val w = width * maxOf(a.scaleFactor, b.scaleFactor)
+                val d = kotlin.math.abs(a.centerXFraction - b.centerXFraction)
+                val overlap = (w - d) / w
+                if (overlap > worst) worst = overlap
+            }
+        }
+        return worst
+    }
+
+    @Test
+    fun `no row overlaps more than ~50 percent across realistic counts`() {
+        for (n in 1..16) {
+            assertOverlapWithin(layoutOctopuses(n), octopusWidth, n, "octopus")
+            assertOverlapWithin(layoutCloudCreatures(n), cloudWidth, n, "cloud")
+            assertOverlapWithin(layoutOpenCodeCreatures(n), openCodeWidth, n, "opencode")
+            assertOverlapWithin(layoutAntigravityCreatures(n), antigravityWidth, n, "antigravity")
+        }
+    }
+
+    @Test
+    fun `low counts keep full size and do not shrink`() {
+        // 1-2 sessions must not trigger any crowd shrink — they render large.
+        assertTrue(layoutOctopuses(1).first().scaleFactor > 0.9f)
+        assertTrue(layoutOctopuses(2).all { it.scaleFactor > 0.85f })
+    }
+
+    private fun assertOverlapWithin(slots: List<CreatureSlot>, width: Float, n: Int, name: String) {
+        val overlap = worstOverlap(slots, width)
+        // ≤50% is the target; allow a small slack for the crowded floor + jitter.
+        assertTrue(
+            "$name n=$n overlapped ${(overlap * 100).toInt()}% (> cap)",
+            overlap <= 0.56f,
+        )
+    }
+}

--- a/apple/AgentDeck/Terrarium/CreatureLayout.swift
+++ b/apple/AgentDeck/Terrarium/CreatureLayout.swift
@@ -20,7 +20,8 @@ enum CreatureLayout {
             backY: 0.52,
             singleRowLimit: 4,
             baseScale: 1.0,
-            minScale: 0.58
+            minScale: 0.58,
+            creatureWidth: 0.11
         )
     }
 
@@ -33,7 +34,8 @@ enum CreatureLayout {
             backY: 0.28,
             singleRowLimit: 3,
             baseScale: 0.98,
-            minScale: 0.56
+            minScale: 0.56,
+            creatureWidth: 0.080
         )
     }
 
@@ -46,7 +48,8 @@ enum CreatureLayout {
             backY: 0.46,
             singleRowLimit: 3,
             baseScale: 0.96,
-            minScale: 0.56
+            minScale: 0.56,
+            creatureWidth: 0.078
         )
     }
 
@@ -61,9 +64,19 @@ enum CreatureLayout {
             backY: 0.34,
             singleRowLimit: 3,
             baseScale: 0.96,
-            minScale: 0.56
+            minScale: 0.56,
+            creatureWidth: 0.096
         )
     }
+
+    /// Hard floor for the crowd-driven shrink. Below the per-band `minScale`
+    /// so tightly packed bands can still shrink enough to honor the overlap cap
+    /// before we give up and accept brief overlap.
+    private static let crowdedMinScale: Float = 0.40
+
+    /// Max fraction of a creature's width that two neighbors may overlap.
+    /// 0.5 → centers stay at least half a body-width apart (≤50% overlap).
+    private static let maxOverlapFraction: Float = 0.5
 
     private static func layoutBand(
         count: Int,
@@ -73,7 +86,8 @@ enum CreatureLayout {
         backY: Float,
         singleRowLimit: Int,
         baseScale: Float,
-        minScale: Float
+        minScale: Float,
+        creatureWidth: Float
     ) -> [CreatureSlot] {
         guard count > 0 else { return [] }
 
@@ -100,12 +114,25 @@ enum CreatureLayout {
             let rowInset = 0.015 + Float(row) * 0.02
             let rowMinX = xMin + rowInset
             let rowMaxX = xMax - rowInset
-            let rowScale = max(minScale, scale - Float(row) * 0.04)
+            // Alternating jitter magnitude — constant within a row.
+            let spread = max(0.003, min(0.012, (rowMaxX - rowMinX) / Float(max(rowCount * 5, 1))))
+
+            // Overlap cap: keep neighbor center-spacing ≥ maxOverlapFraction of
+            // the on-screen body width so creatures never overlap by more than
+            // ~half. When the band is too tight to honor that at the count-based
+            // scale, shrink every creature in the row by the same ratio (down to
+            // crowdedMinScale) instead of letting them pile up.
+            var rowScale = max(minScale, scale - Float(row) * 0.04)
+            if rowCount >= 2 {
+                // Worst-case gap after the alternating jitter squeezes a pair.
+                let spacing = (rowMaxX - rowMinX) / Float(rowCount - 1) - 2 * spread
+                let overlapCapScale = max(0, spacing) / (maxOverlapFraction * creatureWidth)
+                rowScale = max(crowdedMinScale, min(rowScale, overlapCapScale))
+            }
 
             for col in 0..<rowCount {
                 let t = rowCount == 1 ? 0.5 : Float(col) / Float(rowCount - 1)
                 let baseX = rowMinX + (rowMaxX - rowMinX) * t
-                let spread = max(0.003, min(0.012, (rowMaxX - rowMinX) / Float(max(rowCount * 5, 1))))
                 let phase: Float = ((absoluteIndex + row) % 2 == 0) ? -1 : 1
                 let x = min(xMax, max(xMin, baseX + spread * phase))
                 let yJitter = Float((absoluteIndex % 3) - 1) * 0.008

--- a/esp32/src/ui/terrarium/antigravity.cpp
+++ b/esp32/src/ui/terrarium/antigravity.cpp
@@ -87,13 +87,26 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
     if (idx >= MAX_ANTIGRAVITY) return;
 
     float scaleFactor = (total >= 4) ? 0.70f : (total >= 3) ? 0.84f : 1.0f;
+
+    // Horizontal band the creatures spread across (fraction of width).
+    float span = (total <= 1) ? 0.0f : (total <= 2) ? 0.22f : 0.34f;
+
+    // Overlap cap: shrink further so neighbor center-spacing stays ≥ 50% of the
+    // glyph width (≤50% overlap). Mark box ≈ bodyRadius*2.7 wide.
+    if (total >= 2) {
+        float spacing = span / (total - 1) - 0.04f;  // minus jitter squeeze margin
+        if (spacing < 0.0f) spacing = 0.0f;
+        float capScale = spacing / (0.5f * Layout::AntigravityRadiusFrac * 2.7f);
+        if (capScale < scaleFactor) scaleFactor = capScale;
+        if (scaleFactor < 0.45f) scaleFactor = 0.45f;
+    }
+
     float bodyRadius = w * Layout::AntigravityRadiusFrac * scaleFactor;
 
     float homeX;
     if (total <= 1) {
         homeX = Layout::AntigravityHomeX;
     } else {
-        float span = (total <= 2) ? 0.22f : 0.34f;
         homeX = Layout::AntigravityHomeX - span / 2 + span * idx / (total - 1);
     }
     homeX += jitterX[idx];

--- a/esp32/src/ui/terrarium/cloud.cpp
+++ b/esp32/src/ui/terrarium/cloud.cpp
@@ -57,6 +57,20 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
 
     // Dynamic scale: shrink when many instances
     float scaleFactor = (total >= 4) ? 0.70f : (total >= 3) ? 0.85f : 1.0f;
+
+    // Horizontal band the creatures spread across (fraction of width).
+    float span = (total <= 1) ? 0.0f : (total <= 2) ? 0.25f : 0.40f;
+
+    // Overlap cap: shrink further so neighbor center-spacing stays ≥ 50% of the
+    // glyph width (≤50% overlap). Cloud silhouette ≈ baseRadius*1.8 wide.
+    if (total >= 2) {
+        float spacing = span / (total - 1) - 0.04f;  // minus jitter squeeze margin
+        if (spacing < 0.0f) spacing = 0.0f;
+        float capScale = spacing / (0.5f * Layout::CloudRadiusFrac * 1.8f);
+        if (capScale < scaleFactor) scaleFactor = capScale;
+        if (scaleFactor < 0.45f) scaleFactor = 0.45f;
+    }
+
     float baseRadius = w * Layout::CloudRadiusFrac * scaleFactor;
 
     // Calculate home position — wider spread for more creatures
@@ -64,7 +78,6 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
     if (total <= 1) {
         homeX = Layout::CloudHomeX;
     } else {
-        float span = (total <= 2) ? 0.25f : 0.40f;
         homeX = Layout::CloudHomeX - span / 2 + span * idx / (total - 1);
     }
     homeX += jitterX[idx];

--- a/esp32/src/ui/terrarium/octopus.cpp
+++ b/esp32/src/ui/terrarium/octopus.cpp
@@ -60,6 +60,22 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
 
     // Dynamic scale: shrink creatures when many sessions
     float scaleFactor = (total >= 5) ? 0.60f : (total >= 4) ? 0.70f : (total >= 3) ? 0.85f : 1.0f;
+
+    // Horizontal band the creatures spread across (fraction of width).
+    float span = (total <= 1) ? 0.0f : (total <= 2) ? 0.30f : (total <= 3) ? 0.40f : 0.50f;
+
+    // Overlap cap: shrink further so neighbor center-spacing stays ≥ 50% of the
+    // glyph width (≤50% body overlap). Footprint ≈ bodyRadius*2.2, i.e. a width
+    // fraction of OctBodyRadiusFrac*2.2*scaleFactor. When the fixed span can't
+    // give that spacing, shrink every creature by the same ratio (floor 0.45).
+    if (total >= 2) {
+        float spacing = span / (total - 1) - 0.04f;  // minus jitter squeeze margin
+        if (spacing < 0.0f) spacing = 0.0f;
+        float capScale = spacing / (0.5f * Layout::OctBodyRadiusFrac * 2.2f);
+        if (capScale < scaleFactor) scaleFactor = capScale;
+        if (scaleFactor < 0.45f) scaleFactor = 0.45f;
+    }
+
     float bodyRadius = w * Layout::OctBodyRadiusFrac * scaleFactor;
     // The robot occupies the full 24×24 viewBox; map it into a square box so the
     // on-screen footprint matches the old block glyph (~bodyRadius*2.2 wide).
@@ -70,7 +86,6 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
     if (total <= 1) {
         homeX = Layout::OctHomeX;
     } else {
-        float span = (total <= 2) ? 0.30f : (total <= 3) ? 0.40f : 0.50f;
         homeX = Layout::OctHomeX - span / 2 + span * idx / (total - 1);
     }
     homeX += jitterX[idx];

--- a/esp32/src/ui/terrarium/opencode.cpp
+++ b/esp32/src/ui/terrarium/opencode.cpp
@@ -55,6 +55,20 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
 
     // Dynamic scale: shrink when many instances
     float scaleFactor = (total >= 4) ? 0.70f : (total >= 3) ? 0.85f : 1.0f;
+
+    // Horizontal band the creatures spread across (fraction of width).
+    float span = (total <= 1) ? 0.0f : (total <= 2) ? 0.25f : 0.40f;
+
+    // Overlap cap: shrink further so neighbor center-spacing stays ≥ 50% of the
+    // glyph width (≤50% overlap). Mark box ≈ bodyRadius*2.6 wide.
+    if (total >= 2) {
+        float spacing = span / (total - 1) - 0.04f;  // minus jitter squeeze margin
+        if (spacing < 0.0f) spacing = 0.0f;
+        float capScale = spacing / (0.5f * Layout::OpenCodeRadiusFrac * 2.6f);
+        if (capScale < scaleFactor) scaleFactor = capScale;
+        if (scaleFactor < 0.45f) scaleFactor = 0.45f;
+    }
+
     float bodyRadius = w * Layout::OpenCodeRadiusFrac * scaleFactor;
 
     // Calculate home position — wider spread for more creatures
@@ -62,7 +76,6 @@ void render(uint16_t* buf, int w, int h, float time, float dt,
     if (total <= 1) {
         homeX = Layout::OpenCodeHomeX;
     } else {
-        float span = (total <= 2) ? 0.25f : 0.40f;
         homeX = Layout::OpenCodeHomeX - span / 2 + span * idx / (total - 1);
     }
     homeX += jitterX[idx];


### PR DESCRIPTION
## Problem
Dashboard creatures ("standing agents") in a terrarium band could overlap heavily at high session counts. Each band's width is a fixed fraction of the screen, so as the count rose the neighbor spacing shrank faster than the body size — bodies piled up (measured 59–68% overlap at 16–20 sessions).

## Fix
Enforce a **≤50% overlap cap** with **proportional dynamic shrinking**: within a row, if neighbor center-spacing would fall below half the on-screen body width, every creature in that row shrinks by the same ratio down to a hard floor, instead of overlapping. Below the floor (extreme crowding) brief overlap is accepted.

Applied to the surfaces that render standing creatures with a continuous scale:

- **macOS/iOS app + Android** — shared `layoutBand` (`apple/.../CreatureLayout.swift` + `android/.../CreatureLayout.kt`, kept line-for-line identical). New per-band `creatureWidth`, crowd-shrink floor `0.40` (below the old `0.56–0.58` floor so shrinking can actually resolve crowding).
- **ESP32** e-ink/LCD terrarium (`octopus/cloud/opencode/antigravity.cpp`) — same cap on the stepped `scaleFactor`, using each glyph's real footprint multiplier (×2.2 / ×1.8 / ×2.6 / ×2.7), floor `0.45`.

The TUI (`agentdeck dashboard`) is intentionally out of scope — its braille sprites are discrete (1×/2×/3×) and can't shrink proportionally.

## Verification
- **No regression at realistic counts**: math sim over 1–20 sessions/band shows the cap engages only at n≥16; counts 2–12 are unchanged. High-count overlap 59–68% → capped at 50–55% (the >50% residuals are only the extreme-crowding floor case).
- **New `CreatureLayoutTest`** (Android) locks the ≤50% within-row invariant + "low counts stay full size" — 2 tests pass.
- Builds green: Swift `AgentDeck_macOS`, Android `testDebugUnitTest`, ESP32 `inkdeck` firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)