### PR TITLE
fix(tests): green the Windows suite — LF working tree + platform-aware tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The repo is LF-everywhere, including Windows working trees: bash scripts,
+# vitest-imported .mjs generators, and byte-compared generated mirrors all
+# break under CRLF smudging (core.autocrlf). Only cmd.exe scripts stay CRLF.
+* text=auto eol=lf
+*.bat text eol=crlf

--- a/bridge/src/__tests__/linux-service.test.ts
+++ b/bridge/src/__tests__/linux-service.test.ts
@@ -21,12 +21,18 @@ import {
   installUnit,
 } from '../linux-service.js';
 
+// The vitest harness pins AGENTDECK_DATA_DIR to a host tmpdir (vitest.setup.ts),
+// which on Windows is a `C:\…` path the systemd validator rightly rejects. Tests
+// that don't care about the data dir pass this POSIX fixture instead of
+// inheriting the env, so the unit builder stays pure and cross-platform.
+const posixDataDir = '/tmp/agentdeck-test-data';
+
 describe('buildUnitFile', () => {
   const node = '/usr/bin/node';
   const cliJs = '/home/alice/.local/share/agentdeck/cli.js';
 
   it('produces a well-formed unit with the three standard sections', () => {
-    const unit = buildUnitFile({ node, cliJs });
+    const unit = buildUnitFile({ node, cliJs, dataDirOverride: posixDataDir });
     expect(unit).toContain('[Unit]');
     expect(unit).toContain('[Service]');
     expect(unit).toContain('[Install]');
@@ -35,19 +41,19 @@ describe('buildUnitFile', () => {
   });
 
   it('runs the daemon in the foreground so systemd supervises the real process', () => {
-    const unit = buildUnitFile({ node, cliJs });
+    const unit = buildUnitFile({ node, cliJs, dataDirOverride: posixDataDir });
     expect(unit).toContain(`ExecStart="${node}" "${cliJs}" daemon start --foreground`);
     expect(unit).toContain('Type=simple');
   });
 
   it('mirrors LaunchAgent KeepAlive via Restart=on-failure', () => {
-    const unit = buildUnitFile({ node, cliJs });
+    const unit = buildUnitFile({ node, cliJs, dataDirOverride: posixDataDir });
     expect(unit).toContain('Restart=on-failure');
     expect(unit).toContain('RestartSec=5');
   });
 
   it('waits for the network to be online', () => {
-    const unit = buildUnitFile({ node, cliJs });
+    const unit = buildUnitFile({ node, cliJs, dataDirOverride: posixDataDir });
     expect(unit).toContain('After=network-online.target');
     expect(unit).toContain('Wants=network-online.target');
   });
@@ -142,7 +148,11 @@ describe('unit-file escaping (golden bytes)', () => {
   });
 
   it('doubles $ and % in ExecStart words (expanded there even inside quotes)', () => {
-    const unit = buildUnitFile({ node: '/opt/n v$1/node', cliJs: '/opt/deck %i/cli.js' });
+    const unit = buildUnitFile({
+      node: '/opt/n v$1/node',
+      cliJs: '/opt/deck %i/cli.js',
+      dataDirOverride: posixDataDir,
+    });
     expect(unit).toContain('ExecStart="/opt/n v$$1/node" "/opt/deck %%i/cli.js" daemon start --foreground');
   });
 
@@ -244,7 +254,9 @@ describe('installUnit (fresh data dir)', () => {
     if (scratch) rmSync(scratch, { recursive: true, force: true });
   });
 
-  it('creates a not-yet-existing data directory before touching systemd', () => {
+  // win32: needs a data dir that is both fs-creatable and '/'-absolute for the
+  // systemd validator — no such path exists on Windows; ubuntu CI covers it.
+  it.skipIf(process.platform === 'win32')('creates a not-yet-existing data directory before touching systemd', () => {
     scratch = mkdtempSync(join(tmpdir(), 'agentdeck-linux-svc-'));
     const dataDir = join(scratch, 'data', 'agentdeck'); // nested + absent
     process.env.AGENTDECK_DATA_DIR = dataDir;

--- a/bridge/src/__tests__/python-ble-runtime.test.ts
+++ b/bridge/src/__tests__/python-ble-runtime.test.ts
@@ -39,12 +39,17 @@ describe('optional Python BLE runtime', () => {
   it('resolves packaged scripts from the bridge package and keeps the venv in the data directory', () => {
     const root = join(tempDir(), 'bridge');
     const dataDir = join(tempDir(), 'data');
-    const paths = resolveBleRuntimePaths({ packageRoot: root, dataDir, env: {} });
+    // Pin the platform: the venv interpreter location is platform-shaped
+    // (bin/python vs Scripts\python.exe), the rest is host-join()ed either way.
+    const paths = resolveBleRuntimePaths({ packageRoot: root, dataDir, env: {}, platform: 'linux' });
 
     expect(paths.scripts.idotmatrixScan).toBe(join(root, 'src', 'idotmatrix', 'scan.py'));
     expect(paths.scripts.timeboxSync).toBe(join(root, 'src', 'timebox', 'sync_ble.py'));
     expect(paths.venvPython).toBe(join(dataDir, 'python-ble', 'venv', 'bin', 'python'));
     expect(paths.legacyPython).toBe(join(root, '..', '.venv', 'bin', 'python'));
+
+    const win = resolveBleRuntimePaths({ packageRoot: root, dataDir, env: {}, platform: 'win32' });
+    expect(win.venvPython).toBe(join(dataDir, 'python-ble', 'venv', 'Scripts', 'python.exe'));
   });
 
   it('reports missing npm assets instead of silently disabling BLE', () => {
@@ -57,7 +62,8 @@ describe('optional Python BLE runtime', () => {
 
     expect(status.ready).toBe(false);
     expect(status.reason).toContain('npm package is missing');
-    expect(status.reason).toContain('python/requirements-ble.txt');
+    // The reason embeds host-join()ed relative paths — backslashes on Windows.
+    expect(status.reason?.replace(/\\/g, '/')).toContain('python/requirements-ble.txt');
   });
 
   it('creates and marks a persistent environment on first explicit setup', () => {

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,6 +14,8 @@ The Node.js **bridge**, the Claude Code **hook installer**, and the **Stream Dec
 | **Claude Code CLI** on `PATH` | Yes | `npm install -g @anthropic-ai/claude-code` |
 | **Git Bash or WSL** on `PATH` | For source scripts | Only the bash scripts under `scripts/` (`install.sh`, `uninstall.sh`, `package-plugin.sh`, …) need it. `pnpm install`/`build`/`test` are pure Node |
 
+**Line endings**: the repo's `.gitattributes` checks everything out LF (bash scripts, vitest-imported generators, and byte-compared generated mirrors all break under CRLF), overriding any local `core.autocrlf`. A clone from before it existed keeps its CRLF working tree until files are rewritten — convert in place by deleting the tracked files and running `git restore .`, or just re-clone.
+
 ## Install
 
 ```powershell

--- a/hooks/src/__tests__/install.test.ts
+++ b/hooks/src/__tests__/install.test.ts
@@ -358,7 +358,7 @@ describe('steering hook channels (request-response)', () => {
     expect(notif).toContain('|| true');
   });
 
-  it('migration 5 upgrades fire-and-forget Stop hooks to request-response', () => {
+  it('migration 5 rewrites legacy Stop hooks to the current platform hook set (request-response on POSIX)', () => {
     const legacyStopCommand = [
       'PORT="${AGENTDECK_PORT:-}"',
       '# daemon.json lookup elided',
@@ -376,8 +376,17 @@ describe('steering hook channels (request-response)', () => {
     applyHooks(settings);
     const stopCmd = (settings.hooks.Stop as Array<{ hooks: Array<{ command: string }> }>)
       .flatMap((h) => h.hooks).map((h) => h.command).join('\n');
-    expect(stopCmd).toContain('RESP=$(curl');
-    expect(stopCmd).toContain('/hooks/Stop');
+    // The essential property: the legacy fire-and-forget hook was rewritten to
+    // the current platform hook set. Only POSIX has a request-response Stop
+    // variant; win32 emits its fire-and-forget PowerShell form (which builds the
+    // URI as '/hooks/'+$ev, so the literal '/hooks/Stop' never appears in it).
+    if (process.platform === 'win32') {
+      expect(stopCmd).toContain('Invoke-RestMethod');
+      expect(stopCmd).toContain("$ev='Stop'");
+    } else {
+      expect(stopCmd).toContain('RESP=$(curl');
+      expect(stopCmd).toContain('/hooks/Stop');
+    }
   });
 });
 

--- a/scripts/__tests__/version-policy.test.ts
+++ b/scripts/__tests__/version-policy.test.ts
@@ -1,9 +1,12 @@
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { readTargetVersion, releaseTargets, validateReleaseVersion } from '../release-version.mjs';
 import { areVersionsCompatible, compatibilityLine, parseNumericVersion } from '../version-policy.mjs';
 
-const root = new URL('../..', import.meta.url).pathname;
+// fileURLToPath, not URL.pathname: the latter yields '/E:/…' on Windows, which
+// path.resolve() mangles into 'E:\E:\…'.
+const root = fileURLToPath(new URL('../..', import.meta.url));
 
 describe('cross-target version compatibility', () => {
   it('ignores patch values and ordering within the same major.minor line', () => {

--- a/scripts/generate-protocol.sh
+++ b/scripts/generate-protocol.sh
@@ -20,6 +20,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="${AGENTDECK_PROTOCOL_OUT_DIR:-$PROJECT_DIR/generated/protocol}"
 
+# Windows interop: a caller may hand us a Windows-native override ('C:\Users\…').
+# Under WSL the caller's WSLENV(/p) flag translates it to /mnt/c/… before bash
+# sees it; under Git Bash it arrives raw, where forward slashes suffice. Only
+# the override is normalized — the default is a POSIX path, where a backslash
+# is a legal character. Children (generate-command-builders.mjs) read the same
+# variable from the environment, so re-export the normalized form — but only
+# when an override was actually set: exporting the default would redirect
+# command-builders.ts away from shared/src/.
+if [ -n "${AGENTDECK_PROTOCOL_OUT_DIR:-}" ]; then
+  OUT_DIR="${OUT_DIR//\\//}"
+  export AGENTDECK_PROTOCOL_OUT_DIR="$OUT_DIR"
+fi
+
 mkdir -p "$OUT_DIR"
 
 echo "=== Step 1: Generate JSON Schema from TypeScript ==="

--- a/shared/src/__tests__/protocol-generated-sync.test.ts
+++ b/shared/src/__tests__/protocol-generated-sync.test.ts
@@ -45,7 +45,15 @@ describe('generated protocol artifacts in sync', () => {
     freshDir = mkdtempSync(join(tmpdir(), 'agentdeck-protocol-'));
     execFileSync('bash', ['scripts/generate-protocol.sh'], {
       cwd: repoRoot,
-      env: { ...process.env, AGENTDECK_PROTOCOL_OUT_DIR: freshDir },
+      env: {
+        ...process.env,
+        AGENTDECK_PROTOCOL_OUT_DIR: freshDir,
+        // On Windows, `bash` may be WSL, which drops custom env vars unless
+        // WSLENV names them — and /p translates the path (C:\… → /mnt/c/…).
+        // Git Bash ignores WSLENV and receives the variable natively.
+        WSLENV: [process.env.WSLENV, 'AGENTDECK_PROTOCOL_OUT_DIR/p']
+          .filter(Boolean).join(':'),
+      },
       stdio: 'pipe',
     });
     return () => rmSync(freshDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`pnpm test` on Windows failed with 13 tests across 7 suites — none tied to any feature work, all environmental. This PR makes the full suite and every locally-runnable PR check green on Windows without weakening any drift gate and without changing ubuntu CI behavior.

- **`.gitattributes` (new)** — `* text=auto eol=lf` + `*.bat text eol=crlf`. The index is already 100% LF (verified: `git add --renormalize .` stages nothing), so this only governs working-tree checkout. CRLF smudging under `core.autocrlf=true` broke bash scripts (`set -o pipefail\r`), vitest imports of the `.mjs` generators, and the golden byte comparisons in the terrarium / session-weight drift gates.
- **`version-policy.test.ts`** — `fileURLToPath` instead of `URL.pathname` (`'/E:/…'` → `resolve()` → `'E:\E:\…'` ENOENT).
- **`linux-service.test.ts`** — the unit-builder tests inherited the harness's Windows tmpdir via `AGENTDECK_DATA_DIR`, which the systemd validator rightly rejects; they now pass an explicit POSIX fixture (no validation bypass, same golden bytes). The one fs-touching test is `skipIf(win32)` — no path is both fs-creatable and `/`-absolute on Windows; ubuntu CI still runs it.
- **`python-ble-runtime.test.ts`** — pins `platform: 'linux'` for the venv-path shape, adds an explicit win32-shape assertion, and normalizes separators in the missing-assets message check.
- **`install.test.ts`** — migration-5 assertion is platform-branched: win32 emits the fire-and-forget PowerShell hook form (no request-response Stop variant exists there); POSIX assertions unchanged. Title updated to state the property honestly.
- **`generate-protocol.sh` + `protocol-generated-sync.test.ts`** — real bug: where `bash` resolves to WSL, custom Windows env vars are dropped entirely, so the drift gate silently regenerated into the repo working tree and compared against an empty temp dir (it never actually gated on Windows). Fixed with `WSLENV=…/p` (WSL propagates + path-translates; Git Bash ignores it and gets the var natively) plus backslash normalization scoped to the override in the script.
- **`docs/windows.md`** — line-endings note with the conversion recipe for pre-`.gitattributes` clones.

## Verification (local, Windows 11)

- Full vitest: **137 files / 2247 passed / 3 skipped / 0 failed** (was 13 failures, confirmed on master first)
- Coverage 48.4 / 44.1 / 47.6 / 49.7 vs thresholds 17/15/14/16
- verify-version, build, typecheck, check-preview-mirror-sync (10 pins in sync), `generate-protocol` → zero diff in the CI gate scope, verify-tokens-sync (+ self-test), design-system `--check`, docs:check, sync-pages-nav `--check`, sync-hardware-spec-cards `--check`: all pass
- Design lint: local totals are grep-version artifacts (same tree bytes: 89 on ubuntu, 91 under WSL grep, 316 under git-bash grep 3.0) — no lint-scoped file is touched by this diff, and CRLF→LF was verified count-neutral

## Ubuntu CI impact

None on any traced path: the env var is unset in CI so the new script block is a no-op; `WSLENV` is inert on Linux; the linux-service and installUnit tests run unskipped; a fresh Linux clone checks out `gradlew.bat` CRLF, which no workflow invokes (all use `./gradlew`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)