### PR TITLE
fix(plugin): adapt the Codex usage encoder to a single live window

### DIFF
--- a/docs/streamdeck-layout.md
+++ b/docs/streamdeck-layout.md
@@ -85,6 +85,26 @@ No session while daemon is connected: healthy idle dashboard, not recovery UI. S
 
 No encoder handles LCD touch.
 
+**Usage encoders rotate only through the windows the provider actually reports.**
+A window's zoom stop exists while that window does, so E3 is `both → 7d → session`
+whenever Codex reports the weekly cap alone — which it has since 2026-07-12, when
+the 5h rolling window disappeared upstream (permanently, not the transient
+post-reset slot flip `normalizeCodexRateLimits` already absorbs). In the `both`
+view a lone gauge keeps its half-width geometry rather than stretching across the
+full 200px LCD, **stays in its canonical column — 5H left, 7D right — and keeps
+printing its own reset countdown**, so a Codex `7D` panel is structurally
+identical to the `7D` panel E2 draws beside a live `5H`.
+
+The freed column carries a side card set one type step below the gauge (18px vs
+26px), so it reads as context rather than a second instrument. It never restates
+the gauge: best-available is the **subscription** behind the quota
+(`CHATGPT / PLUS / Renews Aug 5`, the renewal rolled forward from Codex's
+one-shot `auth.json` snapshot by `resolveChatGptRenewalDate`), then the bare plan
+tier, then the window's **absolute** reset instant (`Sat 18:02` — the one fact the
+gauge's relative countdown does not carry). Nothing knowable means no card, which
+drops the encoder back to the two-panel layout. Providers still reporting both
+windows render unchanged.
+
 When the daemon is down, all four LCDs render one 800px OFFLINE banner and a press
 opens the AgentDeck app.
 

--- a/plugin/src/__tests__/usage-encoder.test.ts
+++ b/plugin/src/__tests__/usage-encoder.test.ts
@@ -7,7 +7,8 @@
  * notes are distinct, and stale data suppresses the tanks.
  */
 import { describe, it, expect } from 'vitest';
