### PR TITLE
Surface per-model weekly usage limits (Fable) on the Pixoo HUD

### DIFF
--- a/bridge/src/__tests__/usage-event.test.ts
+++ b/bridge/src/__tests__/usage-event.test.ts
@@ -44,10 +44,18 @@ function usage(overrides: Partial<ApiUsageData> = {}): ApiUsageData {
     extraUsageMonthlyLimit: 100,
     extraUsageUsedCredits: 12,
     extraUsageUtilization: 12,
+    scopedLimits: [],
     inferredBillingType: 'subscription',
     ...overrides,
   };
 }
+
+const FABLE_LIMIT = {
+  modelName: 'Fable',
+  percent: 11,
+  resetsAt: '2026-06-12T18:00:00Z',
+  severity: 'normal',
+};
 
 describe('buildUsageEvent subscription quota scoping', () => {
   it('omits Anthropic quota when the model is not yet known', () => {
@@ -321,5 +329,44 @@ describe('buildUsageEvent Codex window normalization', () => {
 
     expect(evt.codexRateLimits!.primary).toBeUndefined();
     expect(evt.codexRateLimits!.secondary).toBeUndefined();
+  });
+});
+
+describe('buildUsageEvent scoped model limits', () => {
+  it('forwards per-model weekly sub-limits on a subscription', () => {
+    const evt = buildUsageEvent(
+      snapshot({ modelName: 'claude-fable-5', billingType: 'subscription' }),
+      usage({ scopedLimits: [FABLE_LIMIT] }),
+      true,
+    ) as UsageEvent;
+
+    expect(evt.scopedLimits).toEqual([{
+      modelName: 'Fable',
+      percent: 11,
+      resetsAt: '2026-06-12T18:00:00Z',
+      severity: 'normal',
+    }]);
+  });
+
+  it('omits the key entirely when the API reports no scoped limits', () => {
+    const evt = buildUsageEvent(
+      snapshot({ modelName: 'claude-fable-5', billingType: 'subscription' }),
+      usage(),
+      true,
+    ) as UsageEvent;
+
+    expect(evt.scopedLimits).toBeUndefined();
+  });
+
+  it('drops scoped limits when the account-wide quota does not apply', () => {
+    // Same gate as fiveHourPercent: a per-model carve-out is a slice of the
+    // subscription pool, so it must not ride along on API billing.
+    const evt = buildUsageEvent(
+      snapshot({ modelName: 'gpt-5', billingType: 'api', costLimit: 10, costSpent: 1 }),
+      usage({ inferredBillingType: 'api', scopedLimits: [FABLE_LIMIT] }),
+      true,
+    ) as UsageEvent;
+
+    expect(evt.scopedLimits).toBeUndefined();
   });
 });

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -670,6 +670,12 @@ async function fetchUsageViaWs(siblings: { port: number }[]): Promise<ApiUsageDa
                 extraUsageMonthlyLimit: evt.extraUsageMonthlyLimit ?? null,
                 extraUsageUsedCredits: evt.extraUsageUsedCredits ?? null,
                 extraUsageUtilization: evt.extraUsageUtilization ?? null,
+                scopedLimits: (evt.scopedLimits ?? []).map((s: any) => ({
+                  modelName: s.modelName,
+                  percent: s.percent,
+                  resetsAt: s.resetsAt ?? null,
+                  severity: s.severity ?? null,
+                })),
                 inferredBillingType: null,
               });
             }

