### PR TITLE
Warn when a serial frame exceeds the board's line buffer

### DIFF
--- a/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
+++ b/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
@@ -818,6 +818,22 @@ actor ESP32Serial {
         let hadLineReset = conn.needsLineReset
         let prefix = conn.needsLineReset ? "\n" : ""
         let payload = Array((prefix + json + "\n").utf8)
+
+        // Invariant: a frame must fit the board's line buffer. Violating it
+        // desyncs the board's parser rather than dropping one frame — see
+        // `lineBufferBytes(for:)`. Log loudly with the event type so the
+        // offending payload is identifiable without a serial capture.
+        let limit = Self.lineBufferBytes(for: conn.deviceInfo?.board)
+        if payload.count > limit {
+            let type = Self.frameType(json) ?? "?"
+            DaemonLogger.shared.throttledDebug(
+                "ESP32",
+                key: "oversized-frame:\(conn.port):\(type)",
+                "OVERSIZED \(conn.port): \(type) frame is \(payload.count)B > \(limit)B line buffer "
+                    + "(board=\(conn.deviceInfo?.board ?? "?")) — board parser will desync",
+                minInterval: 30
+            )
+        }
         switch writePayload(payload, to: conn.fd) {
         case .success:
             conn.needsLineReset = false
@@ -992,6 +1008,26 @@ actor ESP32Serial {
     /// — anything larger is discarded whole on-device, so shipping it is pure
     /// waste at best and a WS-client killer at worst.
     static let timelineHistoryByteBudget = 3500
+
+    /// The firmware's line buffer, mirrored from
+    /// `esp32/src/net/serial_client.cpp` (`SERIAL_BUF_SIZE`). A frame longer
+    /// than this does not merely get truncated — the board's overflow path
+    /// resets `serialBufPos` mid-line, so the tail of the oversized frame is
+    /// parsed as a fresh line, fails the leading `{` test, and never refreshes
+    /// `lastSerialJsonMs`. Thirty seconds of that and `serialConnected()` goes
+    /// false while the daemon still believes the link is healthy — the board
+    /// would show "Searching for AgentDeck..." with a live cable attached.
+    static func lineBufferBytes(for board: String?) -> Int {
+        (board == "inkdeck") ? 8192 : 4096
+    }
+
+    /// Cheap `"type"` extraction for diagnostics — avoids re-parsing the frame.
+    static func frameType(_ json: String) -> String? {
+        guard let r = json.range(of: "\"type\":\"") else { return nil }
+        let rest = json[r.upperBound...]
+        guard let end = rest.firstIndex(of: "\"") else { return nil }
+        return String(rest[..<end])
+    }
 
     /// Keep the NEWEST entries whose summed JSON size fits the byte budget,
     /// preserving chronological order for the ones that survive.


### PR DESCRIPTION
## Why

An ips_10 was reported stuck on "Searching for AgentDeck..." with a live USB cable and a daemon that believed the link was healthy. One hypothesis was an oversized frame. Answering it required adding instrumentation, rebuilding the daemon, and redeploying — for a question that recurs.

The hypothesis was wrong (measured: zero violations), but the check is worth keeping, because the failure mode it guards is silent and easy to misread.

## What oversizing actually does

The firmware does not drop an oversized frame. On overflow it resets `serialBufPos` mid-line, so the **tail** of the frame is parsed as a fresh line, fails the leading `{` test, and never refreshes `lastSerialJsonMs`. Thirty seconds of that and `serialConnected()` flips false — while the daemon keeps writing successfully and sees heartbeat acks. The board shows a searching overlay with a healthy cable attached.

That is exactly the shape of the report that prompted this, which is why it was a plausible suspect.

## The change

One check at `sendToConnection`, the single write chokepoint. Limit mirrors `SERIAL_BUF_SIZE` in `esp32/src/net/serial_client.cpp` (4096; InkDeck 8192). Logs the event type so the offending payload is identifiable without a serial capture, throttled to once per 30s per port+type.

Two existing comments already assumed callers respected this budget — `DaemonServer`'s connect-burst note and `timelineHistoryByteBudget`'s own doc. Now a violation says so instead of being assumed away.

## Verification

- 461 tests pass
- Ran against the live rig before committing: **zero violations** across all four connected serial boards (ips_10, ttgo_t_display, ulanzi_tc001, inkdeck) over a full daemon lifecycle including startup burst

So this ships as a guard, not a fix. The ips_10 report had a different root cause — the board was running firmware from before `dccd1b52` ("avoid IPS10 hosted WiFi teardown race"); flashing current firmware resolved its SDIO assert reboots (36 daemon starts, 0 asserts, versus ~16% per start before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)