### PR TITLE
fix(macos): back off wedged serial ports instead of resetting the board

### DIFF
--- a/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
+++ b/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
@@ -141,6 +141,16 @@ actor ESP32Serial {
         }
     }
     private static let transientMaxBackoff: TimeInterval = 60
+    // A USB-serial bridge that keeps FAILING TO OPEN (timeout or errno, not a
+    // one-off) is almost certainly hardware-wedged (e.g. a CH340 termios wedge)
+    // that no software open can recover — only a physical power-cycle can. Yet
+    // every open() attempt toggles DTR/RTS and RESETS the attached board, so
+    // retrying such a port on the 60s transient cap reboots an otherwise-healthy
+    // board once a minute. After this many consecutive open failures, escalate
+    // the backoff to the permanent-block cadence (5 min) so the reset-poking
+    // becomes rare while the port still self-heals once the bridge is
+    // power-cycled and finally opens. See memory ips10-wedged-ch340-daemon-reset-poke.
+    private static let openFailureEscalationThreshold = 4
 
     nonisolated(unsafe) private var stateProvider: (() -> [String: Any]?)?
     nonisolated(unsafe) private var usageProvider: (() -> [String: Any]?)?
@@ -363,6 +373,15 @@ actor ESP32Serial {
 
         let ports = detectPorts()
         lastDetectedPorts = ports
+        // A wedged bridge stays enumerated, so a port VANISHING from the
+        // detected set means it was physically unplugged. Drop its failure
+        // record so a re-plug starts with a fresh backoff instead of inheriting
+        // the escalated (5-min) delay above — even when macOS re-enumerates it
+        // under the same device name.
+        if !failedPorts.isEmpty {
+            let detected = Set(ports)
+            failedPorts = failedPorts.filter { detected.contains($0.key) }
+        }
         let now = Date()
         publishStatusShadow()
 
@@ -377,8 +396,15 @@ actor ESP32Serial {
                     // Only retry permanent failures after 5 minutes
                     if now.timeIntervalSince(failure.lastAttempt) < Self.permanentBlockDuration { continue }
                 } else {
-                    // Exponential backoff for transient errors: 10s * 2^(n-1), cap 60s
-                    let backoff = min(10.0 * pow(2.0, Double(failure.failCount - 1)), Self.transientMaxBackoff)
+                    // Exponential backoff for transient errors: 10s * 2^(n-1).
+                    // Once a port has failed to open this many times in a row it
+                    // is treated as wedged: raise the cap from 60s to the 5-min
+                    // permanent-block cadence so we stop DTR-resetting the board
+                    // every minute (see openFailureEscalationThreshold).
+                    let cap = failure.failCount >= Self.openFailureEscalationThreshold
+                        ? Self.permanentBlockDuration
+                        : Self.transientMaxBackoff
+                    let backoff = min(10.0 * pow(2.0, Double(failure.failCount - 1)), cap)
                     if now.timeIntervalSince(failure.lastAttempt) < backoff { continue }
                 }
             }

