### PR TITLE
Stop the daemon retrying a dead fallback port

### DIFF
--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		CFCABF9422E74B8CF2A23C7E /* CodexOtelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE1D983995443760EDE3A4A /* CodexOtelParserTests.swift */; };
 		D036600F5679C1A191132F87 /* SingletonGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5C866AF54937CD8E433F49 /* SingletonGuard.swift */; };
 		D0A70501108B295ED44C169E /* PortFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165A6BFF174139F6AF07CED /* PortFormatting.swift */; };
+		D0FB0E0FFBBCE44786BA9B51 /* DaemonPortFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */; };
 		D14972CEAF0D69E6918C86BA /* AgentDeckPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056D70153C3F720A6D935C9F /* AgentDeckPaths.swift */; };
 		D169DFD5EA54C323E1128E7B /* AgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F55435772A15B8F0E92C1 /* AgentState.swift */; };
 		D2335AB9E3A5DEE25405617F /* TimeboxProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A351E073AB448BEE1DA392 /* TimeboxProtocolTests.swift */; };
@@ -366,6 +367,7 @@
 		F1AA123E5D16742D2C7B003C /* apme-dashboard.html in Resources */ = {isa = PBXBuildFile; fileRef = 766909A21820E709DA63C7C2 /* apme-dashboard.html */; };
 		F1C357A840E59D7A188C808B /* OnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9965CED8937C8C1F27DFCC68 /* OnboardingScreen.swift */; };
 		F20373DB53552C2F36204EDF /* TerrariumConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403CDDF7DDFCF5D8702491EA /* TerrariumConfig.swift */; };
+		F30F046B8C2F044E12263AE8 /* DaemonPortFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */; };
 		F352145007826B5BE9683A3D /* WearableTabletPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B908900BFBC530F17EAB6 /* WearableTabletPreviews.swift */; };
 		F4150CA5E9A31CD575F69F0C /* SessionGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAB8DFED8E277FFB6136742 /* SessionGrouping.swift */; };
 		F42F09D300661953D5F0EAFF /* StateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA46D3D4A84FBDE6C8B3AB62 /* StateMachine.swift */; };
@@ -580,6 +582,7 @@
 		D8FF164B1E859BEE08BBF646 /* TopologyRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopologyRail.swift; sourceTree = "<group>"; };
 		DA46D3D4A84FBDE6C8B3AB62 /* StateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateMachine.swift; sourceTree = "<group>"; };
 		DA58B8921954E616F8ECCC53 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonPortFallbackTests.swift; sourceTree = "<group>"; };
 		DAF69E65D3118C105A193227 /* OpenClawTokenExtractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClawTokenExtractTests.swift; sourceTree = "<group>"; };
 		DBBD731AC01994F5C7C1A78A /* UsageAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClient.swift; sourceTree = "<group>"; };
 		DC62763B9E0E57235CFDACED /* NotificationPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermission.swift; sourceTree = "<group>"; };
@@ -670,6 +673,7 @@
 				0392D39F45022F762AFE6BE0 /* CodexConfigInstallerTests.swift */,
 				8BE1D983995443760EDE3A4A /* CodexOtelParserTests.swift */,
 				E84D819AA86894944600240C /* DaemonActorIndependenceTests.swift */,
+				DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */,
 				95997D1E19933CBB5A3F400D /* DeviceApprovalGateTests.swift */,
 				4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */,
 				C671E2324E45E6745813C681 /* ESP32WifiForwardTests.swift */,
@@ -1276,6 +1280,7 @@
 				00E9789B6EFDA8174842999D /* CodexConfigInstallerTests.swift in Sources */,
 				CFCABF9422E74B8CF2A23C7E /* CodexOtelParserTests.swift in Sources */,
 				5110D91D663BA602A485005E /* DaemonActorIndependenceTests.swift in Sources */,
+				F30F046B8C2F044E12263AE8 /* DaemonPortFallbackTests.swift in Sources */,
 				1DA82A36B17B48756691D2CD /* DeviceApprovalGateTests.swift in Sources */,
 				1D406D25862B20792A8293F3 /* DevicePreviewSnapshotTests.swift in Sources */,
 				AECF975059EA0A725DB1A3E7 /* ESP32WifiForwardTests.swift in Sources */,
@@ -1311,6 +1316,7 @@
 				23C366450AF88EC0E69DDD11 /* CodexConfigInstallerTests.swift in Sources */,
 				E55963FC1E5C23442A500CE4 /* CodexOtelParserTests.swift in Sources */,
 				A7560FE516D5460EB526FA3A /* DaemonActorIndependenceTests.swift in Sources */,
+				D0FB0E0FFBBCE44786BA9B51 /* DaemonPortFallbackTests.swift in Sources */,
 				53D37B6B6CCF9EFD0013F153 /* DeviceApprovalGateTests.swift in Sources */,
 				19CDAF0B79C1F843366192C0 /* DevicePreviewSnapshotTests.swift in Sources */,
 				5E3FCF09BE50281AE6749762 /* ESP32WifiForwardTests.swift in Sources */,

