### PR TITLE
fix(bridge): preserve complete navigable prompt options

### DIFF
--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -2423,6 +2423,33 @@ describe('OutputParser', () => {
       expect(events[0].options).toHaveLength(4);
     });
 
+    it('a stale markdown "1." line from chat must not overwrite the ❯-marked option', () => {
+      const p = armParser();
+      const events: any[] = [];
+      p.on('option_prompt', (d) => events.push(d));
+      p.on('permission_prompt', (d) => events.push(d));
+
+      // Reproduces agentdeck-debug.log: a Bash approval prompt (❯ 1. Yes / 2. No)
+      // with a markdown numbered line from the ASSISTANT'S OWN chat message landing
+      // in the same scanned block. The stale "1." maps to index 0 with no cursor and
+      // must NOT clobber the real "❯ 1. Yes" — the ❯ cursor is authoritative.
+      // Long numbered prose line with the same shape as the captured case — keeps
+      // the `>` and `( )` characters (so label cleaning is still exercised) without
+      // embedding real conversation text.
+      p.feed([
+        'Do you want to proceed?',
+        '❯ 1. Yes',
+        '  2. No',
+        '',
+        '1. Lorem ipsum dolor sit amet > consectetur (adipiscing elit) sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam.',
+      ].join('\n'));
+      vi.advanceTimersByTime(200);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const opts: PromptOption[] = events[events.length - 1].options;
+      expect(opts.map((o) => o.label)).toEqual(['Yes', 'No']);
+    });
+
     it('still works with scrambled TUI order after backward scan', () => {
       const p = armParser();
       const events = collectEvents(p, 'option_prompt');

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -2741,6 +2741,51 @@ describe('OutputParser', () => {
     });
   });
 
