### PR TITLE
fix(ci): refresh preview mirror pins after movement-only changes

### DIFF
--- a/apple/AgentDeck/Rendering/CreatureGeometry.swift
+++ b/apple/AgentDeck/Rendering/CreatureGeometry.swift
@@ -14,8 +14,8 @@
 // same commit. Note: Kotlin-side parser workarounds (e.g. normalizeSvgArcFlags)
 // don't change path geometry and only need a pin bump.
 // SYNC-HASH android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureGeometry.kt 572daa6ea96266eb0d0d6467bd06a0192c1c9457
-// SYNC-HASH android/app/src/main/kotlin/dev/agentdeck/terrarium/creature/CloudCreature.kt bb4ba5599a3f5b9c79042f42355388203090d5f7
-// SYNC-HASH android/app/src/main/kotlin/dev/agentdeck/terrarium/creature/OpenCodeCreature.kt 9a1f55256723685ab8305cdf23d70b3730fced90
+// SYNC-HASH android/app/src/main/kotlin/dev/agentdeck/terrarium/creature/CloudCreature.kt e33052a7d027b94029c01361b31b3cfc468868ab
+// SYNC-HASH android/app/src/main/kotlin/dev/agentdeck/terrarium/creature/OpenCodeCreature.kt b7e13109d9d18f6762db7d745317abbdcdd14c59
 //
 // Faithful scope: the Kotlin SSOT defines path geometry for the agent marks —
 //   • Octopus / Claude Code robot        (claudecode.svg,   viewBox 24)

--- a/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
+++ b/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
@@ -9,7 +9,7 @@
 // Sync pin — verified by `scripts/check-preview-mirror-sync.mjs` (CI). When the
 // origin changes, re-port (or confirm no visual impact given the deliberate
 // simplifications below) and bump the pin in the same commit.
-// SYNC-HASH bridge/src/tui/terrarium.ts fd825e4143f53222785fb293b789a1fd685309e8
+// SYNC-HASH bridge/src/tui/terrarium.ts 47a475ebde15a4333b3395deeb67f83cc00a2290
 //
 // Scope / deliberate simplifications (vs the TS original):
 //   - No Braille sprites: creatures render as 3-char ASCII glyphs colored by


### PR DESCRIPTION
## Summary
- refresh two Android creature-source pins after movement-only changes
- refresh the TUI renderer pin after crayfish-clearance positioning changes
- leave Apple mirror code unchanged because `CreatureGeometry` mirrors path data only and the TUI preview explicitly uses a simplified deterministic placement model

This repairs the failing Preview mirror sync check currently affecting unrelated PRs, including #70 and #71.

## Verification
- `node scripts/check-preview-mirror-sync.mjs` (10 pins across 6 mirrors in sync)
- `git diff --check`