### PR TITLE
fix(bridge): correctly render AskUserQuestion / permission / diff prompts on the deck

### DIFF
--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -2423,6 +2423,33 @@ describe('OutputParser', () => {
       expect(events[0].options).toHaveLength(4);
     });
 
+    it('a stale markdown "1." line from chat must not overwrite the ❯-marked option', () => {
+      const p = armParser();
+      const events: any[] = [];
+      p.on('option_prompt', (d) => events.push(d));
+      p.on('permission_prompt', (d) => events.push(d));
+
+      // Reproduces agentdeck-debug.log: a Bash approval prompt (❯ 1. Yes / 2. No)
+      // with a markdown numbered line from the ASSISTANT'S OWN chat message landing
+      // in the same scanned block. The stale "1." maps to index 0 with no cursor and
+      // must NOT clobber the real "❯ 1. Yes" — the ❯ cursor is authoritative.
+      // Long numbered prose line with the same shape as the captured case — keeps
+      // the `>` and `( )` characters (so label cleaning is still exercised) without
+      // embedding real conversation text.
+      p.feed([
+        'Do you want to proceed?',
+        '❯ 1. Yes',
+        '  2. No',
+        '',
+        '1. Lorem ipsum dolor sit amet > consectetur (adipiscing elit) sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam.',
+      ].join('\n'));
+      vi.advanceTimersByTime(200);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const opts: PromptOption[] = events[events.length - 1].options;
+      expect(opts.map((o) => o.label)).toEqual(['Yes', 'No']);
+    });
+
     it('still works with scrambled TUI order after backward scan', () => {
       const p = armParser();
       const events = collectEvents(p, 'option_prompt');

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -2741,6 +2741,51 @@ describe('OutputParser', () => {
     });
   });
 
+  // === AskUserQuestion tall prompt: full-width rule must not eat leading options ===
+  //
+  // Regression for the live bug captured in a `-d` session (agentdeck-debug.log,
+  // lines 2617-2620): AskUserQuestion draws a full-width horizontal rule between the
+  // trailing affordances. ANSI cursor-positioning strips its newline, so the rule
+  // (measured ~270 "───" triples) is glued onto the "Type something." label AND
+  // consumes the whole option-scan window, so the real leading options (a, b) fall
+  // outside `slice(-N)` and are never parsed — the trailing affordances then get
+  // re-indexed to slots 1-2 and `navigable=false` is emitted (stuck AWAITING).
+  describe('AskUserQuestion tall prompt with oversized separator', () => {
+    it('keeps leading options a/b when a giant box-drawing rule contaminates a later option', () => {
+      const p = armParser();
+      const events = collectEvents(p, 'option_prompt');
+
+      // Faithful to the live capture (agentdeck-debug.log DIAG dump): the giant
+      // rule is glued to option 3's label with no newline, AND the per-option
+      // descriptions render UNINDENTED (col 0) — both conditions must be handled.
+      const rule = '─── '.repeat(1000); // ~4000 chars
+
+      p.feed([
+        'Which option do you choose?',
+        '❯ 1. a',
+        'Option a.',   // unindented description, exactly as the TUI emits it
+        '',
+        '  2. b',
+        'Option b.',   // unindented description
+        '',
+        `  3. Type something.${rule}`,
+        '4. Chat about this',
+        '',
+        'Enter to select · ↑/↓ to navigate · Esc to cancel',
+      ].join('\n'));
+      vi.advanceTimersByTime(200);
+
+      expect(events).toHaveLength(1);
+      const opts: PromptOption[] = events[0].options;
+      // All four real options survive, at their true indices, label de-contaminated.
+      expect(opts.map((o) => o.label)).toEqual(['a', 'b', 'Type something.', 'Chat about this']);
+      expect(opts.map((o) => o.index)).toEqual([0, 1, 2, 3]);
+      // The ❯ cursor row (option a) must be in view so the deck can drive the UI.
+      expect(events[0].navigable).toBe(true);
+      expect(events[0].cursorIndex).toBe(0);
+    });
+  });
+
   // === Hierarchical CC prompt shapes ===
   //
   // Claude Code 2.x surfaces richer prompts than simple yes/no/always: plan

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -665,6 +665,29 @@ describe('OutputParser', () => {
       expect(seen).toContain('working');
       expect(seen).not.toContain('idle');
     });