+  // === AskUserQuestion tall prompt: full-width rule must not eat leading options ===
+  //
+  // Regression for the live bug captured in a `-d` session (agentdeck-debug.log,
+  // lines 2617-2620): AskUserQuestion draws a full-width horizontal rule between the
+  // trailing affordances. ANSI cursor-positioning strips its newline, so the rule
+  // (measured ~270 "───" triples) is glued onto the "Type something." label AND
+  // consumes the whole option-scan window, so the real leading options (a, b) fall
+  // outside `slice(-N)` and are never parsed — the trailing affordances then get
+  // re-indexed to slots 1-2 and `navigable=false` is emitted (stuck AWAITING).
+  describe('AskUserQuestion tall prompt with oversized separator', () => {
+    it('keeps leading options a/b when a giant box-drawing rule contaminates a later option', () => {
+      const p = armParser();
+      const events = collectEvents(p, 'option_prompt');
+
+      // Faithful to the live capture (agentdeck-debug.log DIAG dump): the giant
+      // rule is glued to option 3's label with no newline, AND the per-option
+      // descriptions render UNINDENTED (col 0) — both conditions must be handled.
+      const rule = '─── '.repeat(1000); // ~4000 chars
+
+      p.feed([
+        'Which option do you choose?',
+        '❯ 1. a',
+        'Option a.',   // unindented description, exactly as the TUI emits it
+        '',
+        '  2. b',
+        'Option b.',   // unindented description
+        '',
+        `  3. Type something.${rule}`,
+        '4. Chat about this',
+        '',
+        'Enter to select · ↑/↓ to navigate · Esc to cancel',
+      ].join('\n'));
+      vi.advanceTimersByTime(200);
+
+      expect(events).toHaveLength(1);
+      const opts: PromptOption[] = events[0].options;
+      // All four real options survive, at their true indices, label de-contaminated.
+      expect(opts.map((o) => o.label)).toEqual(['a', 'b', 'Type something.', 'Chat about this']);
+      expect(opts.map((o) => o.index)).toEqual([0, 1, 2, 3]);
+      // The ❯ cursor row (option a) must be in view so the deck can drive the UI.
+      expect(events[0].navigable).toBe(true);
+      expect(events[0].cursorIndex).toBe(0);
+    });
+  });
+
   // === Hierarchical CC prompt shapes ===
   //
   // Claude Code 2.x surfaces richer prompts than simple yes/no/always: plan

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -799,7 +799,7 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
 
 export async function startDaemon(opts: DaemonOptions): Promise<void> {
   if (opts.debug) {
-    enableDebugLog('/tmp/agentdeck-debug.log');
+    enableDebugLog();
     log('[agentdeck] Debug logging enabled');
   }
 

--- a/bridge/src/logger.ts
+++ b/bridge/src/logger.ts
@@ -1,4 +1,6 @@
 import { createWriteStream, type WriteStream } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 let debugStream: WriteStream | null = null;
 let debugEnabled = false;
@@ -6,9 +8,11 @@ let ptyMode = false;
 
 /**
  * Enable debug logging to a file. This avoids interfering with PTY terminal.
- * User can `tail -f /tmp/agentdeck-debug.log` in another terminal.
+ * Defaults to the OS temp dir (portable — `/tmp` on macOS/Linux, `%TEMP%` on
+ * Windows, where a hardcoded `/tmp/...` resolves to a bogus `<drive>:\tmp\...`
+ * and silently writes nothing). `tail -f "$(node -e 'console.log(require("os").tmpdir())')/agentdeck-debug.log"`.
  */
-export function enableDebugLog(path = '/tmp/agentdeck-debug.log'): void {
+export function enableDebugLog(path = join(tmpdir(), 'agentdeck-debug.log')): void {
   debugStream = createWriteStream(path, { flags: 'w' });
   debugEnabled = true;
   debugStream.write(`[agentdeck] Debug log started at ${new Date().toISOString()}\n`);

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -15,6 +15,21 @@ const DIFF_PROMPT = /\(V\)iew diff.*\(A\)pply.*\(D\)eny|\(a\)pply.*\(d\)eny.*\(v
 const OPTION_NUMBERED = /^\s*❯?\s*\d{1,2}[.)]\s*.+/m;
 const OPTION_BULLET = /^\s*[►▸●○]\s+.+/m;
 
+// Bounded window (chars) the option-block parser scans back over. Must fit a tall
+// AskUserQuestion prompt (question + per-option descriptions + trailing
+// affordances) once oversized rules are collapsed (see BOX_RULE_RUN). The
+// backward block-scan + longest-run filter in parseOptions keep stale numbered
+// lists from earlier in the buffer out, so extra headroom is safe.
+const OPTION_SCAN_WINDOW = 3000;
+
+// Oversized full-width rule. Claude Code's AskUserQuestion draws a horizontal rule
+// (─────) between options; ANSI cursor positioning strips its newline, so hundreds
+// of box-drawing chars (U+2500–U+257F, optionally interspersed with the spaces the
+// cursor-forward→space step inserts) get glued onto the adjacent option label AND
+// exhaust OPTION_SCAN_WINDOW — dropping the real leading options. Collapse any long
+// run to a short newline-delimited rule.
+const BOX_RULE_RUN = /(?:[─-╿][ \t]*){12,}/g;
+
 // Claude Code uses ❯ as its prompt char. May have \u00A0 (nbsp) or spaces around it.
 // v2.1.49+: autocomplete suggestions appear on the same line (e.g. "❯ Try "refactor..."")
 // so we can't require end-of-line. Just check for ❯ at start of line.
@@ -184,7 +199,12 @@ export class OutputParser extends EventEmitter {
       .replace(/\x1b\[\d*(?:;\d*)?[Hf]/g, '\n') // CUP/HVP → newline
       .replace(/\x1b\[\d*[ABEF]/g, '\n');        // CUU/CUD/CNL/CPL → newline
     const clean = stripAnsi(spaced);
-    this.buffer += clean;
+    // Collapse oversized box-drawing rules (AskUserQuestion full-width separators)
+    // before buffering. A newline-stripped rule otherwise glues hundreds of box
+    // chars onto the adjacent option label AND exhausts the bounded option-scan
+    // window, dropping the real leading options. Raw `clean` is still used for the
+    // chunk-level pattern triggers below.
+    this.buffer += clean.replace(BOX_RULE_RUN, '\n──\n');
 
     if (this.buffer.length > 8192) {
       this.buffer = this.buffer.slice(-4096);
@@ -468,7 +488,7 @@ export class OutputParser extends EventEmitter {
       // numbered/bulleted lines, box-drawing chrome, cursor overwrite, and
       // recommended/selected, and block-scopes so unrelated numbered response
       // text isn't pulled in.
-      const rich = this.parseOptions(this.buffer.slice(-2000));
+      const rich = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
       if (rich.options.length >= 2) {
         const options = rich.options.map(opt => ({
           ...opt,
@@ -525,7 +545,7 @@ export class OutputParser extends EventEmitter {
       this.resetOptionTimer();
       this.optionTimer = setTimeout(() => {
         this.optionTimer = null;
-        const parsed = this.parseOptions(this.buffer.slice(-2000));
+        const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
         if (parsed.options.length > 0) {
           // Check if this looks like a permission prompt (Yes/No style from tool approval)
           if (this.looksLikePermission(parsed.options) && !this.isCursorSelectionUI()) {
@@ -576,7 +596,7 @@ export class OutputParser extends EventEmitter {
         this.resetOptionTimer();
         this.optionTimer = setTimeout(() => {
           this.optionTimer = null;
-          const parsed = this.parseOptions(this.buffer.slice(-2000));
+          const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
           if (parsed.navigable) {
             // Options still present — emit cursor_update if index changed
             if (parsed.cursorIndex !== this.lastCursorIndex) {
@@ -609,7 +629,7 @@ export class OutputParser extends EventEmitter {
       this.resetOptionTimer();
       this.optionTimer = setTimeout(() => {
         this.optionTimer = null;
-        const parsed = this.parseOptions(this.buffer.slice(-2000));
+        const parsed = this.parseOptions(this.buffer.slice(-OPTION_SCAN_WINDOW));
         if (parsed.navigable && parsed.cursorIndex !== this.lastCursorIndex) {
           this.lastCursorIndex = parsed.cursorIndex;
           debug('Parser', `EMIT cursor_update (ANSI reposition): cursorIndex=${parsed.cursorIndex}`);
@@ -1021,13 +1041,18 @@ export class OutputParser extends EventEmitter {
       } else if (line.trim() === '' || sepRe.test(line)) {
         // Blank or separator line — always tolerate (TUI redraws create variable blank runs)
         blockStart--;
-      } else if (foundOption && /^\s/.test(line)) {
-        // Indented text line — likely option description, tolerate within limit
+      } else if (foundOption && (/^\s/.test(line) || optLineRe.test(allLines[blockStart - 2] ?? ''))) {
+        // Option description between options. Two shapes: classic INDENTED text,
+        // OR an UNINDENTED (col 0) description sitting directly under its option —
+        // which is how Claude Code's AskUserQuestion renders them. For the
+        // unindented case we require an option on the line directly above, so the
+        // scan can't bridge into a stale numbered list separated from the real
+        // prompt by prose (e.g. "Would you like to proceed?"). Tolerate within limit.
         descGap++;
         if (descGap > MAX_DESC_GAP) break;
         blockStart--;
       } else {
-        // Unindented text or no options found yet — hard block boundary
+        // Unindented prose (not a description) or no option seen yet — hard boundary.
         break;
       }
     }
@@ -1113,8 +1138,15 @@ export class OutputParser extends EventEmitter {
       }
     }
     if (currentRun.length > bestRun.length) bestRun = currentRun;
-    // Re-index to 0-based for downstream consumers
-    const contiguous = bestRun.map((opt, i) => ({ ...opt, index: i }));
+    // Re-index to 0-based ONLY when the leading options were genuinely truncated
+    // off the top (run doesn't start at option 0 — e.g. a long list scrolled so
+    // "1." was cut off). When option 0 is present we keep the true parsed indices
+    // so `select_option` targets the right cursor row — never silently renumber a
+    // trailing subset as 1..N when the real leading options exist but were dropped.
+    const runStart = bestRun.length > 0 ? bestRun[0].index : 0;
+    const contiguous = runStart > 0
+      ? bestRun.map((opt, i) => ({ ...opt, index: i }))
+      : bestRun.map((opt) => ({ ...opt }));
     const finalOptions = contiguous.length >= 2 ? contiguous : sorted;
     return { options: finalOptions, navigable, cursorIndex };
   }

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -1063,14 +1063,21 @@ export class OutputParser extends EventEmitter {
 
     // Use a Map keyed by index so later (newer) lines overwrite earlier (stale) ones
     const byIndex = new Map<number, PromptOption>();
+    // Indices whose option carried the ❯ cursor — authoritative for the ACTIVE
+    // prompt. A ❯-marked option must never be clobbered by a later non-cursor
+    // line at the same index (e.g. a stale markdown "1. …" from chat scrollback
+    // that got scanned into this block).
+    const cursorLocked = new Set<number>();
     for (const line of lines) {
       const hasCursor = /^\s*❯/.test(line);
       const nm = line.match(/^\s*❯?\s*(\d{1,2})[.)]\s*(.+)/);
       if (nm) {
         const idx = parseInt(nm[1], 10) - 1;
+        if (!hasCursor && cursorLocked.has(idx)) continue;
         if (hasCursor) {
           navigable = true;
           cursorIndex = idx;
+          cursorLocked.add(idx);
         }
         let raw = nm[2].trim();
         // Strip TUI footer text concatenated after last option (no newline from cursor positioning)


### PR DESCRIPTION
## Summary
- preserve leading AskUserQuestion options when oversized TUI separators and unindented descriptions are present
- prevent stale numbered prose from replacing the cursor-marked option
- use the platform temporary directory for debug logs on Windows

This is the reviewed, low-risk subset of #55. It preserves Doug Warren’s original commits and authorship. The spinner lifecycle rewrite from that PR is intentionally excluded and tracked separately in #68.

## Verification
- `pnpm vitest run bridge/src/__tests__/output-parser.test.ts` (216 tests)
- `pnpm build`

Note: an initial bridge-only build used stale `shared` output after switching branches and failed on an unrelated missing export. The repository workflow (`pnpm build`, which builds `shared` first) passed.