--- a/apple/AgentDeck/Daemon/DaemonService.swift
+++ b/apple/AgentDeck/Daemon/DaemonService.swift
@@ -133,6 +133,35 @@ final class DaemonService: ObservableObject {
         actualPort == configuredPort ? nil : actualPort
     }
 
+    /// Whether we should consider ourselves "already moved off the configured
+    /// port". Must stay paired with `sessionOverridePort` — see
+    /// `syncResolvedPortState`.
+    nonisolated static func resolvedFallbackAttempted(configuredPort: Int, actualPort: Int) -> Bool {
+        resolvedSessionOverridePort(configuredPort: configuredPort, actualPort: actualPort) != nil
+    }
+
+    /// Next port to attempt after a bind failure, or nil to retry the same one.
+    ///
+    /// Advancing requires knowing we are off the configured port. That used to
+    /// be read from `fallbackAttempted` alone, which is only set when *this*
+    /// retry path chose a fallback — so a session override recorded by
+    /// `syncResolvedPortState` (a previous successful bind or external-daemon
+    /// connect on a non-configured port) left the flag false and gated the
+    /// branch off. Combined with `onDefault` also being false in that state,
+    /// both escape hatches closed and the daemon retried a dead port to
+    /// exhaustion while a free one was already known. Deriving it from the
+    /// override too closes that hole.
+    nonisolated static func advancedFallbackPort(
+        attemptedPort: Int,
+        sessionOverridePort: Int?,
+        fallbackAttempted: Bool,
+        availablePort: Int?
+    ) -> Int? {
+        let offConfiguredPort = fallbackAttempted || (sessionOverridePort != nil)
+        guard offConfiguredPort, let next = availablePort, next != attemptedPort else { return nil }
+        return next
+    }
+
     init() {
         start()
         setupSignalHandler()
@@ -328,6 +357,13 @@ final class DaemonService: ObservableObject {
             configuredPort: configuredPort,
             actualPort: actualPort
         )
+        // Pair the flag with the override. Leaving it false here is what let
+        // the retry path stall on a dead fallback port (see
+        // `advancedFallbackPort`).
+        fallbackAttempted = Self.resolvedFallbackAttempted(
+            configuredPort: configuredPort,
+            actualPort: actualPort
+        )
         isOnFallbackPort = (sessionOverridePort != nil)
         if isOnFallbackPort {
             bindFailureReason = "Daemon moved to fallback port \(actualPort) because \(configuredPort) was held by another process. Clients will rediscover via mDNS."
@@ -434,8 +470,14 @@ final class DaemonService: ObservableObject {
         // before burning a retry. Without this, retries repeatedly hit the
         // same blocked port (e.g., 9122 held by zombie node) instead of
         // advancing to 9123, 9124, etc.
-        if fallbackAttempted, let nextPort = alt, nextPort != attemptedPort {
+        if let nextPort = Self.advancedFallbackPort(
+            attemptedPort: attemptedPort,
+            sessionOverridePort: sessionOverridePort,
+            fallbackAttempted: fallbackAttempted,
+            availablePort: alt
+        ) {
             sessionOverridePort = nextPort
+            fallbackAttempted = true
             DaemonLogger.shared.info("Advancing fallback port \(attemptedPort) → \(nextPort)")
         }
 

--- a/apple/AgentDeckTests/DaemonPortFallbackTests.swift
+++ b/apple/AgentDeckTests/DaemonPortFallbackTests.swift
@@ -1,0 +1,103 @@
+// DaemonPortFallbackTests.swift — the daemon must not retry a dead port while
+// a free one is already known.
+//
+// Observed 2026-07-19. The user stopped the CLI daemon; the app tried to take
+// over, failed to bind, burned its whole retry budget and gave up — with the
+// preferred port sitting free the entire time. Its own diagnostic said so:
+//
+//   retryOrFallback diag: userExplicitPort=9120 onDefault=false
+//                         fallbackAttempted=false
+//                         findAvailable=9120 attemptedPort=9121
+//
+// Both escape hatches were gated off at once. `onDefault` was false because a
+// session override was set; `fallbackAttempted` was false because the override
+// came from `syncResolvedPortState` (a previous successful bind or external
+// connect on a non-configured port), not from this retry path choosing a
+// fallback. Nothing advanced the port, so every retry hit 9121 again.
+//
+// 9121 is in the session-bridge range (9121-9139), so falling back there and
+// then finding it taken is a recurring shape, not a one-off.
+
+#if os(macOS)
+import XCTest
+@testable import AgentDeck
+
+final class DaemonPortFallbackTests: XCTestCase {
+
+    // MARK: - The stall
+
+    /// The exact state from the incident: on a fallback port, override set by
+    /// `syncResolvedPortState` so `fallbackAttempted` is false, and the
+    /// configured port free. It must advance rather than retry 9121.
+    func testAdvancesOffADeadFallbackPortWhenOverrideCameFromASuccessfulBind() {
+        let next = DaemonService.advancedFallbackPort(
+            attemptedPort: 9121,
+            sessionOverridePort: 9121,
+            fallbackAttempted: false,   // the stale flag that caused the stall
+            availablePort: 9120
+        )
+        XCTAssertEqual(next, 9120, "must reclaim the free port instead of retrying the dead one")
+    }
+
+    /// The path that already worked: this retry loop chose the fallback, so the
+    /// flag is set. Still advances.
+    func testAdvancesWhenFallbackWasChosenByTheRetryPath() {
+        let next = DaemonService.advancedFallbackPort(
+            attemptedPort: 9122,
+            sessionOverridePort: nil,
+            fallbackAttempted: true,
+            availablePort: 9123
+        )
+        XCTAssertEqual(next, 9123)
+    }
+
+    // MARK: - Cases that must NOT advance
+
+    /// On the user's configured port with no override: advancing here would
+    /// skip the squatter-cleanup and user-messaging path that owns this case.
+    func testDoesNotAdvanceWhileStillOnTheConfiguredPort() {
+        let next = DaemonService.advancedFallbackPort(
+            attemptedPort: 9120,
+            sessionOverridePort: nil,
+            fallbackAttempted: false,
+            availablePort: 9125
+        )
+        XCTAssertNil(next, "the configured-port case is handled by the fallback fast path, not here")
+    }
+
+    func testDoesNotAdvanceWhenTheOnlyFreePortIsTheOneThatJustFailed() {
+        let next = DaemonService.advancedFallbackPort(
+            attemptedPort: 9121,
+            sessionOverridePort: 9121,
+            fallbackAttempted: true,
+            availablePort: 9121
+        )
+        XCTAssertNil(next, "no point re-selecting the port we just failed on")
+    }
+
+    func testDoesNotAdvanceWhenNoPortIsAvailable() {
+        let next = DaemonService.advancedFallbackPort(
+            attemptedPort: 9121,
+            sessionOverridePort: 9121,
+            fallbackAttempted: true,
+            availablePort: nil
+        )
+        XCTAssertNil(next)
+    }
+
+    // MARK: - The invariant behind the bug
+
+    /// `fallbackAttempted` must track `sessionOverridePort`. They drifted apart
+    /// in `syncResolvedPortState`, which set the override and left the flag
+    /// alone — that drift *is* the bug above.
+    func testFallbackFlagTracksTheSessionOverride() {
+        // Bound the configured port → no override, not a fallback.
+        XCTAssertNil(DaemonService.resolvedSessionOverridePort(configuredPort: 9120, actualPort: 9120))
+        XCTAssertFalse(DaemonService.resolvedFallbackAttempted(configuredPort: 9120, actualPort: 9120))
+
+        // Ended up elsewhere → override recorded, and the flag must say so.
+        XCTAssertEqual(DaemonService.resolvedSessionOverridePort(configuredPort: 9120, actualPort: 9121), 9121)
+        XCTAssertTrue(DaemonService.resolvedFallbackAttempted(configuredPort: 9120, actualPort: 9121))
+    }
+}
+#endif


### PR DESCRIPTION
## Why

Stopping the CLI daemon left the app unable to take port 9120 back. It burned its whole retry budget and gave up — with 9120 free the entire time. Its own diagnostic said so:

```
retryOrFallback diag: userExplicitPort=9120 onDefault=false
                      fallbackAttempted=false
                      findAvailable=9120 attemptedPort=9121
```

`findAvailable=9120` next to `attemptedPort=9121` is the whole bug: it knew where to go and didn't go there. The user had to restart the app manually.

## Mechanism

`retryOrFallback` has two ways to change port, and this state closed both:

| branch | gate | why it was off |
|---|---|---|
| fallback fast path | `onDefault` | false — a session override was set |
| advance to next free port | `fallbackAttempted` | false — see below |

`fallbackAttempted` is only set when *this retry path* picks a fallback. But an override also gets recorded by `syncResolvedPortState` after a successful bind or an external-daemon connect on a non-configured port — and that path left the flag alone. So the daemon sat on 9121, off the configured port, with the flag claiming it had never fallen back.

Every retry then re-attempted 9121 until the budget ran out.

## Fix

Both changes target the drift, not the symptom:

- `syncResolvedPortState` derives `fallbackAttempted` from the override rather than leaving it stale. The two mean the same thing — "we are off the configured port" — and `restart()` already resets them together.
- The advance decision moves into `advancedFallbackPort`, a pure static that treats a session override as equivalent to the flag. The retry path also sets the flag when it advances, so they cannot drift again.

Tuning the retry budget would not have helped: the daemon was retrying a port it had no reason to want. And 9121 is inside the session-bridge range (9121-9139), so falling back there and later finding it taken is a recurring shape rather than a one-off.

## Verification

- 459 tests pass (453 + 6 new)
- New tests cover the incident state, the path that already worked, and the three cases that must **not** advance: still on the configured port (that case belongs to the fast path and its squatter cleanup / user messaging), only the failed port free, nothing free
- Confirmed the incident case **fails** against the previous gate while the other five pass — so the test is not vacuous and the behaviour change is narrow

## Not covered

Reproducing the original end-to-end race needs a real CLI-daemon handover with a session bridge holding 9121; this pins the decision logic that failed, not the full sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)