### PR TITLE
fix(claude): UTF-8 stdin + POST body in Windows hook one-liner

### DIFF
--- a/hooks/src/__tests__/install.test.ts
+++ b/hooks/src/__tests__/install.test.ts
@@ -77,6 +77,19 @@ describe('Hook Installer', () => {
       expect(cmd).not.toContain('Library/Containers/bound.serendipity');
       expect(cmd).not.toContain('group.bound.serendipity');
     });
+
+    it('reads stdin and posts the body as UTF-8', () => {
+      const cmd = buildHookCommandWin('UserPromptSubmit');
+      // [Console]::In decodes with the console OEM codepage and string
+      // bodies get ISO-8859-1-encoded — both mangle non-ASCII payloads.
+      expect(cmd).toContain('StreamReader([Console]::OpenStandardInput(),[System.Text.Encoding]::UTF8)');
+      expect(cmd).toContain('[System.Text.Encoding]::UTF8.GetBytes($body)');
+      expect(cmd).not.toContain('[Console]::In.ReadToEnd()');
+      // The script rides inside the double-quoted -Command argument under
+      // cmd.exe — it must never contain a double quote of its own.
+      const inner = cmd.slice(cmd.indexOf('"') + 1, cmd.lastIndexOf('"'));
+      expect(inner).not.toContain('"');
+    });
   });
 
   describe('applyHooks', () => {

--- a/hooks/src/install.ts
+++ b/hooks/src/install.ts
@@ -84,6 +84,11 @@ export function buildHookCommand(eventName: string): string {
  * Single quotes are used inside the PowerShell script so the entire `-Command`
  * argument can stay double-quoted under cmd.exe. Errors are swallowed so a
  * dead daemon never blocks the host session.
+ *
+ * UTF-8 handling mirrors the Codex snippets in codex-install.ts: stdin is
+ * read through a UTF-8 StreamReader ([Console]::In decodes with the console
+ * OEM codepage) and the body is posted as UTF-8 bytes (Invoke-RestMethod
+ * encodes string bodies as ISO-8859-1, replacing non-ASCII text with '?').
  */
 export function buildHookCommandWin(eventName: string): string {
   const ps = [
@@ -91,8 +96,8 @@ export function buildHookCommandWin(eventName: string): string {
     `$port=$env:AGENTDECK_PORT`,
     `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $p=if($d.httpPort){$d.httpPort}else{$d.port}; if($p){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$p+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$p}catch{}}}catch{}}}`,
     `if(-not $port){$port=9120}`,
-    `$body=[Console]::In.ReadToEnd()`,
-    `try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$port+'/hooks/'+$ev) -Method Post -Body $body -ContentType 'application/json' -TimeoutSec 2 -ErrorAction Stop|Out-Null}catch{}`,
+    `$body=(New-Object System.IO.StreamReader([Console]::OpenStandardInput(),[System.Text.Encoding]::UTF8)).ReadToEnd()`,
+    `try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$port+'/hooks/'+$ev) -Method Post -Body ([System.Text.Encoding]::UTF8.GetBytes($body)) -ContentType 'application/json; charset=utf-8' -TimeoutSec 2 -ErrorAction Stop|Out-Null}catch{}`,
   ].join('; ');
   return `powershell -NoProfile -ExecutionPolicy Bypass -Command "${ps}"`;
 }


### PR DESCRIPTION
@
## Problem

`buildHookCommandWin` in `hooks/src/install.ts` had two encoding bugs (the same pair already fixed for the Codex snippets in `codex-install.ts`):

- `[Console]::In.ReadToEnd()` decodes piped stdin using the console **OEM codepage** (e.g. CP949 on Korean Windows).
- `Invoke-RestMethod` encodes a **string** body as ISO-8859-1.

Together these mangle any non-ASCII text (e.g. Korean prompts) in Claude Code hook payloads on Windows.

## Fix

- Read stdin through a UTF-8 `StreamReader` over `[Console]::OpenStandardInput()`.
- POST the body as UTF-8 **bytes** with `charset=utf-8`.

Existing installs self-migrate: `applyHooks` strips and re-adds the AgentDeck entries on the next `agentdeck claude` start.

## Verification

- Verified end-to-end on Windows 11 by executing the generated command string through `cmd.exe` (as Claude Code does) with a Korean/quoted payload piped to stdin against a mock daemon: byte-identical delivery to `/hooks/UserPromptSubmit`, exit 0.
- Unit test added (`reads stdin and posts the body as UTF-8`); `hooks/src/__tests__/install.test.ts` passes (25/25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@