### PR TITLE
fix(hooks): validate daemon ports before posting

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,33 @@
 
 ---
 
+## 2026-08-04 — Hook loopback URL의 포트 주입 차단
+
+### 문제
+Claude/Codex hook 설치기가 `AGENTDECK_PORT`와 `daemon.json`의 포트 값을 검증하지
+않고 `http://127.0.0.1:$PORT/...`에 보간했다. 숫자가 아닌 값, 특히 `@`를 포함한 값은
+URL 파서에서 앞부분을 userinfo로 바꾸어 loopback이 아닌 호스트로 hook payload를
+전송하게 만들 수 있었다. 동일한 snippet이 hooks, setup, macOS 앱에 중복 생성되어
+한 작성기만 고치면 설치 경로에 따라 취약한 설정이 다시 생길 수 있는 상태였다.
+
+### 해결
+- POSIX 작성기 5곳과 PowerShell 작성기 3곳 모두 환경 변수와 daemon JSON 포트를
+  **정수 1–65535**로 제한하고, 검증 실패 시 탐색을 계속하거나 기본값 9120으로
+  강등한다.
+- POSIX daemon 파일 경로는 Python source에 삽입하지 않고 argv로 전달해, 홈 경로의
+  따옴표가 코드로 해석되는 문제도 함께 제거했다.
+- 기존 Claude hook에는 migration 9를 추가해 검증 marker가 없는 설치를 한 번만
+  자동 재생성한다. Codex OTel endpoint와 Swift daemon 포트 판독에도 같은 범위를
+  적용했다.
+- 실제 shell 실행 회귀 테스트로 악성 문자열·범위 밖 포트 차단, 정상 daemon 포트
+  선택, 따옴표가 포함된 홈 경로를 확인하고, 모든 공동 작성기의 검증 marker를
+  교차 검사한다.
+- 검증: TypeScript 2,382개, 문서 88개, 변경 대상 macOS 테스트 7개 통과. macOS
+  전체 486개에서는 이 변경과 무관한 기존 세션 정렬 기대값 테스트 1개만 실패하고
+  1개가 skip됐다.
+
+---
+
 ## 2026-08-03 (3) — Codex 5h 창의 영구 소멸, 그리고 DRM 체크섬이 3일간 죽여둔 플러그인
 
 ### 문제

--- a/apple/AgentDeck/Daemon/Core/CodexConfigInstaller.swift
+++ b/apple/AgentDeck/Daemon/Core/CodexConfigInstaller.swift
@@ -54,8 +54,8 @@ enum CodexConfigInstaller {
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }
-        if let p = obj["httpPort"] as? Int, p > 0 { return p }
-        if let p = obj["port"] as? Int, p > 0 { return p }
+        if let p = obj["httpPort"] as? Int, (1...65535).contains(p) { return p }
+        if let p = obj["port"] as? Int, (1...65535).contains(p) { return p }
         return nil
     }
 