-import { buildClaudeUsageEncoder, buildCodexUsageEncoder } from '../utility-modes/usage.js';
+import { buildClaudeUsageEncoder, buildCodexUsageEncoder, availableUsageViews } from '../utility-modes/usage.js';
+import { renderUsageEncoderBoth } from '../renderers/usage-gauge.js';
 
 const CODEX_LIMITS = {
   primary: { usedPercent: 30, windowMinutes: 300, resetsAt: '2099-01-01T00:00:00Z' },
@@ -70,5 +71,165 @@ describe('buildCodexUsageEncoder', () => {
     expect(enc.note).toBeUndefined();
     expect(enc.fiveHour.known).toBe(true);
     expect(enc.sevenDay.known).toBe(false);
+  });
+});
+
+/**
+ * Single-window companion readout.
+ *
+ * Codex stopped reporting its 5h rolling window upstream on 2026-07-12 and has
+ * reported the weekly cap alone since (verified across every rollout from
+ * 2026-07-13 on), so the "one live window" shape is the steady state, not an
+ * edge case. The freed half carries the SUBSCRIPTION behind the quota; the
+ * window's own countdown stays inside the gauge, where E2 also prints it.
+ */
+describe('buildCodexUsageEncoder — single live window', () => {
+  const WEEKLY_ONLY = { secondary: CODEX_LIMITS.secondary, planType: 'plus' };
+  const CHATGPT_SUB = [{ name: 'ChatGPT Plus', until: '2026-08-05T06:21:49Z' }];
+
+  it('shows the subscription tier and its next renewal', () => {
+    const enc = buildCodexUsageEncoder({ codexRateLimits: WEEKLY_ONLY, subscriptions: CHATGPT_SUB }, true);
+    expect(enc.fiveHour.known).toBe(false);
+    expect(enc.sevenDay.known).toBe(true);
+    expect(enc.sideCard).toMatchObject({ label: 'CHATGPT', value: 'PLUS' });
+    expect(enc.sideCard?.sub).toMatch(/^Renews [A-Z][a-z]{2} \d{1,2}$/);
+  });
+
+  it('leaves the countdown to the gauge instead of restating it on the card', () => {
+    const enc = buildCodexUsageEncoder({ codexRateLimits: WEEKLY_ONLY, subscriptions: CHATGPT_SUB }, true);
+    // The gauge still carries resetsAt, so the card must not repeat that fact.
+    expect(enc.sevenDay.resetsAt).toBe(CODEX_LIMITS.secondary.resetsAt);
+    expect(enc.sideCard?.label).not.toBe('RESETS');
+  });
+
+  it('picks the ChatGPT subscription by name, never by position', () => {
+    const enc = buildCodexUsageEncoder(
+      { codexRateLimits: WEEKLY_ONLY, subscriptions: [{ name: 'Claude' }, ...CHATGPT_SUB] },
+      true,
+    );
+    expect(enc.sideCard).toMatchObject({ label: 'CHATGPT', value: 'PLUS' });
+  });
+
+  it('drops the renewal line when the subscription has no boundary', () => {
+    const enc = buildCodexUsageEncoder(
+      { codexRateLimits: WEEKLY_ONLY, subscriptions: [{ name: 'ChatGPT Pro' }] },
+      true,
+    );
+    expect(enc.sideCard).toMatchObject({ label: 'CHATGPT', value: 'PRO' });
+    expect(enc.sideCard?.sub).toBeUndefined();
+  });
+
+  it('falls back to the bare plan tier when no subscription is reported', () => {
+    const enc = buildCodexUsageEncoder({ codexRateLimits: WEEKLY_ONLY }, true);
+    expect(enc.sideCard).toMatchObject({ label: 'PLAN', value: 'PLUS' });
+  });
+
+  it('falls back to the absolute reset instant when even the tier is unknown', () => {
+    const enc = buildCodexUsageEncoder(
+      { codexRateLimits: { secondary: CODEX_LIMITS.secondary } },
+      true,
+    );
+    // Absolute, not relative — the gauge already prints the countdown. Local-time
+    // formatting, so pin the SHAPE; a literal would pass only in one timezone.
+    expect(enc.sideCard?.label).toBe('RESETS');
+    expect(enc.sideCard?.value).toMatch(/^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) \d{2}:\d{2}$/);
+  });
+
+  it('adds no card at all when the stale window leaves nothing knowable', () => {
+    const enc = buildCodexUsageEncoder(
+      { codexRateLimits: { secondary: { usedPercent: 23, windowMinutes: 10080, stale: true } } },
+      true,
+    );
+    expect(enc.sideCard).toBeUndefined();
+  });
+
+  it('adds no side card while both windows are live', () => {
+    const enc = buildCodexUsageEncoder(
+      { codexRateLimits: { ...CODEX_LIMITS, planType: 'plus' }, subscriptions: CHATGPT_SUB },
+      true,
+    );
+    expect(enc.sideCard).toBeUndefined();
+  });
+});
+
+describe('renderUsageEncoderBoth — single live window', () => {
+  it('keeps the lone weekly gauge in its canonical right column, side card on the left', () => {
+    const enc = buildCodexUsageEncoder(
+      {
+        codexRateLimits: { secondary: CODEX_LIMITS.secondary, planType: 'plus' },
+        subscriptions: [{ name: 'ChatGPT Plus', until: '2026-08-05T06:21:49Z' }],
+      },
+      true,
+    );
+    const svg = renderUsageEncoderBoth(enc);
+    // 7D stays in the column E2 puts it in, so both encoders agree on where a
+    // window lives. The gauge is identified by its clip (only encPanel clips).
+    expect(svg).toContain('<clipPath id="enc-codex-both-solo"><rect x="102"');
+    // Side card takes the freed 5H column; no dim "—" ghost panel survives.
+    expect(svg).toContain('<rect x="4" y="18" width="94" height="80" rx="7"');
+    expect(svg).toContain('CHATGPT');
+    expect(svg).toContain('PLUS');
+    expect(svg).not.toContain('>—<');
+  });
+
+  it('keeps the gauge printing its own countdown, like E2 does', () => {
+    const svg = renderUsageEncoderBoth(
+      buildCodexUsageEncoder(
+        {
+          codexRateLimits: { secondary: CODEX_LIMITS.secondary },
+          subscriptions: [{ name: 'ChatGPT Plus' }],
+        },
+        true,
+      ),
+    );
+    // formatResetTime output for a far-future window: "<n>d" or "<n>d<n>h".
+    expect(svg).toMatch(/>\d+d(\d+h)?</);
+  });
+
+  it('keeps a lone 5h gauge in the left column instead', () => {
+    const svg = renderUsageEncoderBoth(
+      buildCodexUsageEncoder({ codexRateLimits: { primary: CODEX_LIMITS.primary } }, true),
+    );
+    expect(svg).toContain('<clipPath id="enc-codex-both-solo"><rect x="4"');
+    expect(svg).toContain('<rect x="102" y="18" width="94" height="80" rx="7"');
+  });
+
+  it('renders the side card smaller than the gauge percentage', () => {
+    const svg = renderUsageEncoderBoth(
+      buildCodexUsageEncoder(
+        {
+          codexRateLimits: { secondary: CODEX_LIMITS.secondary },
+          subscriptions: [{ name: 'ChatGPT Plus', until: '2026-08-05T06:21:49Z' }],
+        },
+        true,
+      ),
+    );
+    // Gauge percentage stays the headline (26); the card is context (18). At
+    // gauge weight the card's multi-character value out-read the gauge itself.
+    expect(svg).toContain('font-size="26"');
+    expect(svg).toContain('font-size="18"');
+  });
+
+  it('still renders two gauges when both windows are live', () => {
+    const svg = renderUsageEncoderBoth(buildCodexUsageEncoder({ codexRateLimits: CODEX_LIMITS }, true));
+    expect(svg).not.toContain('RESETS');
+    expect(svg).toContain('5H');
+    expect(svg).toContain('7D');
+  });
+});
+
+describe('availableUsageViews', () => {
+  it('drops the zoom stop for a window the provider no longer reports', () => {
+    const weekly = buildCodexUsageEncoder({ codexRateLimits: { secondary: CODEX_LIMITS.secondary } }, true);
+    expect(availableUsageViews(weekly)).toEqual(['both', '7d', 'session']);
+  });
+
+  it('keeps every stop while both windows are live', () => {
+    const both = buildCodexUsageEncoder({ codexRateLimits: CODEX_LIMITS }, true);
+    expect(availableUsageViews(both)).toEqual(['both', '5h', '7d', 'session']);
+  });
+
+  it('leaves only the gauge and session stops when no window exists', () => {
+    expect(availableUsageViews(buildCodexUsageEncoder({}, true))).toEqual(['both', 'session']);
   });
 });