--- a/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
+++ b/apple/AgentDeck/Daemon/Modules/ESP32Serial.swift
@@ -152,6 +152,24 @@ actor ESP32Serial {
     // power-cycled and finally opens. See memory ips10-wedged-ch340-daemon-reset-poke.
     private static let openFailureEscalationThreshold = 4
 
+    /// Backoff before re-attempting to open a port that failed to open.
+    ///
+    /// Every `open()` toggles DTR/RTS and RESETS the attached board, so a port
+    /// that keeps failing to open (a wedged CH340, a stuck bridge) must not be
+    /// retried on a tight cadence or it reboots an otherwise-healthy board. The
+    /// transient cadence ramps by consecutive `failCount`: 1→10s, 2→20s, 3→40s,
+    /// 4→80s, 5→160s, 6+→300s — the exponential cap rises from
+    /// `transientMaxBackoff` (60s) to `permanentBlockDuration` (5 min) once
+    /// `failCount` reaches `openFailureEscalationThreshold`, so 300s is only
+    /// reached at the 6th failure (not immediately at the 4th). Permanent
+    /// failures (EACCES) use the flat 5-min block. Pure + `nonisolated` so the
+    /// cadence is unit-tested independently of the poll loop.
+    nonisolated static func openFailureBackoff(failCount: Int, isPermanent: Bool) -> TimeInterval {
+        if isPermanent { return permanentBlockDuration }
+        let cap = failCount >= openFailureEscalationThreshold ? permanentBlockDuration : transientMaxBackoff
+        return min(10.0 * pow(2.0, Double(failCount - 1)), cap)
+    }
+
     nonisolated(unsafe) private var stateProvider: (() -> [String: Any]?)?
     nonisolated(unsafe) private var usageProvider: (() -> [String: Any]?)?
     nonisolated(unsafe) private var sessionsListProvider: (() -> [String: Any]?)?
@@ -374,10 +392,15 @@ actor ESP32Serial {
         let ports = detectPorts()
         lastDetectedPorts = ports
         // A wedged bridge stays enumerated, so a port VANISHING from the
-        // detected set means it was physically unplugged. Drop its failure
-        // record so a re-plug starts with a fresh backoff instead of inheriting
-        // the escalated (5-min) delay above — even when macOS re-enumerates it
-        // under the same device name.
+        // detected set means it was physically unplugged / power-cycled / driver
+        // re-enumerated — cases where the wedge may well be gone. Drop its
+        // failure record so a re-plug retries immediately instead of inheriting
+        // the escalated (5-min) delay above, even when macOS re-enumerates it
+        // under the same device name. Trade-off: a device that flaps in and out
+        // of enumeration (bad contact) resets its failCount each time and never
+        // escalates; that's accepted because making a genuine re-plug wait up to
+        // 5 min is the worse user-recovery outcome. Revisit with a grace period
+        // only if enumeration false-negatives are observed in the field.
         if !failedPorts.isEmpty {
             let detected = Set(ports)
             failedPorts = failedPorts.filter { detected.contains($0.key) }
@@ -390,23 +413,13 @@ actor ESP32Serial {
             if connections.contains(where: { $0.port == port }) { continue }
             if openingPorts[port] != nil { continue }
 
-            // Check failure blocklist
+            // Check failure blocklist. openFailureBackoff() is the single,
+            // unit-tested source of the retry cadence (see its doc): it escalates
+            // a wedged port toward a 5-min block so we stop DTR-resetting the
+            // board every minute.
             if let failure = failedPorts[port] {
-                if failure.isPermanent {
-                    // Only retry permanent failures after 5 minutes
-                    if now.timeIntervalSince(failure.lastAttempt) < Self.permanentBlockDuration { continue }
-                } else {
-                    // Exponential backoff for transient errors: 10s * 2^(n-1).
-                    // Once a port has failed to open this many times in a row it
-                    // is treated as wedged: raise the cap from 60s to the 5-min
-                    // permanent-block cadence so we stop DTR-resetting the board
-                    // every minute (see openFailureEscalationThreshold).
-                    let cap = failure.failCount >= Self.openFailureEscalationThreshold
-                        ? Self.permanentBlockDuration
-                        : Self.transientMaxBackoff
-                    let backoff = min(10.0 * pow(2.0, Double(failure.failCount - 1)), cap)
-                    if now.timeIntervalSince(failure.lastAttempt) < backoff { continue }
-                }
+                let backoff = Self.openFailureBackoff(failCount: failure.failCount, isPermanent: failure.isPermanent)
+                if now.timeIntervalSince(failure.lastAttempt) < backoff { continue }
             }
 
             beginOpenPort(port)

--- a/apple/AgentDeckTests/ESP32WifiForwardTests.swift
+++ b/apple/AgentDeckTests/ESP32WifiForwardTests.swift
@@ -211,4 +211,51 @@ final class ESP32WifiForwardTests: XCTestCase {
         }
     }
 }
+
+/// Regression guard for the serial open-failure backoff (PR #77).
+///
+/// Every `open()` toggles DTR/RTS and resets the attached board, so a port that
+/// keeps failing to open (a wedged CH340) must escalate its retry cadence
+/// instead of rebooting a healthy board every minute. This locks the ramp so a
+/// future tweak to the constants can't silently tighten it back to the old
+/// once-a-minute reset-poking. See memory `ips10-wedged-ch340-daemon-reset-poke`.
+final class ESP32SerialOpenBackoffTests: XCTestCase {
+
+    /// Transient (open-timeout / non-EACCES) failures ramp 10→20→40→80→160→300s.
+    /// The cap rises from 60s to the 5-min block at the escalation threshold, so
+    /// 300s is only reached at the 6th failure — a gradual ramp, not a cliff.
+    func testTransientBackoffRampsAndEscalates() {
+        let expected: [(failCount: Int, seconds: TimeInterval)] = [
+            (1, 10), (2, 20), (3, 40),    // below threshold: exponential, capped at 60s
+            (4, 80), (5, 160),            // cap raised to 300s, still ramping
+            (6, 300), (7, 300), (20, 300) // settled at the 5-min block
+        ]
+        for c in expected {
+            XCTAssertEqual(
+                ESP32Serial.openFailureBackoff(failCount: c.failCount, isPermanent: false),
+                c.seconds, accuracy: 0.001,
+                "transient open-failure backoff for failCount \(c.failCount)")
+        }
+    }
+
+    /// No failCount may ever push the transient cadence past the 5-min block.
+    func testTransientBackoffNeverExceedsFiveMinutes() {
+        for failCount in 1...200 {
+            XCTAssertLessThanOrEqual(
+                ESP32Serial.openFailureBackoff(failCount: failCount, isPermanent: false),
+                300,
+                "transient backoff must never exceed the 5-min permanent block")
+        }
+    }
+
+    /// EACCES (permanent) failures use the flat 5-min block regardless of count.
+    func testPermanentFailureUsesFlatFiveMinuteBlock() {
+        for failCount in 1...5 {
+            XCTAssertEqual(
+                ESP32Serial.openFailureBackoff(failCount: failCount, isPermanent: true),
+                300, accuracy: 0.001,
+                "EACCES (permanent) always uses the flat 5-min block")
+        }
+    }
+}
 #endif


### PR DESCRIPTION
## Problem

The Swift daemon's serial module treated only `EACCES` as a permanent open
failure. A port that kept **failing to open** — a timeout, or an errno such as
a CH340 `termios` wedge — was classified transient and retried on the 60s
backoff cap **forever**. Since every `open()` toggles DTR/RTS and **resets the
attached board**, this rebooted an otherwise-healthy board roughly **once a
minute** for as long as the USB-serial bridge stayed wedged.

Observed live on the **ips10 (JC8012P4A1C, ESP32-P4 + C6)**: its CH340 wedged
(`open timed out` / a direct `pyserial` open returned `errno 22`), the daemon
retried every ~60s, and the board kept rebooting — presenting as "the ips10
keeps rebooting" plus a WiFi WS reconnect flap as it re-registered after each
reset. Every other board was stable; only the wedged port flapped.

## Fix (`ESP32Serial.swift`)

- **`openFailureBackoff(failCount:isPermanent:)`** — a `nonisolated static` pure
  function is now the single source of the retry cadence. Transient failures
  ramp `10 → 20 → 40 → 80 → 160 → 300s`: the exponential cap rises from
  `transientMaxBackoff` (60s) to `permanentBlockDuration` (5 min) once
  `failCount` reaches `openFailureEscalationThreshold` (4), so the 5-min block
  is reached at the **6th** failure — a gradual ramp, not a cliff at the 4th.
  A successful open clears the record, so normal recovery is unaffected.
- Drop a port's failure record when it vanishes from the detected set, so a
  physical re-plug / power-cycle / re-enumeration retries immediately instead of
  inheriting the escalated delay — even under the same device name. The
  trade-off (a device that flaps in/out of enumeration never escalates) is
  documented inline and accepted so a genuine re-plug never waits up to 5 min.

## Node parity

This is **not** already handled on the Node side. `bridge/src/esp32-serial.ts`
has **no per-port open-failure backoff** (`failedPorts` is Swift-only), and its
`foreignProbeFailures` denylist only covers identification failures / some
half-open CDC recycles — not the open-failure path. So Node carries the same
*repeated-open* risk. Whether each failed open actually resets a wedged CH340 on
the Node path can't be confirmed from code alone (a timed-out `openSync()` never
returns the fd, so DTR/RTS behavior depends on the driver / `HUPCL` / failure
stage) and needs real-device verification. Tracked as a follow-up in #78 rather
than expanded into this Swift-scoped PR.

## Tests

`ESP32SerialOpenBackoffTests` locks the cadence (transient ramp, the ≤5-min
invariant across 1..200, and the flat EACCES block) so a future constant tweak
can't silently restore the once-a-minute reset-poking. `xcodebuild test` →
**TEST SUCCEEDED**. The fixed daemon was also run on real hardware; all serial
boards reconnected cleanly with empty `portFailures`.

Note: recovering a wedged CH340 itself still requires a physical board
power-cycle — this change only stops the daemon from rebooting the board while
it is wedged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
