### PR TITLE
fix(esp32): self-heal IPS10 persisted bridge endpoint on mDNS rediscovery

### DIFF
--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -119,6 +119,13 @@ static void networkTask(void* param) {
                     Serial.printf("[Net] Bridge (re)discovered via mDNS: %s:%d\n", bridge.ip, bridge.port);
                     strncpy(currentBridgeIp, bridge.ip, sizeof(currentBridgeIp) - 1);
                     currentBridgePort = bridge.port;
+                    // Self-heal the persisted endpoint: 67934f94 saved the bridge
+                    // IP to NVS but never refreshed it, so a board whose daemon
+                    // moved (DHCP drift, host IP change) reloads the STALE saved
+                    // IP on every reboot and loops on "connection reset by peer".
+                    // Persisting the freshly-discovered endpoint here lets the
+                    // board recover across reboots. No-op on non-IPS10 boards.
+                    Net::wifiSaveProvisionedBridge(bridge.ip, bridge.port, bridge.token);
                     // New endpoint: tear down old WS so wsConnect rebinds cleanly
                     if (Net::wsConnected()) Net::wsDisconnect();
                 }


### PR DESCRIPTION
## Problem
`67934f94` persists the daemon bridge endpoint (IP/port/token) to NVS so IPS10 (ESP32-P4 + hosted C6) can auto-reconnect on boot. But it **only writes the endpoint at provision time and never refreshes it.** When the daemon's host IP changes — DHCP drift, or the host briefly holding two addresses on one subnet — the board reloads the **stale saved IP on every reboot**, connects to a dead endpoint, and loops on `connection reset by peer` (errno 104).

This reads as an unstable / rebooting board, but the **MCU never actually resets** — I confirmed on serial that uptime is continuous through the whole loop; it's the WS reconnect churn (display re-init on each drop) that looks like a reboot.

Root cause reproduced live: the board had persisted the host's old `192.168.68.60` and kept chasing it after the host moved to `.100`.

## Fix
The `networkTask` mDNS path already rediscovers the daemon at its new address and updates the in-RAM `currentBridgeIp` / `g_state` — it just never persisted it. Persist the freshly-discovered endpoint there so the board **self-heals across reboots** instead of chasing the stale saved IP forever.

`wifiSaveProvisionedBridge()` has a `BOARD_IPS10`-guarded body (no-op elsewhere), so the added call is safe on every board.

```diff
                     strncpy(currentBridgeIp, bridge.ip, sizeof(currentBridgeIp) - 1);
                     currentBridgePort = bridge.port;
+                    Net::wifiSaveProvisionedBridge(bridge.ip, bridge.port, bridge.token);
                     if (Net::wsConnected()) Net::wsDisconnect();
```

## Verification
- `pio run -e ips10` (persist body active) — green
- `pio run -e ttgo` (no-op path) — green

## Follow-up (not in this PR)
Even with the correct endpoint, IPS10's C6 WiFi-WS still **flaps under USB-serial coexistence** (WS reset ~every 5s; measured WiFi-up in only ~1/8 samples). The board is fully stable over serial/USB — this is the chronic P4+C6 hosted-radio issue. The documented cure is to **park the radio when USB serial is the active transport** (as `BOARD_TTGO`/`BOARD_LED8X32` already do), but `wifiSetRadioParked()` behavior on the hosted C6 is unverified, so it belongs in a separate hardware-tested change. Battery-side "infinite reboot" is separately consistent with IPS10's known brownout-bootloop (P4+C6+10" panel needs a solid 2A supply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)