+
+    it('still reaches AWAITING when a spinner floods the buffer AFTER the prompt', () => {
+      // Live regression: a diff/edit approval appears while a build spinner is
+      // running; the spinner status line ("✢ Flambéing…") then redraws every
+      // ~100ms, flooding the buffer so the ❯ options scroll far past the narrow
+      // navigable-prompt window. The prompt must still emit (deck AWAITING), not
+      // get cancelled into idle.
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+      const events: any[] = [];
+      p.on('option_prompt', (d) => events.push(d));
+      p.on('permission_prompt', (d) => events.push(d));
+
+      p.feed('✳'); // spinner active (build running)
+      p.feed('Do you want to make this edit?\n❯ 1. Yes\n  2. Yes, allow all edits\n  3. No\n');
+      // Spinner status redraws flood the buffer after the prompt.
+      for (let i = 0; i < 80; i++) p.feed('✢ Flambéing…\n');
+      vi.advanceTimersByTime(300);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const opts: PromptOption[] = events[events.length - 1].options;
+      expect(opts.map((o) => o.label)).toEqual(['Yes', 'Yes, allow all edits', 'No']);
+    });
   });
 
   // === Idle Cancels Option Timer ===

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -626,6 +626,47 @@ describe('OutputParser', () => {
     });
   });
 