@@ -302,11 +302,12 @@ enum CodexConfigInstaller {
     private static func buildNotifySnippet(event: String) -> String {
         let lines = [
             #"PORT="${AGENTDECK_PORT:-}""#,
+            #"case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac"#,
             #"if [ -z "$PORT" ]; then"#,
             #"  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do"#,
             #"    [ -f "$F" ] || continue"#,
-            #"    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)"#,
-            #"    [ -n "$P" ] && curl -sf --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }"#,
+            #"    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)"#,
+            #"    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }"#,
             #"  done"#,
             #"fi"#,
             #"PORT="${PORT:-9120}""#,
@@ -351,11 +352,12 @@ enum CodexConfigInstaller {
     private static func buildStdinPostSnippet(event: String) -> String {
         let lines = [
             #"PORT="${AGENTDECK_PORT:-}""#,
+            #"case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac"#,
             #"if [ -z "$PORT" ]; then"#,
             #"  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do"#,
             #"    [ -f "$F" ] || continue"#,
-            #"    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)"#,
-            #"    [ -n "$P" ] && curl -sf --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }"#,
+            #"    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)"#,
+            #"    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }"#,
             #"  done"#,
             #"fi"#,
             #"PORT="${PORT:-9120}""#,

--- a/apple/AgentDeck/Daemon/Core/HookInstaller.swift
+++ b/apple/AgentDeck/Daemon/Core/HookInstaller.swift
@@ -293,10 +293,11 @@ enum HookInstaller {
     private static func buildHookCommand(_ event: String) -> String {
         let preamble = [
             #"PORT="${AGENTDECK_PORT:-}""#,
+            #"case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac"#,
             #"if [ -z "$PORT" ]; then"#,
             #"  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do"#,
             #"    [ -f "$F" ] || continue"#,
-            #"    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)"#,
+            #"    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)"#,
             #"    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }"#,
             #"  done"#,
             #"fi"#,

--- a/apple/AgentDeckTests/CodexConfigInstallerTests.swift
+++ b/apple/AgentDeckTests/CodexConfigInstallerTests.swift
@@ -62,6 +62,8 @@ final class CodexConfigInstallerTests: XCTestCase {
         XCTAssertTrue(withFence.contains("/hooks/codex_tool_end"))
         XCTAssertTrue(withFence.contains("/hooks/codex_stop"))
         XCTAssertTrue(withFence.contains("--connect-timeout 0.2 --max-time 0.8"))
+        XCTAssertTrue(withFence.contains("*[!0-9]*"))
+        XCTAssertTrue(withFence.contains("type(p) is int and 1 <= p <= 65535"))
         XCTAssertTrue(withFence.contains("notify ="))
         XCTAssertTrue(withFence.contains("[otel.trace_exporter.otlp-http]"))
         XCTAssertTrue(withFence.contains("/otel/v1/traces"))

--- a/hooks/src/__tests__/codex-install.test.ts
+++ b/hooks/src/__tests__/codex-install.test.ts
@@ -264,6 +264,8 @@ describe('codex-install: managedBlockBody', () => {
     expect(withFence).toContain('/hooks/codex_tool_end');
     expect(withFence).toContain('/hooks/codex_stop');
     expect(withFence).toContain('--connect-timeout 0.2 --max-time 0.8');
+    expect(withFence).toContain('*[!0-9]*');
+    expect(withFence).toContain('type(p) is int and 1 <= p <= 65535');
     expect(withFence).toContain('notify =');
     expect(withFence).toContain('[otel.trace_exporter.otlp-http]');
     expect(withFence).toContain('/otel/v1/traces');
@@ -304,6 +306,8 @@ describe('codex-install: managedBlockBody', () => {
     // codepage) and posted as UTF-8 bytes (string bodies get ISO-8859-1).
     expect(decoded).toContain('StreamReader([Console]::OpenStandardInput(), [System.Text.Encoding]::UTF8)');
     expect(decoded).toContain('[System.Text.Encoding]::UTF8.GetBytes');
+    expect(decoded).toContain('[int]::TryParse');
+    expect(decoded).toContain('$candidate -gt 65535');
 
     for (const line of withFence.split('\n').filter((value) => value.startsWith('command = '))) {
       expect(line).not.toContain('$ErrorActionPreference');
@@ -318,7 +322,9 @@ describe('codex-install: managedBlockBody', () => {
     expect(script).toContain('$args[$args.Count - 1]');
     expect(script).toContain('/hooks/codex_turn_complete');
     expect(script).toContain('$env:AGENTDECK_PORT');
-    expect(script).toContain("$port = '9120'");
+    expect(script).toContain('$port = 9120');
+    expect(script).toContain('[int]::TryParse');
+    expect(script).toContain('$candidate -gt 65535');
     expect(script).toContain('exit 0');
     // String bodies get ISO-8859-1-encoded by Invoke-RestMethod, mangling
     // non-ASCII payload text — the script must post UTF-8 bytes.
@@ -326,6 +332,17 @@ describe('codex-install: managedBlockBody', () => {
     // PowerShell 5.1 reads BOM-less scripts as ANSI — keep content ASCII
     // so both interpretations are byte-identical.
     expect(/^[\x00-\x7F]*$/.test(script)).toBe(true);
+  });
+
+  it('falls back instead of emitting an out-of-range OTel endpoint', () => {
+    const body = managedBlockBody({
+      includeNotify: false,
+      includeOtel: true,
+      daemonHttpPort: 70000,
+      platform: 'linux',
+    });
+    expect(body).toContain('endpoint = "http://127.0.0.1:9120/otel/v1/traces"');
+    expect(body).not.toContain(':70000/');
   });
 
   it('omits conflicting optional channels when asked', () => {

--- a/hooks/src/__tests__/install.test.ts
+++ b/hooks/src/__tests__/install.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { chmodSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { execFileSync } from 'child_process';
 import {
   HOOK_EVENTS,
   buildHookCommand,
@@ -54,6 +55,89 @@ describe('Hook Installer', () => {
       expect(cmd).toContain('-X POST "http://127.0.0.1:$PORT/hooks/SessionStart"');
     });
 
+    it('keeps strict port-validation markers in every co-owned hook writer', () => {
+      const root = process.cwd();
+      const posixWriters = [
+        'hooks/src/install.ts',
+        'hooks/src/codex-install.ts',
+        'setup/src/setup.ts',
+        'apple/AgentDeck/Daemon/Core/HookInstaller.swift',
+        'apple/AgentDeck/Daemon/Core/CodexConfigInstaller.swift',
+      ];
+      for (const path of posixWriters) {
+        const source = readFileSync(join(root, path), 'utf-8');
+        expect(source, path).toContain('*[!0-9]*');
+        expect(source, path).toContain('1 <= p <= 65535');
+      }
+
+      for (const path of ['hooks/src/install.ts', 'hooks/src/codex-install.ts', 'setup/src/setup.ts']) {
+        const source = readFileSync(join(root, path), 'utf-8');
+        expect(source, path).toContain('[int]::TryParse');
+        expect(source, path).toContain('65535');
+      }
+    });
+
+    it.skipIf(process.platform === 'win32')('rejects non-numeric and out-of-range ports before URL construction', () => {
+      for (const malicious of ['9120@evil.example', '-1', '0', '65536', '12.5', ' 9120']) {
+        const home = mkdtempSync(join(tmpdir(), "agentdeck-port-o'"));
+        const bin = join(home, 'bin');
+        const capture = join(home, 'curl.log');
+        mkdirSync(join(home, '.agentdeck'), { recursive: true });
+        mkdirSync(bin);
+        // A malicious string from daemon.json must be rejected too. The home
+        // path deliberately contains an apostrophe: passing the filename as a
+        // Python argv (instead of interpolating it into source) keeps it safe.
+        writeFileSync(join(home, '.agentdeck', 'daemon.json'), JSON.stringify({ httpPort: malicious }));
+        const fakeCurl = join(bin, 'curl');
+        writeFileSync(fakeCurl, '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$CAPTURE_FILE"\nexit 0\n');
+        chmodSync(fakeCurl, 0o755);
+
+        execFileSync('/bin/sh', ['-c', buildHookCommand('SessionStart')], {
+          env: {
+            ...process.env,
+            HOME: home,
+            AGENTDECK_PORT: malicious,
+            CAPTURE_FILE: capture,
+            PATH: `${bin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+          },
+          input: '{}',
+        });
+
+        const urls = readFileSync(capture, 'utf-8');
+        expect(urls).toContain('http://127.0.0.1:9120/hooks/SessionStart');
+        expect(urls).not.toContain('evil.example');
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    it.skipIf(process.platform === 'win32')('accepts a validated daemon.json port', () => {
+      const home = mkdtempSync(join(tmpdir(), 'agentdeck-valid-port-'));
+      const bin = join(home, 'bin');
+      const capture = join(home, 'curl.log');
+      mkdirSync(join(home, '.agentdeck'), { recursive: true });
+      mkdirSync(bin);
+      writeFileSync(join(home, '.agentdeck', 'daemon.json'), JSON.stringify({ httpPort: 9133 }));
+      const fakeCurl = join(bin, 'curl');
+      writeFileSync(fakeCurl, '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$CAPTURE_FILE"\nexit 0\n');
+      chmodSync(fakeCurl, 0o755);
+
+      execFileSync('/bin/sh', ['-c', buildHookCommand('SessionStart')], {
+        env: {
+          ...process.env,
+          HOME: home,
+          AGENTDECK_PORT: '',
+          CAPTURE_FILE: capture,
+          PATH: `${bin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        },
+        input: '{}',
+      });
+
+      const urls = readFileSync(capture, 'utf-8');
+      expect(urls).toContain('http://127.0.0.1:9133/health');
+      expect(urls).toContain('http://127.0.0.1:9133/hooks/SessionStart');
+      rmSync(home, { recursive: true, force: true });
+    });
+
     it('bounds the fire-and-forget POST so a wedged daemon cannot stall session exit', () => {
       // SessionEnd hooks share one ~1.5s abort budget in Claude Code, and a
       // restarting daemon holds the socket open without replying. Without both
@@ -88,6 +172,8 @@ describe('Hook Installer', () => {
       expect(cmd).toContain("/hooks/'+$ev");
       expect(cmd).toContain('Invoke-RestMethod');
       expect(cmd).toContain('$port=9120');
+      expect(cmd).toContain('[int]::TryParse');
+      expect(cmd).toContain('$candidate -gt 65535');
     });
 
     it('uses single-line PowerShell so cmd.exe can pass it as one -Command argument', () => {
@@ -337,6 +423,32 @@ describe('Hook Installer', () => {
       expect(newCmd).toContain('daemon.json');
       expect(newCmd).not.toContain('${AGENTDECK_PORT:-9120}');
       expect(newCmd).toContain('$PORT');
+    });
+
+    it('self-heals installed hooks that predate strict port validation', () => {
+      const home = mkdtempSync(join(tmpdir(), 'agentdeck-hooks-port-migration-'));
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      const settings = applyHooks({});
+      for (const groups of Object.values(settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>)) {
+        for (const group of groups) {
+          for (const hook of group.hooks) {
+            hook.command = hook.command
+              .split('\n').filter((line) => !line.includes('*[!0-9]*')).join('\n')
+              .replaceAll('[int]::TryParse', '[int]::Parse');
+          }
+        }
+      }
+      const settingsPath = join(home, '.claude', 'settings.json');
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+      migrateHooksIfNeeded(home);
+      const repaired = readFileSync(settingsPath, 'utf-8');
+      const marker = process.platform === 'win32' ? '[int]::TryParse' : '*[!0-9]*';
+      expect(repaired).toContain(marker);
+
+      migrateHooksIfNeeded(home);
+      expect(readFileSync(settingsPath, 'utf-8')).toBe(repaired);
+      rmSync(home, { recursive: true, force: true });
     });
   });
 });

--- a/hooks/src/codex-install.ts
+++ b/hooks/src/codex-install.ts
@@ -38,6 +38,10 @@ export const DEFAULT_CODEX_CONFIG_PATH = join(homedir(), '.codex', 'config.toml'
 export const DEFAULT_WINDOWS_NOTIFY_SCRIPT_PATH = join(homedir(), '.agentdeck', 'codex-notify.ps1');
 const DEFAULT_DAEMON_PORT = 9120;
 
+function isValidPort(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
 export interface InstallOptions {
   /** Override the codex config path (tests + non-default homes). */
   configPath?: string;
@@ -76,14 +80,16 @@ function currentDaemonHttpPort(): number | null {
   if (!existsSync(path)) return null;
   try {
     const obj = JSON.parse(readFileSync(path, 'utf-8'));
-    if (typeof obj.httpPort === 'number' && obj.httpPort > 0) return obj.httpPort;
-    if (typeof obj.port === 'number' && obj.port > 0) return obj.port;
+    if (isValidPort(obj.httpPort)) return obj.httpPort;
+    if (isValidPort(obj.port)) return obj.port;
   } catch { /* malformed JSON — fall through */ }
   return null;
 }
 
 function buildOtelEndpoint(daemonHttpPort?: number): string {
-  const port = daemonHttpPort ?? currentDaemonHttpPort() ?? DEFAULT_DAEMON_PORT;
+  const port = isValidPort(daemonHttpPort)
+    ? daemonHttpPort
+    : currentDaemonHttpPort() ?? DEFAULT_DAEMON_PORT;
   return `http://127.0.0.1:${port}/otel/v1/traces`;
 }
 
@@ -164,18 +170,25 @@ function buildNotifyAssignment(event: string, platform: NodeJS.Platform, notifyS
  *  differs: Claude hooks pipe stdin (`-d @-`); Codex notify hands the
  *  JSON payload as `$1` (`--data-raw "$1"`). */
 function buildNotifySnippet(event: string): string {
+  return posixPortPreamble().concat([
+    `curl -sf --connect-timeout 0.2 --max-time 0.8 -X POST "http://127.0.0.1:$PORT/hooks/${event}" -H 'Content-Type: application/json' --data-raw "$1" 2>/dev/null || true`,
+  ]).join('\n');
+}
+
+/** Canonical POSIX port resolver shared by notify and lifecycle hooks. */
+function posixPortPreamble(): string[] {
   return [
     `PORT="\${AGENTDECK_PORT:-}"`,
+    `case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac`,
     `if [ -z "$PORT" ]; then`,
     `  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do`,
     `    [ -f "$F" ] || continue`,
-    `    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)`,
-    `    [ -n "$P" ] && curl -sf --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }`,
+    `    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)`,
+    `    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }`,
     `  done`,
     `fi`,
     `PORT="\${PORT:-9120}"`,
-    `curl -sf --connect-timeout 0.2 --max-time 0.8 -X POST "http://127.0.0.1:$PORT/hooks/${event}" -H 'Content-Type: application/json' --data-raw "$1" 2>/dev/null || true`,
-  ].join('\n');
+  ];
 }
 
 interface LifecycleHook {
@@ -222,18 +235,9 @@ function buildLifecycleHookCommand(event: string, platform: NodeJS.Platform): st
 }
 
 function buildStdinPostSnippet(event: string): string {
-  return [
-    `PORT="\${AGENTDECK_PORT:-}"`,
-    `if [ -z "$PORT" ]; then`,
-    `  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do`,
-    `    [ -f "$F" ] || continue`,
-    `    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)`,
-    `    [ -n "$P" ] && curl -sf --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }`,
-    `  done`,
-    `fi`,
-    `PORT="\${PORT:-9120}"`,
+  return posixPortPreamble().concat([
     `curl -sf --connect-timeout 0.2 --max-time 0.8 -X POST "http://127.0.0.1:$PORT/hooks/${event}" -H 'Content-Type: application/json' -d @- >/dev/null 2>&1 || true`,
-  ].join('\n');
+  ]).join('\n');
 }
 
 function shellSingleQuoted(s: string): string {
@@ -265,20 +269,24 @@ function buildWindowsPostSnippet(event: string, bodyExpression: string): string 
   return [
     `$ErrorActionPreference = 'SilentlyContinue'`,
     `$ProgressPreference = 'SilentlyContinue'`,
-    `$port = $env:AGENTDECK_PORT`,
-    `if ([string]::IsNullOrWhiteSpace($port)) {`,
+    `[int]$port = 0`,
+    `[int]$candidate = 0`,
+    `if (!([int]::TryParse([string]$env:AGENTDECK_PORT, [ref]$candidate)) -or $candidate -lt 1 -or $candidate -gt 65535) { $candidate = 0 }`,
+    `$port = $candidate`,
+    `if ($port -eq 0) {`,
     `  $daemonFile = Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'`,
     `  if (Test-Path -LiteralPath $daemonFile) {`,
     `    try {`,
     `      $daemon = Get-Content -LiteralPath $daemonFile -Raw | ConvertFrom-Json`,
-    `      $candidate = if ($daemon.httpPort) { $daemon.httpPort } else { $daemon.port }`,
-    `      if ($candidate) {`,
-    `        try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $candidate + '/health') | Out-Null; $port = [string]$candidate } catch {}`,
+    `      $rawCandidate = if ($daemon.httpPort) { $daemon.httpPort } else { $daemon.port }`,
+    `      $candidate = 0`,
+    `      if ([int]::TryParse([string]$rawCandidate, [ref]$candidate) -and $candidate -ge 1 -and $candidate -le 65535) {`,
+    `        try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 1 -Uri ('http://127.0.0.1:' + $candidate + '/health') | Out-Null; $port = $candidate } catch {}`,
     `      }`,
     `    } catch {}`,
     `  }`,
     `}`,
-    `if ([string]::IsNullOrWhiteSpace($port)) { $port = '9120' }`,
+    `if ($port -eq 0) { $port = 9120 }`,
     `$body = ${bodyExpression}`,
     // Post UTF-8 bytes: Invoke-RestMethod encodes string bodies as
     // ISO-8859-1 when the content type carries no charset, replacing

--- a/hooks/src/install.ts
+++ b/hooks/src/install.ts
@@ -61,10 +61,11 @@ export const HOOK_EVENTS = [
 export function buildHookCommand(eventName: string): string {
   const preamble = [
     `PORT="\${AGENTDECK_PORT:-}"`,
+    `case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac`,
     `if [ -z "$PORT" ]; then`,
     `  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do`,
     `    [ -f "$F" ] || continue`,
-    `    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)`,
+    `    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)`,
     `    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }`,
     `  done`,
     `fi`,
@@ -122,8 +123,11 @@ export function buildHookCommand(eventName: string): string {
 export function buildHookCommandWin(eventName: string): string {
   const ps = [
     `$ev='${eventName}'`,
-    `$port=$env:AGENTDECK_PORT`,
-    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $p=if($d.httpPort){$d.httpPort}else{$d.port}; if($p){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$p+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$p}catch{}}}catch{}}}`,
+    `[int]$port=0`,
+    `[int]$candidate=0`,
+    `if(!([int]::TryParse([string]$env:AGENTDECK_PORT,[ref]$candidate)) -or $candidate -lt 1 -or $candidate -gt 65535){$candidate=0}`,
+    `$port=$candidate`,
+    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $raw=if($d.httpPort){$d.httpPort}else{$d.port}; $candidate=0; if([int]::TryParse([string]$raw,[ref]$candidate) -and $candidate -ge 1 -and $candidate -le 65535){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$candidate+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$candidate}catch{}}}catch{}}}`,
     `if(-not $port){$port=9120}`,
     // Read stdin as UTF-8: [Console]::In decodes piped stdin with the console OEM
     // codepage (e.g. CP949), garbling non-ASCII payload text.
@@ -446,6 +450,18 @@ export function migrateHooksIfNeeded(home: string = homedir()): void {
       !settings.hooks?.SubagentStart || !settings.hooks?.SubagentStop
       || !settings.hooks?.TaskCompleted || !settings.hooks?.TeammateIdle
     ) {
+      applyHooks(settings);
+      migrated = true;
+    }
+
+    // Migration 9: pre-validation hook snippets interpolated untrusted env /
+    // daemon.json values directly into a loopback URL. Values containing `@`
+    // can make URL parsers treat `127.0.0.1:<value>` as userinfo and send hook
+    // payloads to a different host. Rebuild once with strict 1..65535 parsing.
+    const hasValidatedPort = process.platform === 'win32'
+      ? raw.includes('[int]::TryParse')
+      : raw.includes('*[!0-9]*');
+    if (!hasValidatedPort) {
       applyHooks(settings);
       migrated = true;
     }

--- a/setup/src/setup.ts
+++ b/setup/src/setup.ts
@@ -228,10 +228,11 @@ const HOOK_EVENTS = [
 function buildHookCommand(eventName: string): string {
   const preamble = [
     `PORT="\${AGENTDECK_PORT:-}"`,
+    `case "$PORT" in ''|*[!0-9]*) PORT="" ;; *) [ "$PORT" -ge 1 ] 2>/dev/null && [ "$PORT" -le 65535 ] 2>/dev/null || PORT="" ;; esac`,
     `if [ -z "$PORT" ]; then`,
     `  for F in "$HOME/.agentdeck/daemon.json" "$HOME/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/daemon.json" "$HOME/Library/Group Containers/group.bound.serendipity.agent.deck/daemon.json"; do`,
     `    [ -f "$F" ] || continue`,
-    `    P=$(python3 -c "import json;d=json.load(open('$F'));print(d.get('httpPort') or d.get('port',''))" 2>/dev/null)`,
+    `    P=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));p=d.get('httpPort') or d.get('port');print(p if type(p) is int and 1 <= p <= 65535 else '')" "$F" 2>/dev/null)`,
     `    [ -n "$P" ] && curl -sf --connect-timeout 0.2 --max-time 0.3 "http://127.0.0.1:$P/health" >/dev/null 2>&1 && { PORT="$P"; break; }`,
     `  done`,
     `fi`,
@@ -264,8 +265,11 @@ function buildHookCommand(eventName: string): string {
 function buildHookCommandWin(eventName: string): string {
   const ps = [
     `$ev='${eventName}'`,
-    `$port=$env:AGENTDECK_PORT`,
-    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $p=if($d.httpPort){$d.httpPort}else{$d.port}; if($p){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$p+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$p}catch{}}}catch{}}}`,
+    `[int]$port=0`,
+    `[int]$candidate=0`,
+    `if(!([int]::TryParse([string]$env:AGENTDECK_PORT,[ref]$candidate)) -or $candidate -lt 1 -or $candidate -gt 65535){$candidate=0}`,
+    `$port=$candidate`,
+    `if(-not $port){$f=Join-Path $env:USERPROFILE '.agentdeck\\daemon.json'; if(Test-Path $f){try{$d=Get-Content -Raw $f|ConvertFrom-Json; $raw=if($d.httpPort){$d.httpPort}else{$d.port}; $candidate=0; if([int]::TryParse([string]$raw,[ref]$candidate) -and $candidate -ge 1 -and $candidate -le 65535){try{Invoke-RestMethod -Uri ('http://127.0.0.1:'+$candidate+'/health') -TimeoutSec 1 -ErrorAction Stop|Out-Null; $port=$candidate}catch{}}}catch{}}}`,
     `if(-not $port){$port=9120}`,
     // Read stdin as UTF-8: [Console]::In decodes piped stdin with the console OEM
     // codepage (e.g. CP949), garbling non-ASCII payload text.


### PR DESCRIPTION
Closes #104.

## What changed

- validate `AGENTDECK_PORT` and daemon JSON ports as integers in the range 1–65535 before constructing loopback URLs
- apply the same rule to Claude/Codex POSIX hooks, PowerShell hooks, setup, and macOS Swift installers
- pass daemon filenames to Python via argv instead of interpolating paths into Python source
- reject invalid Codex OTel port overrides
- add Claude hook migration 9 so pre-validation installs self-heal once
- add execution-level hostile-port, valid-discovery, path-quoting, cross-writer, and migration regressions

## Root cause and impact

Hook writers trusted string port sources and interpolated them into `http://127.0.0.1:$PORT/...`. URL authority syntax such as `@` could reinterpret the nominal loopback portion as userinfo and send hook payloads to another host. Strict numeric range validation preserves the loopback boundary.

## Validation

- GitHub Actions: CI, Design System, and Apple Tests passed
- `pnpm build`
- `pnpm test` — 2,382 passed
- `pnpm docs:check` — 88 Markdown files passed
- focused hooks tests — 82 passed
- focused macOS `CodexConfigInstallerTests` — 7 passed
- local macOS full suite — 486 executed; 484 passed, 1 skipped, 1 local-only unrelated failure: `ProtocolTests.testSortSessionsUnweightedMatchesLegacyOrdering` (expected `[4,1,2]`, current rank implementation returns `[4,2,1]`); the GitHub Apple Tests workflow passed