--- a/plugin/src/actions/iterm-dial.ts
+++ b/plugin/src/actions/iterm-dial.ts
@@ -23,7 +23,7 @@ import { encoderRegistry, isDaemonConnected } from '../encoder-registry.js';
 import { svgToDataUrl } from '../renderers/button-renderer.js';
 import { renderUsageEncoderBoth, renderUsageEncoderSingle } from '../renderers/usage-gauge.js';
 import { renderUsageSession } from '../renderers/usage-dial-renderer.js';
-import { type UsageModeData, updateUsageModeData, getUsageModeData, fireUsageRefresh, buildCodexUsageEncoder } from '../utility-modes/usage.js';
+import { type UsageModeData, type UsageView, updateUsageModeData, getUsageModeData, fireUsageRefresh, buildCodexUsageEncoder, availableUsageViews } from '../utility-modes/usage.js';
 import type { ConnectionManager } from '../connection-manager.js';
 import { renderOfflineTouchStrip } from '../renderers/session-slot-renderer.js';
 import { dlog, dinfo } from '../log.js';
@@ -32,14 +32,12 @@ import { openAgentDeckAppOrGitHub } from '../system/index.js';
 
 const PIXMAP_LAYOUT = 'layouts/encoder-layout.json';
 
-/** Views the dial rotates through. */
-const USAGE_VIEWS = ['both', '5h', '7d', 'session'] as const;
-type UsageView = typeof USAGE_VIEWS[number];
-
 let currentLayout = '';
 let hasReceivedData = false;