+  // === Spinner concurrent with a navigable prompt ===
+  //
+  // Claude Code animates a status spinner (✻/✽) at the same time a permission /
+  // option prompt is on screen. Those spinner chunks must NOT cancel the pending
+  // option debounce — otherwise the prompt never emits and the deck sits at
+  // idle/processing instead of AWAITING (observed live: a Yes/No prompt that never
+  // surfaced on the deck). The ❯ cursor distinguishes a real navigable prompt from
+  // a bare numbered list, so only ❯-marked prompts suppress the spinner.
+  describe('spinner concurrent with a navigable prompt', () => {
+    it('still emits the prompt (AWAITING) when spinner chars keep arriving alongside it', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500); // clear boot idle timer
+      const events: any[] = [];
+      p.on('option_prompt', (d) => events.push(d));
+      p.on('permission_prompt', (d) => events.push(d));
+
+      p.feed('✳');                                            // spinner active (Claude animating)
+      p.feed('Do you want to proceed?\n❯ 1. Yes\n  2. No\n'); // prompt arrives during spinner
+      p.feed('✻');                                            // concurrent spinner char — must NOT cancel the prompt
+      vi.advanceTimersByTime(200);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const opts: PromptOption[] = events[events.length - 1].options;
+      expect(opts.map((o) => o.label)).toEqual(['Yes', 'No']);
+    });
+
+    it('a spinner char marks the agent working (spinner_start), never idle, when no prompt is present', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+      const seen: string[] = [];
+      p.on('spinner_start', () => seen.push('working'));
+      p.on('idle', () => seen.push('idle'));
+
+      p.feed('✻ Running a command\n');
+      vi.advanceTimersByTime(100);
+
+      expect(seen).toContain('working');
+      expect(seen).not.toContain('idle');
+    });
+  });
+
   // === Idle Cancels Option Timer ===
 
   describe('idle vs option debounce', () => {

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -688,6 +688,26 @@ describe('OutputParser', () => {
       const opts: PromptOption[] = events[events.length - 1].options;
       expect(opts.map((o) => o.label)).toEqual(['Yes', 'Yes, allow all edits', 'No']);
     });
+
+    it('emits AWAITING when a spinner char and the ❯ prompt arrive in the SAME initial chunk', () => {
+      // First-chunk hole: the spinner-suppression branch must FALL THROUGH to option
+      // detection, not `return`. If a single PTY batch glues a status spinner char
+      // onto the navigable AskUserQuestion prompt, an early return would skip arming
+      // the option timer and AWAITING would never emit. The prompt must still surface.
+      const p = armParser();
+      vi.advanceTimersByTime(500); // clear boot idle timer
+      const events: any[] = [];
+      p.on('option_prompt', (d) => events.push(d));
+      p.on('permission_prompt', (d) => events.push(d));
+
+      // Spinner + question + ❯ options all in one feed() — no prior spinner chunk.
+      p.feed('✳ Cooking…\nWhich approach?\n❯ 1. Refactor now\n  2. Ship first\n  3. Ask me later\n');
+      vi.advanceTimersByTime(300);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const opts: PromptOption[] = events[events.length - 1].options;
+      expect(opts.map((o) => o.label)).toEqual(['Refactor now', 'Ship first', 'Ask me later']);
+    });
   });
 
   // === Idle Cancels Option Timer ===

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -779,7 +779,7 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
 
 export async function startDaemon(opts: DaemonOptions): Promise<void> {
   if (opts.debug) {
-    enableDebugLog('/tmp/agentdeck-debug.log');
+    enableDebugLog();
     log('[agentdeck] Debug logging enabled');
   }
 

--- a/bridge/src/logger.ts
+++ b/bridge/src/logger.ts
@@ -1,4 +1,6 @@
 import { createWriteStream, type WriteStream } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 let debugStream: WriteStream | null = null;
 let debugEnabled = false;
@@ -6,9 +8,11 @@ let ptyMode = false;
 
 /**
  * Enable debug logging to a file. This avoids interfering with PTY terminal.
- * User can `tail -f /tmp/agentdeck-debug.log` in another terminal.
+ * Defaults to the OS temp dir (portable — `/tmp` on macOS/Linux, `%TEMP%` on
+ * Windows, where a hardcoded `/tmp/...` resolves to a bogus `<drive>:\tmp\...`
+ * and silently writes nothing). `tail -f "$(node -e 'console.log(require("os").tmpdir())')/agentdeck-debug.log"`.
  */
-export function enableDebugLog(path = '/tmp/agentdeck-debug.log'): void {
+export function enableDebugLog(path = join(tmpdir(), 'agentdeck-debug.log')): void {
   debugStream = createWriteStream(path, { flags: 'w' });
   debugEnabled = true;
   debugStream.write(`[agentdeck] Debug log started at ${new Date().toISOString()}\n`);

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -15,6 +15,21 @@ const DIFF_PROMPT = /\(V\)iew diff.*\(A\)pply.*\(D\)eny|\(a\)pply.*\(d\)eny.*\(v
 const OPTION_NUMBERED = /^\s*❯?\s*\d{1,2}[.)]\s*.+/m;
 const OPTION_BULLET = /^\s*[►▸●○]\s+.+/m;
 
+// Bounded window (chars) the option-block parser scans back over. Must fit a tall
+// AskUserQuestion prompt (question + per-option descriptions + trailing
+// affordances) once oversized rules are collapsed (see BOX_RULE_RUN). The
+// backward block-scan + longest-run filter in parseOptions keep stale numbered
+// lists from earlier in the buffer out, so extra headroom is safe.
+const OPTION_SCAN_WINDOW = 3000;
+
+// Oversized full-width rule. Claude Code's AskUserQuestion draws a horizontal rule
+// (─────) between options; ANSI cursor positioning strips its newline, so hundreds
+// of box-drawing chars (U+2500–U+257F, optionally interspersed with the spaces the
+// cursor-forward→space step inserts) get glued onto the adjacent option label AND
+// exhaust OPTION_SCAN_WINDOW — dropping the real leading options. Collapse any long
+// run to a short newline-delimited rule.
+const BOX_RULE_RUN = /(?:[─-╿][ \t]*){12,}/g;
+
 // Claude Code uses ❯ as its prompt char. May have \u00A0 (nbsp) or spaces around it.
 // v2.1.49+: autocomplete suggestions appear on the same line (e.g. "❯ Try "refactor..."")
 // so we can't require end-of-line. Just check for ❯ at start of line.
@@ -184,7 +199,12 @@ export class OutputParser extends EventEmitter {
       .replace(/\x1b\[\d*(?:;\d*)?[Hf]/g, '\n') // CUP/HVP → newline
       .replace(/\x1b\[\d*[ABEF]/g, '\n');        // CUU/CUD/CNL/CPL → newline
     const clean = stripAnsi(spaced);
-    this.buffer += clean;
+    // Collapse oversized box-drawing rules (AskUserQuestion full-width separators)
+    // before buffering. A newline-stripped rule otherwise glues hundreds of box
+    // chars onto the adjacent option label AND exhausts the bounded option-scan
+    // window, dropping the real leading options. Raw `clean` is still used for the
+    // chunk-level pattern triggers below.
+    this.buffer += clean.replace(BOX_RULE_RUN, '\n──\n');
 
     if (this.buffer.length > 8192) {
       this.buffer = this.buffer.slice(-4096);
@@ -468,7 +488,7 @@ export class OutputParser extends EventEmitter {
       // numbered/bulleted lines, box-drawing chrome, cursor overwrite, and
       // recommended/selected, and block-scopes so unrelated numbered response
       // text isn't pulled in.
-      const rich = this.parseOptions(this.buffer.slice(-2000));
+      const rich = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
       if (rich.options.length >= 2) {
         const options = rich.options.map(opt => ({
           ...opt,
@@ -525,7 +545,7 @@ export class OutputParser extends EventEmitter {
       this.resetOptionTimer();
       this.optionTimer = setTimeout(() => {
         this.optionTimer = null;
-        const parsed = this.parseOptions(this.buffer.slice(-2000));
+        const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
         if (parsed.options.length > 0) {
           // Check if this looks like a permission prompt (Yes/No style from tool approval)
           if (this.looksLikePermission(parsed.options) && !this.isCursorSelectionUI()) {
@@ -576,7 +596,7 @@ export class OutputParser extends EventEmitter {
         this.resetOptionTimer();
         this.optionTimer = setTimeout(() => {
           this.optionTimer = null;
-          const parsed = this.parseOptions(this.buffer.slice(-2000));
+          const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
           if (parsed.navigable) {
             // Options still present — emit cursor_update if index changed
             if (parsed.cursorIndex !== this.lastCursorIndex) {
@@ -609,7 +629,7 @@ export class OutputParser extends EventEmitter {
       this.resetOptionTimer();
       this.optionTimer = setTimeout(() => {
         this.optionTimer = null;
-        const parsed = this.parseOptions(this.buffer.slice(-2000));
+        const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
         if (parsed.navigable && parsed.cursorIndex !== this.lastCursorIndex) {
           this.lastCursorIndex = parsed.cursorIndex;
           debug('Parser', `EMIT cursor_update (ANSI reposition): cursorIndex=${parsed.cursorIndex}`);
@@ -1021,13 +1041,18 @@ export class OutputParser extends EventEmitter {
       } else if (line.trim() === '' || sepRe.test(line)) {
         // Blank or separator line — always tolerate (TUI redraws create variable blank runs)
         blockStart--;
-      } else if (foundOption && /^\s/.test(line)) {
-        // Indented text line — likely option description, tolerate within limit
+      } else if (foundOption && (/^\s/.test(line) || optLineRe.test(allLines[blockStart - 2] ?? ''))) {
+        // Option description between options. Two shapes: classic INDENTED text,
+        // OR an UNINDENTED (col 0) description sitting directly under its option —
+        // which is how Claude Code's AskUserQuestion renders them. For the
+        // unindented case we require an option on the line directly above, so the
+        // scan can't bridge into a stale numbered list separated from the real
+        // prompt by prose (e.g. "Would you like to proceed?"). Tolerate within limit.
         descGap++;
         if (descGap > MAX_DESC_GAP) break;
         blockStart--;
       } else {
-        // Unindented text or no options found yet — hard block boundary
+        // Unindented prose (not a description) or no option seen yet — hard boundary.
         break;
       }
     }
@@ -1113,8 +1138,15 @@ export class OutputParser extends EventEmitter {
       }
     }
     if (currentRun.length > bestRun.length) bestRun = currentRun;
-    // Re-index to 0-based for downstream consumers
-    const contiguous = bestRun.map((opt, i) => ({ ...opt, index: i }));
+    // Re-index to 0-based ONLY when the leading options were genuinely truncated
+    // off the top (run doesn't start at option 0 — e.g. a long list scrolled so
+    // "1." was cut off). When option 0 is present we keep the true parsed indices
+    // so `select_option` targets the right cursor row — never silently renumber a
+    // trailing subset as 1..N when the real leading options exist but were dropped.
+    const runStart = bestRun.length > 0 ? bestRun[0].index : 0;
+    const contiguous = runStart > 0
+      ? bestRun.map((opt, i) => ({ ...opt, index: i }))
+      : bestRun.map((opt) => ({ ...opt }));
     const finalOptions = contiguous.length >= 2 ? contiguous : sorted;
     return { options: finalOptions, navigable, cursorIndex };
   }

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -1063,14 +1063,21 @@ export class OutputParser extends EventEmitter {
 
     // Use a Map keyed by index so later (newer) lines overwrite earlier (stale) ones
     const byIndex = new Map<number, PromptOption>();
+    // Indices whose option carried the ❯ cursor — authoritative for the ACTIVE
+    // prompt. A ❯-marked option must never be clobbered by a later non-cursor
+    // line at the same index (e.g. a stale markdown "1. …" from chat scrollback
+    // that got scanned into this block).
+    const cursorLocked = new Set<number>();
     for (const line of lines) {
       const hasCursor = /^\s*❯/.test(line);
       const nm = line.match(/^\s*❯?\s*(\d{1,2})[.)]\s*(.+)/);
       if (nm) {
         const idx = parseInt(nm[1], 10) - 1;
+        if (!hasCursor && cursorLocked.has(idx)) continue;
         if (hasCursor) {
           navigable = true;
           cursorIndex = idx;
+          cursorLocked.add(idx);
         }
         let raw = nm[2].trim();
         // Strip TUI footer text concatenated after last option (no newline from cursor positioning)

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -435,6 +435,16 @@ export class OutputParser extends EventEmitter {
       // This prevents matching spinner chars in large text blocks (responses, banners)
       const nonWs = chunk.replace(/\s/g, '').length;
       if (nonWs < 80) {
+        // A spinner char while a ❯-marked navigable prompt is on screen is Claude
+        // Code's concurrent status animation, NOT processing. Treating it as a
+        // spinner here would cancel the pending option debounce below and leave the
+        // deck stuck at idle/processing instead of AWAITING. Ignore it and let the
+        // prompt path emit. (A bare numbered list without ❯ still cancels — see the
+        // "spinner cancels option timer" case.)
+        if (this.bufferHasNavigablePrompt()) {
+          debug('Parser', 'spinner char ignored — navigable prompt on screen');
+          return;
+        }
         if (!this.spinnerActive) {
           this.spinnerActive = true;
           this.clearSuggestion();
@@ -997,6 +1007,16 @@ export class OutputParser extends EventEmitter {
   private isCursorSelectionUI(): boolean {
     const tail = this.buffer.slice(-500);
     return /Enter\s*to\s*confirm/i.test(tail);
+  }
+
+  /**
+   * True when a ❯-marked numbered option (a navigable selection/permission prompt)
+   * is currently on screen. Used to suppress the concurrent status spinner so its
+   * chunks don't cancel the pending option prompt — the ❯ cursor is what
+   * distinguishes an active prompt from a bare numbered list in response text.
+   */
+  private bufferHasNavigablePrompt(): boolean {
+    return /❯[ \t ]*\d{1,2}[.)]/.test(this.buffer.slice(-600));
   }
 
   /** Check if numbered options look like a permission prompt (Yes/No/Always style) */

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -461,34 +461,39 @@ export class OutputParser extends EventEmitter {
         // A spinner char while a ❯-marked navigable prompt is on screen is Claude
         // Code's concurrent status animation, NOT processing. Treating it as a
         // spinner here would cancel the pending option debounce below and leave the
-        // deck stuck at idle/processing instead of AWAITING. Ignore it and let the
-        // prompt path emit. (A bare numbered list without ❯ still cancels — see the
-        // "spinner cancels option timer" case.)
+        // deck stuck at idle/processing instead of AWAITING. Skip the spinner
+        // activation but DELIBERATELY fall through to the prompt/option detection
+        // below — never `return` — so AWAITING still arms even when the spinner and
+        // the ❯ prompt land in the SAME initial chunk (a first-chunk hole: returning
+        // here would skip option-timer arming and the prompt would never emit). (A
+        // bare numbered list without ❯ still cancels — see the "spinner cancels
+        // option timer" case.)
         if (this.bufferHasNavigablePrompt() || this.recentInteractivePrompt()) {
           // Re-arm from the buffer too, so a long-lived prompt keeps suppressing
           // even after its detection chunk aged out of the time window.
           if (this.bufferHasNavigablePrompt()) this.lastInteractivePromptAt = Date.now();
-          debug('Parser', 'spinner char ignored — navigable prompt on screen');
+          debug('Parser', 'spinner char ignored — navigable prompt on screen; falling through to prompt parsing');
+          // No return: control continues to the option/permission detection below.
+        } else {
+          if (!this.spinnerActive) {
+            this.spinnerActive = true;
+            this.clearSuggestion();
+            debug('Parser', 'EMIT spinner_start');
+            this.emit('spinner_start');
+          }
+          this.resetSpinnerTimer();
+          this.spinnerTimer = setTimeout(() => {
+            if (this.spinnerActive) {
+              this.spinnerActive = false;
+              debug('Parser', 'EMIT spinner_stop (debounced)');
+              this.emit('spinner_stop');
+            }
+          }, SPINNER_DEBOUNCE_MS);
+          // Cancel idle & option timers — we're processing now
+          this.resetIdleTimer();
+          this.resetOptionTimer();
           return;
         }
-        if (!this.spinnerActive) {
-          this.spinnerActive = true;
-          this.clearSuggestion();
-          debug('Parser', 'EMIT spinner_start');
-          this.emit('spinner_start');
-        }
-        this.resetSpinnerTimer();
-        this.spinnerTimer = setTimeout(() => {
-          if (this.spinnerActive) {
-            this.spinnerActive = false;
-            debug('Parser', 'EMIT spinner_stop (debounced)');
-            this.emit('spinner_stop');
-          }
-        }, SPINNER_DEBOUNCE_MS);
-        // Cancel idle & option timers — we're processing now
-        this.resetIdleTimer();
-        this.resetOptionTimer();
-        return;
       }
     }
 

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -84,6 +84,11 @@ const SPINNER_DEBOUNCE_MS = 2000;
 const IDLE_DEBOUNCE_MS = 300;
 const OPTION_DEBOUNCE_MS = 150;
 const SUGGESTION_DEBOUNCE_MS = 500;
+// After an interactive prompt (❯ options / permission / diff) is detected, Claude
+// Code keeps animating a status spinner alongside it. For this window we treat
+// spinner/idle signals as that concurrent animation — not real processing/idle —
+// so the prompt reliably reaches AWAITING instead of being cancelled into idle.
+const INTERACTIVE_PROMPT_SUPPRESS_MS = 1500;
 
 // Ghost text: ANSI segment extractor — captures one or more consecutive SGR sequences
 // followed by visible text. Handles stacked escapes like \x1b[38;2;r;g;bm\x1b[3mtext
@@ -169,6 +174,8 @@ export class OutputParser extends EventEmitter {
   // from user prompt echo (❯ text) in the same PTY batch
   private interactiveCooldown: ReturnType<typeof setTimeout> | null = null;
   private remoteUrl: string | null = null;
+  /** Wall-clock ms of the last interactive-prompt detection (spinner/idle suppression). */
+  private lastInteractivePromptAt = 0;
 
   feed(rawData: string): void {
     const data = this.pendingAnsi + rawData;
@@ -394,6 +401,16 @@ export class OutputParser extends EventEmitter {
       DIFF_PROMPT.test(chunk) || YES_NO_ALWAYS.test(chunk) ||
       PERMISSION_YN.test(chunk) ||
       OPTION_NUMBERED.test(chunk) || OPTION_BULLET.test(chunk);
+    // Arm the suppression window only for a REAL prompt — a ❯-marked navigable
+    // option, or a permission/diff prompt — so a concurrent status spinner that
+    // later floods the buffer can't cancel it into idle. A bare numbered list in
+    // response text (no ❯) must NOT arm it; a spinner should still cancel that.
+    if (
+      DIFF_PROMPT.test(chunk) || YES_NO_ALWAYS.test(chunk) || PERMISSION_YN.test(chunk) ||
+      /^\s*❯\s*\d{1,2}[.)]/m.test(chunk)
+    ) {
+      this.lastInteractivePromptAt = Date.now();
+    }
 
     // --- Spinner + prompt handling ---
     if (this.spinnerActive) {
@@ -407,6 +424,12 @@ export class OutputParser extends EventEmitter {
         this.emit('spinner_stop');
         // Fall through to prompt detection below
       } else if (hasIdlePrompt) {
+        // A ❯ during the suppression window is the option cursor of a live prompt,
+        // not the idle input line — don't emit idle (deck must stay AWAITING).
+        if (this.recentInteractivePrompt()) {
+          debug('Parser', 'idle prompt ignored — interactive prompt on screen');
+          return;
+        }
         // Idle prompt during spinner — but ignore if chunk is large (screen redraw).
         // Real idle prompts come in small chunks; screen redraws include ❯ in 200+ char chunks.
         const nonWs = chunk.replace(/\s/g, '').length;
@@ -441,7 +464,10 @@ export class OutputParser extends EventEmitter {
         // deck stuck at idle/processing instead of AWAITING. Ignore it and let the
         // prompt path emit. (A bare numbered list without ❯ still cancels — see the
         // "spinner cancels option timer" case.)
-        if (this.bufferHasNavigablePrompt()) {
+        if (this.bufferHasNavigablePrompt() || this.recentInteractivePrompt()) {
+          // Re-arm from the buffer too, so a long-lived prompt keeps suppressing
+          // even after its detection chunk aged out of the time window.
+          if (this.bufferHasNavigablePrompt()) this.lastInteractivePromptAt = Date.now();
           debug('Parser', 'spinner char ignored — navigable prompt on screen');
           return;
         }
@@ -1016,7 +1042,18 @@ export class OutputParser extends EventEmitter {
    * distinguishes an active prompt from a bare numbered list in response text.
    */
   private bufferHasNavigablePrompt(): boolean {
-    return /❯[ \t ]*\d{1,2}[.)]/.test(this.buffer.slice(-600));
+    return /❯[ \t ]*\d{1,2}[.)]/.test(this.buffer.slice(-2000)); // wide: a concurrent spinner redraws every ~100ms
+  }
+
+  /**
+   * True within INTERACTIVE_PROMPT_SUPPRESS_MS of the last interactive-prompt
+   * detection. A time-based backstop to `bufferHasNavigablePrompt`: it holds even
+   * when a flooding spinner has pushed the ❯ options out of the buffer window,
+   * so the prompt reliably reaches AWAITING instead of flickering to idle.
+   */
+  private recentInteractivePrompt(): boolean {
+    return this.lastInteractivePromptAt > 0 &&
+      Date.now() - this.lastInteractivePromptAt < INTERACTIVE_PROMPT_SUPPRESS_MS;
   }
 
   /** Check if numbered options look like a permission prompt (Yes/No/Always style) */


### PR DESCRIPTION
## Summary

A series of related fixes to the Claude Code PTY output parser (`bridge/src/output-parser.ts`) so interactive prompts — `AskUserQuestion`, permission approvals, diff/edit approvals — render correctly on the Stream Deck / D200H instead of showing the wrong options, a stale option, or a false **idle**. Each was root-caused from a live `-d` capture and locked with a regression test.

## Commits / fixes

**1. Parse all `AskUserQuestion` options (`e3788fd3`)**
An `AskUserQuestion` prompt (e.g. `a`, `b` + Claude's `Type something.` / `Chat about this` affordances) rendered with the real leading options **dropped** — the trailing affordances got renumbered as slots 1–2. Two compounding causes: the descriptions render **unindented** (col 0), so the option-block backward scan broke on them and cut off the leading options; and a full-width `────` rule between options got its newline stripped, gluing hundreds of box chars onto the adjacent label and exhausting the scan window. Fix: tolerate an unindented description **only when an option sits directly above** (still excludes stale numbered lists), collapse oversized box-drawing rules at buffer-build time, widen/name the option-scan window, and gate the 0-based re-index to genuine truncation. Also made the debug-log path portable (`os.tmpdir()`), since the hardcoded `/tmp` silently wrote nothing on Windows.

**2. Stale numbered prose can't overwrite the `❯` option (`d8bd37b4`)**
A markdown `1. …` line from the assistant's own chat scrollback could be scanned into the option block and, mapping to index 0 with no cursor, **overwrite the real `❯ 1. Yes`** — so a Yes/No prompt rendered as `[<prose>, No]`. Fix: a `❯`-marked option is authoritative for its index; a later non-cursor line at the same index can no longer clobber it.

**3. Show AWAITING when a prompt coincides with the spinner (`4ed10b06`)**
Claude Code animates a status spinner (`✻`/`✽`) at the same time a permission/option prompt is on screen. Each spinner chunk was cancelling the pending option debounce, so the prompt never emitted and the deck sat at idle/processing instead of AWAITING. Fix: ignore a spinner char while a `❯`-marked navigable prompt is on screen (the `❯` distinguishes a real prompt from a numbered list in prose; the "spinner cancels option timer" bare-list case is untouched). An active spinner with no prompt still reads as working, never idle.

**4. Keep AWAITING when a spinner floods the buffer after a prompt (`ed07a415`)**
The remaining case: a diff/edit approval that appears while a build spinner runs still went idle. The `✻/✽` status line redraws every ~100ms and floods the linear buffer, pushing the `❯` options past the buffer window within a few hundred ms → the spinner cancels the option debounce → the state machine flips AWAITING → processing → idle. The buffer-tail check can't win that race (the linear buffer doesn't reflect screen position), so a **time-based backstop** was added: arm a suppression window when a *real* prompt is detected (`❯`-marked / permission / diff — never a bare numbered list), and for ~1.5s treat spinner/idle signals as the concurrent animation (don't cancel the debounce, don't emit idle). Re-armed from the buffer so a long-lived prompt keeps suppressing; the navigable-prompt window was also widened 600 → 2000.

## Tests

Each fix ships a regression test in `bridge/src/__tests__/output-parser.test.ts` reproducing the exact captured shape (unindented descriptions + giant rule; a stale `1.` prose line below a `❯` prompt; a prompt with concurrent spinner chunks; a prompt followed by 80 spinner status redraws). The existing prompt-shape and "spinner cancels option timer / stale numbered list" guards stay green. Full `output-parser.test.ts` (219) and full bridge suite (1171 / 2 skipped) pass.

## Verification

All four were reproduced and fixed end-to-end on a live `-d` session driving a Stream Deck — the deck now shows the real options and reaches AWAITING for `AskUserQuestion`, Yes/No permission, and diff/edit approvals, including while a build spinner is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