--- a/bridge/src/pixoo/pixoo-renderer.ts
+++ b/bridge/src/pixoo/pixoo-renderer.ts
@@ -31,9 +31,7 @@ import { drawTextCentered } from './pixoo-font.js';
 import {
   type RGB, COLORS, setPixel, blendPixel, glowPixel, fillRect, lerpColor,
   drawOfficialDotGlyph, drawTetra,
-  drawText,
-  getOctopusPaletteForSession, getJellyfishPaletteForSession, getOpenCodePaletteForSession,
-  getAntigravityPaletteForSession,
+  drawText, fontCanRender,
 } from './pixoo-sprites.js';
 import {
   type Camera, type ActiveCreature, CAMERA_WIDE, blitWithCamera, quantizeCameraPixels,
@@ -644,6 +642,62 @@ function simplifiedState(state: State): 'idle' | 'processing' | 'awaiting' {
 
 // ===== Usage HUD Helpers =====
 
+/** Brand color for per-model scoped weekly limits (Fable etc). Deliberately
+ *  distinct from Claude's orange and Codex's violet so the sub-limit band is
+ *  not mistaken for a third provider. */
+const SCOPED_LIMIT_BRAND: RGB = [255, 198, 64];
+
+/** Screen-space colors for the session-state tally strip. */
+const TALLY_PROCESSING: RGB = [54, 184, 255];
+const TALLY_AWAITING: RGB = [255, 176, 32];
+const TALLY_IDLE: RGB = [96, 208, 140];
+
+/**
+ * Draw the session-state tally along the top edge: one colored dot per state
+ * followed by its count (processing / awaiting / idle).
+ *
+ * The terrarium already encodes state per creature, but at a glance a tank of
+ * six creatures does not answer "how many are waiting on me". States with a
+ * zero count are omitted so the strip stays short, and the whole strip is
+ * skipped when there are no live sessions at all.
+ */
+function drawStateTally(buf: Uint8Array, sessions: SessionInfo[] | null): void {
+  if (!sessions) return;
+  let processing = 0, awaiting = 0, idle = 0;
+  for (const s of sessions) {
+    if (!s.alive) continue;
+    if (s.state === 'processing') processing++;
+    else if (s.state === 'awaiting') awaiting++;
+    else idle++;
+  }
+  const entries: Array<[number, RGB]> = [];
+  if (processing > 0) entries.push([processing, TALLY_PROCESSING]);
+  if (awaiting > 0) entries.push([awaiting, TALLY_AWAITING]);
+  if (idle > 0) entries.push([idle, TALLY_IDLE]);
+  if (entries.length === 0) return;
+
+  // Each entry is a 2x2 dot, 1px gap, then the count text (4px per digit).
+  const widthOf = ([count]: [number, RGB]) => 2 + 1 + String(count).length * 4;
+  const total = entries.reduce((sum, e) => sum + widthOf(e), 0) + (entries.length - 1) * 2;
+  let x = Math.max(1, Math.floor((64 - total) / 2));
+
+  // Dim plate so the strip stays legible. Fish and particles swim through this
+  // band, so the plate has to be dark enough to sink them behind the digits —
+  // 0.55 left them cutting across the numbers.
+  for (let y = 0; y < 7; y++) {
+    for (let px = 0; px < 64; px++) blendPixel(buf, px, y, COLORS.black, 0.78);
+  }
+
+  for (const entry of entries) {
+    const [count, color] = entry;
+    fillRect(buf, x, 2, 2, 2, color);
+    const text = String(count);
+    // drawText lays out right-to-left from the given right edge.
+    drawText(buf, text, x + 3 + text.length * 4 - 1, 1, color);
+    x += widthOf(entry) + 2;
+  }
+}
+
 /** Gauge bar color based on usage percentage. */
 function gaugeColor(pct: number, animFrame: number, brand: RGB): RGB {
   if (pct >= 90) {
@@ -686,7 +740,10 @@ function drawUsageHUD(
   if (!usageEvent) return;
   type Window = { percent: number; resetsAt?: string };
   type Provider = {
-    glyph: OfficialDotGlyphName; brand: RGB;
+    glyph?: OfficialDotGlyphName; brand: RGB;
+    /** Drawn in the identity dock instead of a glyph — for rows that are a
+     *  sub-limit of another provider rather than a provider of their own. */
+    dockLabel?: string;
     primary?: Window; secondary?: Window;
     subscriptionUntil?: string;
   };
@@ -700,6 +757,16 @@ function drawUsageHUD(
         percent: usageEvent.sevenDayPercent, resetsAt: usageEvent.sevenDayResetsAt,
       },
     });
+    // Per-model weekly carve-outs (Fable on Max) get their own band directly
+    // under Claude's. They are a slice of the same seven-day pool, so they ride
+    // the same freshness gate and are dropped entirely when quota is stale.
+    for (const scoped of usageEvent.scopedLimits ?? []) {
+      providers.push({
+        dockLabel: scoped.modelName.slice(0, 1).toUpperCase(),
+        brand: SCOPED_LIMIT_BRAND,
+        secondary: { percent: scoped.percent, resetsAt: scoped.resetsAt },
+      });
+    }
   }
   // A window counts as renderable only when it is both fresh AND carries a
   // number. "Not stale but no percent" is a malformed frame, not a zero — the
@@ -722,9 +789,23 @@ function drawUsageHUD(
   if (providers.length === 0) return;
 
   const timeColor: RGB = [0x60, 0x70, 0x80];
-  const firstY = providers.length > 1 ? 50 : 57;
+  // Bands stack upward from the bottom edge, so adding a third row (a scoped
+  // model limit) shifts the whole HUD up instead of overflowing off-screen.
+  const firstY = 64 - providers.length * 7;
 
   function drawCreatureMarker(provider: Provider, rowY: number): void {
+    if (provider.dockLabel) {
+      // Right-aligned inside the 9px dock, vertically centered in the band.
+      // A model whose initial the 3×5 font lacks still needs an identity mark,
+      // so fall back to a solid chip rather than leaving the dock blank.
+      if (fontCanRender(provider.dockLabel)) {
+        drawText(buf, provider.dockLabel, 7, rowY + 1, provider.brand);
+      } else {
+        fillRect(buf, 3, rowY + 2, 3, 3, provider.brand);
+      }
+      return;
+    }
+    if (!provider.glyph) return;
     const mask = OFFICIAL_DOT_GLYPHS[provider.glyph];
     const sourceSize = OFFICIAL_DOT_GLYPH_SIZE;
     // Sample the canonical square canvas instead of cropping its occupied
@@ -1223,27 +1304,10 @@ export function renderFrame(
     }
   }
 
-  // Session count indicator (top-left, screen-space) — colored dots when 2+ sessions
-  const sessionCount = creatureInstances.size;
-  if (sessionCount >= 2) {
-    const orderedCreatures = [...creatureInstances.values()];
-    for (let i = 0; i < Math.min(sessionCount, 6); i++) {
-      const dotX = 1 + i * 3;  // 2px dot + 1px gap
-      const c = orderedCreatures[i];
-      // Color the dot by agent type so OpenCode is distinguishable, not painted as an octopus.
-      const dotColor = c.creatureType === 'jellyfish'
-        ? getJellyfishPaletteForSession(i).body
-        : c.creatureType === 'opencode'
-          ? getOpenCodePaletteForSession(i).outer
-          : c.creatureType === 'antigravity'
-            ? getAntigravityPaletteForSession(i).yellow
-          : getOctopusPaletteForSession(i).body;
-      setPixel(outputBuf, dotX, 1, dotColor);
-      setPixel(outputBuf, dotX + 1, 1, dotColor);
-      setPixel(outputBuf, dotX, 2, dotColor);
-      setPixel(outputBuf, dotX + 1, 2, dotColor);
-    }
-  }
+  // Session-state tally (top edge, screen-space). Replaces the former
+  // per-agent-type dot row: creature shape already carries agent type, while
+  // "how many are waiting on me" had no readout at all.
+  drawStateTally(outputBuf, sessions);
 
   // Usage HUD (bottom-right, screen-space)
   drawUsageHUD(outputBuf, usageEvent, animFrame);

--- a/bridge/src/pixoo/pixoo-sprites.ts
+++ b/bridge/src/pixoo/pixoo-sprites.ts
@@ -1598,7 +1598,21 @@ const PIXEL_FONT: Record<string, number[]> = {
   'm': [0b101, 0b111, 0b101, 0b101, 0b101],  // two pillars joined — distinct from 'n'
   'd': [0b001, 0b001, 0b011, 0b101, 0b011],  // lowercase d — for day units (e.g. "6d22h")
   ' ': [0b000, 0b000, 0b000, 0b000, 0b000],
+  // Uppercase initials for scoped per-model quota rows. The OAuth usage payload
+  // carves weekly sub-limits by model display name (Fable, Opus, Sonnet,
+  // Cowork); the HUD dock shows the first letter where a provider row would
+  // show its official mark. Unlisted letters fall back to a solid chip.
+  'C': [0b111, 0b100, 0b100, 0b100, 0b111],
+  'F': [0b111, 0b100, 0b110, 0b100, 0b100],
+  'O': [0b111, 0b101, 0b101, 0b101, 0b111],
+  'S': [0b111, 0b100, 0b111, 0b001, 0b111],
 };
+
+/** True when the 3×5 font can render every character of `text`. */
+export function fontCanRender(text: string): boolean {
+  for (const ch of text) if (!PIXEL_FONT[ch]) return false;
+  return true;
+}
 
 /** Draw right-aligned text using 3×5 pixel font. */
 export function drawText(

--- a/bridge/src/usage-api.ts
+++ b/bridge/src/usage-api.ts
@@ -15,6 +15,13 @@ const FILE_CACHE_TTL_MS = 120_000; // 120s — reduced from 60s to avoid 429 fro
 /** Token expiry safety margin — skip fetch if token expires within this window */
 const TOKEN_EXPIRY_MARGIN_MS = 10 * 60 * 1000; // 10 minutes
 
+export interface ApiScopedLimit {
+  modelName: string;
+  percent: number;
+  resetsAt: string | null;
+  severity: string | null;
+}
+
 export interface ApiUsageData {
   fiveHourPercent: number | null;
   fiveHourResetsAt: string | null;
@@ -24,6 +31,8 @@ export interface ApiUsageData {
   extraUsageMonthlyLimit: number | null;
   extraUsageUsedCredits: number | null;
   extraUsageUtilization: number | null;
+  /** Per-model weekly sub-limits parsed from the payload's `limits[]` array. */
+  scopedLimits: ApiScopedLimit[];
   /** Inferred from API response: subscription if rate-limit fields present, api if 401/no fields */
   inferredBillingType: 'subscription' | 'api' | null;
 }
@@ -107,7 +116,12 @@ function readFileCache(): UsageCacheFile | null {
   try {
     const raw = readFileSync(USAGE_CACHE_FILE, 'utf-8');
     const cache = JSON.parse(raw) as UsageCacheFile;
-    if (cache?.data && typeof cache.fetchedAt === 'number') return cache;
+    if (cache?.data && typeof cache.fetchedAt === 'number') {
+      // Caches written before scoped limits existed have no such key; the type
+      // says array, so normalize on read rather than guarding every consumer.
+      if (!Array.isArray(cache.data.scopedLimits)) cache.data.scopedLimits = [];
+      return cache;
+    }
     return null;
   } catch {
     return null;
@@ -142,6 +156,39 @@ function parseUtilization(limitObj: unknown): number | null {
     if (typeof obj.usage === 'number') return obj.usage;
   }
   return null;
+}
+
+/**
+ * Extract per-model weekly sub-limits from the payload's `limits[]` array.
+ *
+ * Rows look like:
+ *   { kind: 'weekly_scoped', group: 'weekly', percent: 11, severity: 'normal',
+ *     resets_at: '...', scope: { model: { id: null, display_name: 'Fable' } } }
+ *
+ * Only `weekly_scoped` rows carrying a model display name are returned — the
+ * `session` and `weekly_all` rows duplicate five_hour / seven_day, which the
+ * caller already reads from the top-level fields. `scope.model.id` is commonly
+ * null, so the display name is the only stable identifier.
+ */
+function parseScopedLimits(limits: unknown): ApiScopedLimit[] {
+  if (!Array.isArray(limits)) return [];
+  const out: ApiScopedLimit[] = [];
+  for (const row of limits) {
+    if (row == null || typeof row !== 'object') continue;
+    const r = row as Record<string, any>;
+    if (r.kind !== 'weekly_scoped') continue;
+    const modelName = r.scope?.model?.display_name;
+    if (typeof modelName !== 'string' || modelName.length === 0) continue;
+    const percent = parseUtilization(r);
+    if (percent == null) continue;
+    out.push({
+      modelName,
+      percent,
+      resetsAt: parseResetsAt(r),
+      severity: typeof r.severity === 'string' ? r.severity : null,
+    });
+  }
+  return out;
 }
 
 /** Extract resets_at from a rate-limit object, handling multiple possible shapes */
@@ -292,10 +339,12 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
       extraUsageMonthlyLimit: extraUsage?.monthly_limit ?? null,
       extraUsageUsedCredits: extraUsage?.used_credits ?? null,
       extraUsageUtilization: parseUtilization(extraUsage),
+      scopedLimits: parseScopedLimits(data.limits),
       inferredBillingType: hasRateLimitData ? 'subscription' : 'api',
     };
 
-    debug('UsageAPI', `5h: ${result.fiveHourPercent}%, 7d: ${result.sevenDayPercent}%, extra: ${result.extraUsageEnabled ? 'enabled' : 'disabled'}`);
+    const scopedSummary = result.scopedLimits.map(s => `${s.modelName}: ${s.percent}%`).join(', ');
+    debug('UsageAPI', `5h: ${result.fiveHourPercent}%, 7d: ${result.sevenDayPercent}%, extra: ${result.extraUsageEnabled ? 'enabled' : 'disabled'}${scopedSummary ? `, scoped: ${scopedSummary}` : ''}`);
 
     // Success — reset counters, write cache
     lastFetchFailed = false;

--- a/bridge/src/usage-event.ts
+++ b/bridge/src/usage-event.ts
@@ -184,6 +184,16 @@ export function buildUsageEvent(
     fiveHourResetsAt,
     sevenDayPercent,
     sevenDayResetsAt,
+    // Per-model weekly sub-limits ride the same subscription gate as the
+    // account-wide quota — on API billing there is no such carve-out.
+    scopedLimits: subscriptionQuotaApplies && apiUsage?.scopedLimits?.length
+      ? apiUsage.scopedLimits.map(s => ({
+          modelName: s.modelName,
+          percent: s.percent,
+          resetsAt: s.resetsAt ?? undefined,
+          severity: s.severity ?? undefined,
+        }))
+      : undefined,
     extraUsageEnabled: subscriptionQuotaApplies ? (apiUsage?.extraUsageEnabled ?? undefined) : undefined,
     extraUsageMonthlyLimit: subscriptionQuotaApplies ? (apiUsage?.extraUsageMonthlyLimit ?? undefined) : undefined,
     extraUsageUsedCredits: subscriptionQuotaApplies ? (apiUsage?.extraUsageUsedCredits ?? undefined) : undefined,

--- a/generated/protocol/BridgeEvent.kt
+++ b/generated/protocol/BridgeEvent.kt
@@ -216,6 +216,11 @@ data class BridgeEvent (
     val resetDate: String? = null,
     val resetTime: String? = null,
 
+    /**
+     * Per-model weekly sub-limits (Fable etc). Omitted when the plan has none.
+     */
+    val scopedLimits: List<ScopedModelLimit>? = null,
+
     @Json(name = "sessionDurationSec")
     val sessionDurationSEC: Double? = null,
 
@@ -987,6 +992,32 @@ enum class Outcome(val value: String) {
         }
     }
 }
+
+/**
+ * A per-model weekly quota carved out of the account-wide weekly limit.
+ *
+ * The OAuth usage payload reports these in its `limits[]` array as `kind: 'weekly_scoped'`
+ * rows carrying `scope.model.display_name` (e.g. "Fable"). They are separate from
+ * `seven_day`, which is the all-model total.
+ */
+data class ScopedModelLimit (
+    /**
+     * Display name from the API, e.g. "Fable".
+     */
+    val modelName: String,
+
+    /**
+     * Utilization 0-100.
+     */
+    val percent: Double,
+
+    val resetsAt: String? = null,
+
+    /**
+     * API's own severity hint: normal | warning | critical.
+     */
+    val severity: String? = null
+)
 
 data class ApmeModelScorecard (
     val agentType: AgentType,

--- a/generated/protocol/BridgeEvent.swift
+++ b/generated/protocol/BridgeEvent.swift
@@ -113,6 +113,8 @@ struct ADBridgeEvent: Codable, Equatable {
     var outputTokens: Double?
     var resetDate: String?
     var resetTime: String?
+    /// Per-model weekly sub-limits (Fable etc). Omitted when the plan has none.
+    var scopedLimits: [ADScopedModelLimit]?
     var sessionDurationSec: Double?
     var sessionPercent: Double?
     var sevenDayPercent: Double?
@@ -217,6 +219,7 @@ struct ADBridgeEvent: Codable, Equatable {
         case outputTokens = "outputTokens"
         case resetDate = "resetDate"
         case resetTime = "resetTime"
+        case scopedLimits = "scopedLimits"
         case sessionDurationSec = "sessionDurationSec"
         case sessionPercent = "sessionPercent"
         case sevenDayPercent = "sevenDayPercent"
@@ -337,6 +340,7 @@ extension ADBridgeEvent {
         outputTokens: Double?? = nil,
         resetDate: String?? = nil,
         resetTime: String?? = nil,
+        scopedLimits: [ADScopedModelLimit]?? = nil,
         sessionDurationSec: Double?? = nil,
         sessionPercent: Double?? = nil,
         sevenDayPercent: Double?? = nil,
@@ -437,6 +441,7 @@ extension ADBridgeEvent {
             outputTokens: outputTokens ?? self.outputTokens,
             resetDate: resetDate ?? self.resetDate,
             resetTime: resetTime ?? self.resetTime,
+            scopedLimits: scopedLimits ?? self.scopedLimits,
             sessionDurationSec: sessionDurationSec ?? self.sessionDurationSec,
             sessionPercent: sessionPercent ?? self.sessionPercent,
             sevenDayPercent: sevenDayPercent ?? self.sevenDayPercent,
@@ -1931,6 +1936,76 @@ enum ADOutcome: String, Codable, Equatable {
     case interrupted = "interrupted"
     case iterated = "iterated"
     case pending = "pending"
+}
+
+//
+// Hashable or Equatable:
+// The compiler will not be able to synthesize the implementation of Hashable or Equatable
+// for types that require the use of JSONAny, nor will the implementation of Hashable be
+// synthesized for types that have collections (such as arrays or dictionaries).
+
+/// A per-model weekly quota carved out of the account-wide weekly limit.
+///
+/// The OAuth usage payload reports these in its `limits[]` array as `kind: 'weekly_scoped'`
+/// rows carrying `scope.model.display_name` (e.g. "Fable"). They are separate from
+/// `seven_day`, which is the all-model total.
+// MARK: - ADScopedModelLimit
+struct ADScopedModelLimit: Codable, Equatable {
+    /// Display name from the API, e.g. "Fable".
+    var modelName: String
+    /// Utilization 0-100.
+    var percent: Double
+    var resetsAt: String?
+    /// API's own severity hint: normal | warning | critical.
+    var severity: String?
+
+    enum CodingKeys: String, CodingKey {
+        case modelName = "modelName"
+        case percent = "percent"
+        case resetsAt = "resetsAt"
+        case severity = "severity"
+    }
+}
+
+// MARK: ADScopedModelLimit convenience initializers and mutators
+
+extension ADScopedModelLimit {
+    init(data: Data) throws {
+        self = try newJSONDecoder().decode(ADScopedModelLimit.self, from: data)
+    }
+
+    init(_ json: String, using encoding: String.Encoding = .utf8) throws {
+        guard let data = json.data(using: encoding) else {
+            throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+        }
+        try self.init(data: data)
+    }
+
+    init(fromURL url: URL) throws {
+        try self.init(data: try Data(contentsOf: url))
+    }
+
+    func with(
+        modelName: String? = nil,
+        percent: Double? = nil,
+        resetsAt: String?? = nil,
+        severity: String?? = nil
+    ) -> ADScopedModelLimit {
+        return ADScopedModelLimit(
+            modelName: modelName ?? self.modelName,
+            percent: percent ?? self.percent,
+            resetsAt: resetsAt ?? self.resetsAt,
+            severity: severity ?? self.severity
+        )
+    }
+
+    func jsonData() throws -> Data {
+        return try newJSONEncoder().encode(self)
+    }
+
+    func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
+        return String(data: try self.jsonData(), encoding: encoding)
+    }
 }
 
 //

--- a/generated/protocol/bridge-event-schema.json
+++ b/generated/protocol/bridge-event-schema.json
@@ -1086,6 +1086,32 @@
       ],
       "type": "object"
     },
+    "ScopedModelLimit": {
+      "additionalProperties": false,
+      "description": "A per-model weekly quota carved out of the account-wide weekly limit.\n\nThe OAuth usage payload reports these in its `limits[]` array as `kind: 'weekly_scoped'` rows carrying `scope.model.display_name` (e.g. \"Fable\"). They are separate from `seven_day`, which is the all-model total.",
+      "properties": {
+        "modelName": {
+          "description": "Display name from the API, e.g. \"Fable\".",
+          "type": "string"
+        },
+        "percent": {
+          "description": "Utilization 0-100.",
+          "type": "number"
+        },
+        "resetsAt": {
+          "type": "string"
+        },
+        "severity": {
+          "description": "API's own severity hint: normal | warning | critical.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "modelName",
+        "percent"
+      ],
+      "type": "object"
+    },
     "SessionInfo": {
       "additionalProperties": false,
       "properties": {
@@ -1693,6 +1719,13 @@
         },
         "resetTime": {
           "type": "string"
+        },
+        "scopedLimits": {
+          "description": "Per-model weekly sub-limits (Fable etc). Omitted when the plan has none.",
+          "items": {
+            "$ref": "#/definitions/ScopedModelLimit"
+          },
+          "type": "array"
         },
         "sessionDurationSec": {
           "type": "number"

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -234,6 +234,23 @@ export interface PromptOptionsEvent {
   options: PromptOption[];
 }
 
+/**
+ * A per-model weekly quota carved out of the account-wide weekly limit.
+ *
+ * The OAuth usage payload reports these in its `limits[]` array as
+ * `kind: 'weekly_scoped'` rows carrying `scope.model.display_name` (e.g.
+ * "Fable"). They are separate from `seven_day`, which is the all-model total.
+ */
+export interface ScopedModelLimit {
+  /** Display name from the API, e.g. "Fable". */
+  modelName: string;
+  /** Utilization 0-100. */
+  percent: number;
+  resetsAt?: string;
+  /** API's own severity hint: normal | warning | critical. */
+  severity?: string;
+}
+
 export interface UsageEvent {
   type: 'usage_update';
   sessionDurationSec: number;
@@ -252,6 +269,8 @@ export interface UsageEvent {
   fiveHourResetsAt?: string;
   sevenDayPercent?: number;
   sevenDayResetsAt?: string;
+  /** Per-model weekly sub-limits (Fable etc). Omitted when the plan has none. */
+  scopedLimits?: ScopedModelLimit[];
   // Extra usage (pay-per-use beyond plan limits)
   extraUsageEnabled?: boolean;
   extraUsageMonthlyLimit?: number;


### PR DESCRIPTION
## Problem

The OAuth usage payload (`api.anthropic.com/api/oauth/usage`) carries a `limits[]` array alongside `five_hour` / `seven_day`. Its `weekly_scoped` rows describe **per-model carve-outs** of the weekly pool. On a Max plan today that means Fable, which draws from its own slice with its own reset:

```json
{ "kind": "weekly_scoped", "group": "weekly", "percent": 12, "severity": "normal",
  "resets_at": "2026-07-29T15:59:59Z",
  "scope": { "model": { "id": null, "display_name": "Fable" } }, "is_active": true }
```

`usage-api.ts` reads only the two top-level windows and discards the array, so `UsageEvent` has nowhere to carry this and the HUD cannot show it. A user burning through their Fable allowance sees `seven_day` creeping and no explanation.

## Change

**Data path.** `parseScopedLimits()` picks the `weekly_scoped` rows (skipping `session` / `weekly_all`, which duplicate the fields already read) and they flow through `ApiUsageData.scopedLimits` → `UsageEvent.scopedLimits`. Rows are keyed by `scope.model.display_name` because `scope.model.id` is commonly `null`. They ride the existing `subscriptionQuotaApplies` gate — a per-model carve-out of a plan quota is meaningless on API billing.

Caches written before this change have no such key, so `readFileCache()` normalizes it to `[]` on read rather than making every consumer guard.

**Pixoo HUD.** Each scoped limit gets its own 7px band under Claude's. Bands now stack upward from the bottom edge (`64 - n * 7`) instead of choosing between two hardcoded offsets, so a third row lands without overflowing. A scoped row is a sub-limit rather than a provider, so it docks the model's initial where a provider draws its official mark; the 3×5 font gains `C F O S` — the initials the payload can scope today (`seven_day_opus`, `seven_day_sonnet`, `seven_day_cowork` are already reserved keys) — plus a solid-chip fallback via `fontCanRender()` for anything else.

**Session-state tally.** Separately, the top-edge strip now counts live sessions by state (processing / awaiting / idle) instead of drawing one dot per agent type. Creature shape already carries agent type; "how many are waiting on me" had no readout at all, and that is the thing you most want at a glance across a tank of six.

## Verification

Ran against a live Max account with an active Fable sub-limit, on real hardware (Pixoo64, firmware reporting `Hardware: 92`):

- HUD renders `9% 3h59` / `8% 6h55` for Claude and a second band `F  12% 6h55` for Fable, matching the payload.
- Tally reads `•1` processing / `•8` idle against the daemon's live session list.
- `pnpm build` clean; `pnpm generate-protocol` re-run and the regenerated Swift/Kotlin/JSON-schema bindings are included, so `protocol-generated-sync` stays green.
- Full suite: 2042 passing across 120 files (3 new cases in `usage-event.test.ts` covering forwarding, absence, and the API-billing gate).
- `eslint` clean on every touched file — no new warnings.

## Notes

- Purely additive on the wire. Clients that ignore `scopedLimits` are unaffected.
- Only the Node renderer is updated. `apple/AgentDeck/Daemon/Modules/PixooRenderer.swift` mirrors this file and would need the same treatment to keep the two surfaces identical — happy to follow up there if you'd like it in the same PR.
- The tally replacing the agent-type dots is a judgment call about what is worth the top seven rows. If you'd rather keep the dots, that part is easy to drop without touching the scoped-limit work.