-/** Dial-cycled view index for the Codex usage encoder (E3). */
-let viewIndex = 0;
+/** Dial-cycled view for the Codex usage encoder (E3). Held as the view ITSELF,
+ *  not an index — the reachable list resizes as windows appear/disappear, and a
+ *  retained index would silently land on a different view. */
+let currentView: UsageView = 'both';
 
 export function initUsageDial(_bridge: ConnectionManager): void {
   dinfo('CodexUsageDial', 'initUsageDial called');
@@ -94,7 +92,10 @@ function refreshUsageDials(): void {
 function renderCodexUsageView(): string {
   const data = getUsageModeData();
   const enc = buildCodexUsageEncoder(data, hasReceivedData);
-  const view: UsageView = USAGE_VIEWS[viewIndex];
+  // A window can vanish between rotations (or never arrive), so re-anchor to a
+  // reachable view instead of rendering a stop that no longer exists.
+  const views = availableUsageViews(enc);
+  const view: UsageView = views.includes(currentView) ? currentView : 'both';
   if (view === 'session') {
     // Session tokens/cost are shared (not Codex-specific). When none exist, fall
     // back to the windows rather than an empty text card.
@@ -132,10 +133,13 @@ export class UsageDialAction extends SingletonAction {
 
   override async onDialRotate(ev: DialRotateEvent): Promise<void> {
     if (!isDaemonConnected()) return;
-    // Rotation cycles the usage view (both → 5h → 7d → session).
+    // Rotation cycles the views the current payload actually has — with only a
+    // weekly window that is both → 7d → session, no dead 5h stop.
     const dir = ev.payload.ticks >= 0 ? 1 : -1;
-    viewIndex = (viewIndex + dir + USAGE_VIEWS.length) % USAGE_VIEWS.length;
-    dlog('CodexUsageDial', `rotate → view=${USAGE_VIEWS[viewIndex]}`);
+    const views = availableUsageViews(buildCodexUsageEncoder(getUsageModeData(), hasReceivedData));
+    const at = views.indexOf(currentView);
+    currentView = views[((at < 0 ? 0 : at) + dir + views.length) % views.length];
+    dlog('CodexUsageDial', `rotate → view=${currentView}`);
     refreshUsageDials();
   }
 

--- a/plugin/src/renderers/usage-gauge.ts
+++ b/plugin/src/renderers/usage-gauge.ts
@@ -176,6 +176,27 @@ export interface UsageEncoderTank {
   stale?: boolean;
 }
 
+/**
+ * Companion readout shown beside a lone gauge in the 'both' view. A provider can
+ * permanently report a single window (Codex dropped its 5h rolling window
+ * upstream on 2026-07-12 and has reported the weekly cap alone ever since), which
+ * left the other half of the LCD as a dim "—" ghost. This card fills that half
+ * with the facts the gauge itself cannot carry: how far out the reset is in
+ * absolute terms, or the plan tier.
+ */
+export interface UsageEncoderSideCard {
+  /** Small dim heading, e.g. "RESETS" / "PLAN". */
+  label: string;
+  /** Headline value, e.g. "6d2h" / "PLUS". */
+  value: string;
+  /** Optional second line, e.g. the absolute reset instant "Thu 15:02". */
+  sub?: string;
+  /** Dim the headline. Set for the stale marker so it matches the desaturated
+   *  gauge beside it — a "not current" notice must not be the loudest thing on
+   *  the LCD. */
+  muted?: boolean;
+}
+
 export interface UsageEncoderData {
   agent: 'claude' | 'codex';
   /** Top-left title, e.g. "CLAUDE" / "CODEX". */
@@ -188,6 +209,8 @@ export interface UsageEncoderData {
    * reports no rate limits). Keeps the agent title + brand framing.
    */
   note?: string;
+  /** Companion readout for the single-window 'both' view (see the interface). */
+  sideCard?: UsageEncoderSideCard;
 }
 
 function encSvgWrap(inner: string): string {
@@ -209,6 +232,7 @@ function encHeader(data: UsageEncoderData, muted = false): string {
 function encPanel(
   x: number, y: number, w: number, h: number,
   tank: UsageEncoderTank, clipId: string, big: boolean,
+  showReset = true,
 ): string {
   const panelRx = 7;
   const clip = `<clipPath id="${clipId}"><rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${panelRx}"/></clipPath>`;
@@ -240,7 +264,9 @@ function encPanel(
       `</g>`
     : '';
   // Expired window: muted "stale" marker instead of the (absent) countdown.
-  const reset = stale ? 'stale' : formatResetTime(tank.resetsAt);
+  // `showReset` is false when a side card already carries the reset horizon —
+  // printing it twice on one 200px LCD reads as a rendering bug.
+  const reset = showReset ? (stale ? 'stale' : formatResetTime(tank.resetsAt)) : '';
   const pctColor = stale ? LABEL_DIM : HEADLINE;
   const resetColor = stale ? LABEL_DIM : COUNTDOWN;
 
@@ -270,10 +296,61 @@ function encNote(data: UsageEncoderData): string {
   );
 }
 
-/** 'both' view: 5H and 7D as two side-by-side full-bleed mini level-fills. */
+/**
+ * Companion readout beside a lone gauge: a dim heading, a bold value, and an
+ * optional second line. Same chip background and corner radius as `encPanel` so
+ * the two halves read as one instrument rather than a gauge plus a caption.
+ */
+function encSideCard(x: number, y: number, w: number, h: number, card: UsageEncoderSideCard): string {
+  const cx = x + w / 2;
+  // Deliberately smaller than the gauge's 26px percentage: this half is context
+  // for the reading, not a second reading. Matching the gauge's weight made the
+  // encoder look like two competing instruments.
+  return (
+    `<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="7" fill="${CHIP}"/>` +
+    `<text x="${cx}" y="${y + 18}" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="11" font-weight="bold" fill="${LABEL_DIM}">${esc(card.label)}</text>` +
+    `<text x="${cx}" y="${y + 47}" text-anchor="middle" font-family="Arial,sans-serif" font-size="${card.muted ? 16 : 18}" font-weight="bold" fill="${card.muted ? LABEL_DIM : COUNTDOWN}">${esc(card.value)}</text>` +
+    (card.sub
+      ? `<text x="${cx}" y="${y + 67}" text-anchor="middle" font-family="Arial,sans-serif" font-size="12" fill="${LABEL_DIM}">${esc(card.sub)}</text>`
+      : '')
+  );
+}
+
+/**
+ * 'both' view: 5H and 7D as two side-by-side full-bleed mini level-fills.
+ *
+ * When the provider reports only ONE live window the second panel would be a
+ * permanent dim "—" ghost (Codex dropped its 5h rolling window upstream on
+ * 2026-07-12 and has reported the weekly cap alone since). The lone gauge KEEPS
+ * its half-width geometry — stretching one level-fill across the full 200px LCD
+ * reads as a banner, not a gauge — and the freed half carries the side card
+ * instead. Providers still reporting both windows are unaffected.
+ *
+ * The gauge also keeps its CANONICAL COLUMN — 5H left, 7D right — so E2 (Claude,
+ * both windows) and E3 (Codex, weekly only) put the same window in the same
+ * place. Centring the lone gauge or always drawing it left made the two
+ * encoders disagree about where "7D" lives, which read as a layout glitch.
+ *
+ * The gauge keeps printing its own reset countdown too, exactly as it does
+ * beside a sibling gauge on E2 — moving that number out to the side card made
+ * the same fact live in a different place depending on the provider. The card
+ * therefore carries only what no gauge can: the subscription behind the quota.
+ */
 export function renderUsageEncoderBoth(data: UsageEncoderData): string {
   if (data.note != null) return encNote(data);
   const y = 18, h = 80;
+  const live = [data.fiveHour, data.sevenDay].filter((t) => t.known);
+  if (live.length === 1 && data.sideCard) {
+    const soloIsWeekly = data.sevenDay.known;
+    const gaugeX = soloIsWeekly ? 102 : 4;
+    const cardX = soloIsWeekly ? 4 : 102;
+    return encSvgWrap(
+      `<rect width="${ENC_W}" height="${ENC_H}" fill="${BG}"/>` +
+      encHeader(data) +
+      encSideCard(cardX, y, 94, h, data.sideCard) +
+      encPanel(gaugeX, y, 94, h, live[0], `enc-${data.agent}-both-solo`, false),
+    );
+  }
   return encSvgWrap(
     `<rect width="${ENC_W}" height="${ENC_H}" fill="${BG}"/>` +
     encHeader(data) +

--- a/plugin/src/utility-modes/usage.ts
+++ b/plugin/src/utility-modes/usage.ts
@@ -70,6 +70,42 @@ export function formatResetTime(iso?: string): string {
   } catch { return ''; }
 }
 
+/**
+ * Absolute reset instant in the user's local time, e.g. "Thu 15:02".
+ *
+ * Pairs with `formatResetTime`'s relative countdown on the single-window encoder
+ * view: a weekly window resets ~7 days out, where "6d2h" answers "how long do I
+ * have" but not "which day do I get it back" — and the weekday alone would be
+ * ambiguous without the countdown beside it.
+ */
+export function formatResetAbsolute(iso?: string): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    const wd = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()];
+    return `${wd} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  } catch { return ''; }
+}
+
+/**
+ * Subscription renewal date, e.g. "Aug 5" — the year is added only when the
+ * boundary is far enough out (annual plans) that the month alone is ambiguous.
+ * The upstream value is the NEXT renewal, already rolled forward from Codex's
+ * one-shot `auth.json` snapshot (`resolveChatGptRenewalDate`), so this is a
+ * live boundary rather than the stale stamp the token carries.
+ */
+export function formatRenewalDate(iso?: string): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    const mon = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][d.getMonth()];
+    const far = d.getTime() - Date.now() > 300 * 24 * 3600e3;
+    return far ? `${mon} ${d.getDate()} ${d.getFullYear()}` : `${mon} ${d.getDate()}`;
+  } catch { return ''; }
+}
+
 export function formatTokens(n?: number): string {
   if (n == null) return '0';
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -80,7 +116,7 @@ export function formatTokens(n?: number): string {
 // ─── SD+ usage-encoder data builders (Phase 2) ──────────────────────────────
 // Map the shared usage snapshot onto the 200×100 dual-tank encoder renderer.
 
-import type { UsageEncoderData } from '../renderers/usage-gauge.js';
+import type { UsageEncoderData, UsageEncoderSideCard } from '../renderers/usage-gauge.js';
 
 /**
  * Build the Claude usage encoder (E2) from the shared snapshot.
@@ -109,6 +145,24 @@ export function buildClaudeUsageEncoder(data: UsageModeData, hasReceivedData: bo
  * (`limit_id`/`credits`, null windows) surface the balance in the note instead.
  * @param hasReceivedData false before the first usage_update → "Waiting…".
  */
+/** Views a usage encoder can rotate through (the live subset is per-payload). */
+export const USAGE_VIEWS = ['both', '5h', '7d', 'session'] as const;
+export type UsageView = typeof USAGE_VIEWS[number];
+
+/**
+ * Views actually reachable for the current payload. A window's zoom stop exists
+ * only while that window does: Codex stopped reporting its 5h rolling window
+ * upstream on 2026-07-12, so a fixed list left one of four rotation stops
+ * showing a full-bleed "—" for a window that no longer exists.
+ */
+export function availableUsageViews(enc: Pick<UsageEncoderData, 'fiveHour' | 'sevenDay'>): UsageView[] {
+  const views: UsageView[] = ['both'];
+  if (enc.fiveHour.known) views.push('5h');
+  if (enc.sevenDay.known) views.push('7d');
+  views.push('session');
+  return views;
+}
+
 export function buildCodexUsageEncoder(data: UsageModeData, hasReceivedData: boolean): UsageEncoderData {
   // NB: Codex rate limits come from local rollout files, independent of the
   // Claude-API `usageStale` flag — so we do NOT blank Codex on global staleness
@@ -128,11 +182,54 @@ export function buildCodexUsageEncoder(data: UsageModeData, hasReceivedData: boo
       note = 'No Codex usage';
     }
   }
+  // Exactly one live window — Codex has reported the weekly cap alone since
+  // 2026-07-12, when the 5h rolling window disappeared upstream for good (not the
+  // transient post-reset slot flip the daemon normalizer already handles). Fill
+  // the half the missing gauge used to occupy with the SUBSCRIPTION behind the
+  // quota: which plan is paying for it and when it next renews. The window's own
+  // countdown stays inside the gauge, where E2 also prints it.
+  const solo = primary != null && secondary == null ? primary
+    : primary == null && secondary != null ? secondary
+    : undefined;
   return {
     agent: 'codex',
     title: 'CODEX',
     fiveHour: { label: '5H', usedPercent: primary?.usedPercent ?? 0, resetsAt: primary?.resetsAt, known: primary != null, stale: primary?.stale === true },
     sevenDay: { label: '7D', usedPercent: secondary?.usedPercent ?? 0, resetsAt: secondary?.resetsAt, known: secondary != null, stale: secondary?.stale === true },
     note,
+    sideCard: solo ? buildCodexSideCard(data, cx, solo) : undefined,
   };
+}
+
+/**
+ * The companion card beside a lone Codex gauge, best-available first:
+ * the subscription (tier + next renewal), the bare plan tier, and finally the
+ * window's absolute reset instant — the one fact the gauge's relative countdown
+ * does NOT carry, so it never restates what sits beside it. Returns undefined
+ * when nothing is known, which drops the encoder back to the two-panel layout.
+ */
+function buildCodexSideCard(
+  data: UsageModeData,
+  cx: CodexRateLimits | undefined,
+  solo: { resetsAt?: string; stale?: boolean },
+): UsageEncoderSideCard | undefined {
+  // `subscriptions` is multi-provider; match by name, never by index.
+  const sub = data.subscriptions?.find((s) => s.name.toLowerCase().startsWith('chatgpt'));
+  if (sub) {
+    // "ChatGPT Plus" → CHATGPT / PLUS, so the tier is the headline and the
+    // 94px-wide card never has to shrink a 12-character string to fit.
+    const rest = sub.name.slice('chatgpt'.length).trim();
+    const renewal = formatRenewalDate(sub.until);
+    return {
+      label: rest ? 'CHATGPT' : 'PLAN',
+      value: (rest || sub.name).toUpperCase().slice(0, 10),
+      sub: renewal ? `Renews ${renewal}` : undefined,
+    };
+  }
+  const tier = cx?.planType?.trim();
+  if (tier) return { label: 'PLAN', value: tier.toUpperCase().slice(0, 10) };
+  if (!solo.stale && solo.resetsAt) {
+    return { label: 'RESETS', value: formatResetAbsolute(solo.resetsAt), muted: true };
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Problem

Codex stopped reporting its **5h rolling window** on **2026-07-12**. Every rollout since reports only the weekly cap:

```
primary   {used_percent: 23.0, window_minutes: 10080, resets_at: …}
secondary null
plan_type "plus"
```

Verified across the full `~/.codex/sessions` history — `window_minutes:300` last appears on 2026-07-12, and 07-13 → 08-03 is 10080-only. This is a **permanent upstream change**, not the transient post-reset slot flip that `normalizeCodexRateLimits` already absorbs.

The data path handled it correctly (length-based normalization puts the weekly window in `secondary`), but **E3 was still laid out for two windows**: half the 200×100 LCD was a permanent dim `5H / —` ghost, and one of four rotation stops zoomed a window that no longer exists.

## Change

**Gauge stays put.** The lone gauge keeps its half-width geometry (a full-bleed 192px level-fill reads as a banner, not a gauge) and its **canonical column** — 5H left, 7D right — so a Codex `7D` panel is structurally identical to the one E2 draws beside a live `5H`. It also keeps printing **its own reset countdown**; moving that number out to the side card made the same fact live in a different place depending on the provider.

**Freed column carries context, not a second reading.** The side card sits one type step below the gauge (18px vs 26px) and never restates it. Best-available first:

1. Subscription — `CHATGPT / PLUS / Renews Aug 5` (renewal rolled forward from Codex's one-shot `auth.json` snapshot by `resolveChatGptRenewalDate`, so it is the next real boundary rather than the stale stamp the token carries)
2. Bare plan tier — `PLAN / PLUS`
3. The window's **absolute** reset instant — `RESETS / Sat 18:02`, the one fact a relative countdown omits
4. Nothing knowable → no card, and the two-panel layout returns

**Rotation visits only live windows** — `both → 7d → session`. The current view is held as the view itself, not an index, so a list that resizes as windows appear/disappear cannot silently land on a different stop.

## Scope

- Claude's E2 is **untouched**, so this does not collide with the scoped-limits work in #99. Providers reporting both windows render unchanged (pinned by test).
- No new raw hex — the side card reuses the existing token constants.

## Verification

- Full suite green (2342 tests); 24 in `usage-encoder.test.ts` covering name-based subscription selection (never positional), a plan with no renewal boundary, the card not restating the countdown, both left/right column placements, and the type hierarchy.
- `pnpm docs:check` green.
- Rendered from the live payload and checked as pixels for all four states: both windows / current Codex / no subscription info / stale.