### PR TITLE
fix(android): propagate live panel profile changes

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -49,6 +49,32 @@ substring으로 판정해, `75A7N`·`43A7N` LCD Google TV도 E-ink로 분류했�
 
 ---
 
+## 2026-08-04 — Android 패널 override를 실행 중 정책과 토폴로지에 전파 (#91)
+
+### 문제
+`MainActivity`는 패널 override 변경 시 새 `DeviceProfile`로 재생성됐지만, 이미 실행
+중인 `MonitorService`는 시작 때 만든 `BrightnessController`와 E-ink stay-on/wake
+정책을 계속 사용했다. 열린 WebSocket도 `client_register`를 `onOpen`에서만 보내
+데몬의 Android `kind`가 다음 재연결까지 이전 값으로 남았다.
+
+### 해결
+- `DeviceProfileHolder`가 실제 프로필 변경만 순서대로 알리고 동일 값 재설치는
+  no-op이 되도록 했다. 서비스와 연결 계층은 `Build.*`를 재판정하지 않고 이 SSOT의
+  결과만 구독한다.
+- 서비스는 E-ink↔LCD 전환 시 진행 중 display 작업을 취소하고 이전 brightness·
+  stay-on·keepalive 효과를 복원한 뒤 새 controller/preferences를 설치하고, 최신
+  bridge 화면 상태를 즉시 다시 적용한다.
+- WebSocket은 연결된 상태에서 display name 또는 `wireKind`가 바뀌면 Android
+  dashboard 등록을 다시 보낸다. 마지막으로 성공한 identity를 기억해 동일 프로필
+  설치와 동일 identity 변경은 중복 등록을 만들지 않는다.
+- 양방향 서비스 정책 전환 순서, 동일 정책 no-op, 연결 중 `tablet`↔`eink` 재등록,
+  연결 끊김 뒤 재시도, holder 중복 억제를 회귀 테스트로 고정했다.
+- 검증: Android 단위 테스트 308개와 Debug APK 조립, 문서 88개 검사를 통과했다.
+  Release APK 스크립트는 clean worktree에 비밀 `android/signing.properties`가 없어
+  서명 전 단계에서 의도대로 중단됐다.
+
+---
+
 ## 2026-08-03 (3) — Codex 5h 창의 영구 소멸, 그리고 DRM 체크섬이 3일간 죽여둔 플러그인
 
 ### 문제

--- a/android/app/src/main/kotlin/dev/agentdeck/net/AndroidDashboardRegistration.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/net/AndroidDashboardRegistration.kt
@@ -1,0 +1,47 @@
+package dev.agentdeck.net
+
+import dev.agentdeck.util.DeviceProfile
+
+internal data class AndroidDashboardIdentity(
+    val id: String,
+    val name: String,
+    val kind: String,
+) {
+    fun payload(): String = PluginCommands.clientRegisterAndroidDashboard(id, name, kind)
+}
+
+internal fun androidDashboardIdentity(model: String, profile: DeviceProfile): AndroidDashboardIdentity =
+    AndroidDashboardIdentity(
+        id = model,
+        name = profile.displayName,
+        kind = profile.wireKind,
+    )
+
+/**
+ * Publishes topology identity on socket open and on live profile changes.
+ * Successful identity is remembered so duplicate installs do not create
+ * registration churn; failed/disconnected sends remain retryable.
+ */
+internal class AndroidDashboardRegistrationCoordinator(
+    private val sendIfConnected: (payload: String) -> Boolean,
+) {
+    private var lastSent: AndroidDashboardIdentity? = null
+
+    @Synchronized
+    fun socketOpened(identity: AndroidDashboardIdentity): Boolean = publish(identity)
+
+    @Synchronized
+    fun socketClosed() {
+        lastSent = null
+    }
+
+    @Synchronized
+    fun profileChanged(identity: AndroidDashboardIdentity): Boolean = publish(identity)
+
+    private fun publish(identity: AndroidDashboardIdentity): Boolean {
+        if (identity == lastSent) return false
+        if (!sendIfConnected(identity.payload())) return false
+        lastSent = identity
+        return true
+    }
+}

--- a/android/app/src/main/kotlin/dev/agentdeck/net/BridgeConnection.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/net/BridgeConnection.kt
@@ -2,6 +2,7 @@ package dev.agentdeck.net
 
 import android.os.Build
 import android.util.Log
+import dev.agentdeck.util.DeviceProfile
 import dev.agentdeck.util.DeviceProfileHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -69,6 +70,18 @@ class BridgeConnection private constructor() {
     /** Whether we've already switched to [fallbackUrl] this connect cycle. */
     private var triedFallback = false
 
+    private val registrationCoordinator = AndroidDashboardRegistrationCoordinator { payload ->
+        val socket = webSocket
+        _status.value == ConnectionStatus.CONNECTED && socket != null && socket.send(payload)
+    }
+    private val profileListener: (DeviceProfile) -> Unit = { profile ->
+        registrationCoordinator.profileChanged(androidDashboardIdentity(Build.MODEL, profile))
+    }
+
+    init {
+        DeviceProfileHolder.addListener(profileListener)
+    }
+
     private val _status = MutableStateFlow(ConnectionStatus.DISCONNECTED)
     val status: StateFlow<ConnectionStatus> = _status.asStateFlow()
 
@@ -101,6 +114,7 @@ class BridgeConnection private constructor() {
         shouldReconnect = false
         webSocket?.close(1000, "New connection")
         webSocket = null
+        registrationCoordinator.socketClosed()
 
         // Only keep a fallback that's actually distinct from the primary.
         this.fallbackUrl = fallbackUrl?.takeIf { it != wsUrl }
@@ -124,6 +138,7 @@ class BridgeConnection private constructor() {
         _lastError.value = null
         webSocket?.close(1000, "User disconnect")
         webSocket = null
+        registrationCoordinator.socketClosed()
         _status.value = ConnectionStatus.DISCONNECTED
         onEvent?.invoke(BridgeEvent.Disconnected)
     }
@@ -177,13 +192,8 @@ class BridgeConnection private constructor() {
                 // anonymous consumer with no visibility anywhere in the UI.
                 // Some models already embed the brand ("Lenovo TB-J606F") —
                 // `DeviceProfile.displayName` is where that de-duplication lives.
-                val name = DeviceProfileHolder.current.displayName
-                webSocket.send(
-                    PluginCommands.clientRegisterAndroidDashboard(
-                        id = Build.MODEL,
-                        name = name,
-                        kind = DeviceProfileHolder.current.wireKind,
-                    )
+                registrationCoordinator.socketOpened(
+                    androidDashboardIdentity(Build.MODEL, DeviceProfileHolder.current)
                 )
             }
 
@@ -208,6 +218,7 @@ class BridgeConnection private constructor() {
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 bridgeDebug { "onClosed — code=$code reason=$reason" }
+                registrationCoordinator.socketClosed()
                 _status.value = ConnectionStatus.DISCONNECTED
                 onEvent?.invoke(BridgeEvent.Disconnected)
                 // Don't reconnect on auth rejection — token required
@@ -235,6 +246,7 @@ class BridgeConnection private constructor() {
                 } else {
                     Log.w(TAG, "onFailure — $msg")
                 }
+                registrationCoordinator.socketClosed()
                 _status.value = ConnectionStatus.DISCONNECTED
                 _lastError.value = msg
                 onEvent?.invoke(BridgeEvent.Disconnected)

--- a/android/app/src/main/kotlin/dev/agentdeck/service/MonitorService.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/service/MonitorService.kt
@@ -58,9 +58,16 @@ class MonitorService : Service() {
     private var savedScreenOffTimeout: Int? = null
     private lateinit var brightnessController: BrightnessController
     private lateinit var displayPrefs: DisplayPreferences
+    private lateinit var panelPolicy: PanelPolicyTransitionManager
     private var idleTimeoutJob: Job? = null
     private var displaySyncJob: Job? = null
     private var lastBridgeDisplayOn = true
+
+    private val profileListener: (DeviceProfile) -> Unit = { profile ->
+        serviceScope.launch {
+            panelPolicy.install(profile.isEink)
+        }
+    }
 
     private inline fun serviceDebug(message: () -> String) {
         if (VERBOSE_SERVICE_LOGS || Log.isLoggable(TAG, Log.DEBUG)) {
@@ -80,25 +87,22 @@ class MonitorService : Service() {
         // MainActivity normally publishes the profile first; only pay for the
         // blocking preference read when this service is the first one up
         // (BootReceiver start, or the activity was killed).
-        isEink = if (DeviceProfileHolder.hasAuthoritativeProfile) {
-            DeviceProfileHolder.current.isEink
-        } else {
+        if (!DeviceProfileHolder.hasAuthoritativeProfile) {
             val startup = DisplayPreferences(this).readStartupOverridesBlocking()
             DeviceProfile.detect(this, startup.panelOverride)
                 .also { DeviceProfileHolder.install(it) }
-                .isEink
         }
-
-        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
-        brightnessController = BrightnessController(this, contentResolver, pm, isEink)
-        displayPrefs = DisplayPreferences(this, isEink)
 
         acquireCpuWakeLock()
-
-        if (isEink) {
-            enableStayOn()
-            handler.postDelayed(keepaliveRunnable, KEEPALIVE_INTERVAL_MS)
-        }
+        panelPolicy = PanelPolicyTransitionManager(
+            restoreCurrent = ::restorePanelPolicy,
+            applyNext = ::applyPanelPolicy,
+            reapplyLatestState = ::reapplyLatestDisplayState,
+        )
+        DeviceProfileHolder.addListener(profileListener)
+        // Subscribe before reading current so a concurrent install is either
+        // observed by the listener or included in this initial read.
+        panelPolicy.install(DeviceProfileHolder.current.isEink)
 
         serviceScope.launch {
             AgentStateHolder.instance.state.collect { state ->
@@ -204,15 +208,45 @@ class MonitorService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        displaySyncJob?.cancel()
-        displaySyncJob = null
-        idleTimeoutJob?.cancel()
-        if (brightnessController.isDimmed()) brightnessController.restore()
-        handler.removeCallbacks(keepaliveRunnable)
-        restoreStayOn()
+        DeviceProfileHolder.removeListener(profileListener)
+        restorePanelPolicy()
         releaseCpuWakeLock()
         serviceScope.cancel()
         super.onDestroy()
+    }
+
+    private fun restorePanelPolicy() {
+        displaySyncJob?.cancel()
+        displaySyncJob = null
+        idleTimeoutJob?.cancel()
+        idleTimeoutJob = null
+        if (::brightnessController.isInitialized && brightnessController.isDimmed()) {
+            brightnessController.restore()
+        }
+        handler.removeCallbacks(keepaliveRunnable)
+        restoreStayOn()
+    }
+
+    private fun applyPanelPolicy(nextIsEink: Boolean) {
+        isEink = nextIsEink
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        brightnessController = BrightnessController(this, contentResolver, pm, isEink)
+        displayPrefs = DisplayPreferences(this, isEink)
+        if (isEink) {
+            enableStayOn()
+            handler.postDelayed(keepaliveRunnable, KEEPALIVE_INTERVAL_MS)
+        }
+        Log.i(TAG, "Panel policy applied: ${if (isEink) "e-ink" else "LCD"}")
+    }
+
+    private fun reapplyLatestDisplayState() {
+        val state = AgentStateHolder.instance.state.value
+        handleDisplaySync(
+            state.hostDisplayOn,
+            state.bridgeConnected,
+            state.agentState,
+            state.hostDim,
+        )
     }
 
     // --- CPU wake lock (PARTIAL — keeps CPU from sleeping) ---

--- a/android/app/src/main/kotlin/dev/agentdeck/service/PanelPolicyTransitionManager.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/service/PanelPolicyTransitionManager.kt
@@ -1,0 +1,27 @@
+package dev.agentdeck.service
+
+/**
+ * Orders a live panel-policy replacement as one transition.
+ *
+ * The old policy must release brightness/stay-on effects before the new
+ * controller observes persistent settings. Reapplying the latest bridge state
+ * afterwards prevents the service from waiting for another StateFlow emission.
+ */
+internal class PanelPolicyTransitionManager(
+    private val restoreCurrent: () -> Unit,
+    private val applyNext: (isEink: Boolean) -> Unit,
+    private val reapplyLatestState: () -> Unit,
+) {
+    private var currentIsEink: Boolean? = null
+
+    fun install(isEink: Boolean): Boolean {
+        if (currentIsEink == isEink) return false
+
+        val replacing = currentIsEink != null
+        if (replacing) restoreCurrent()
+        applyNext(isEink)
+        currentIsEink = isEink
+        if (replacing) reapplyLatestState()
+        return true
+    }
+}

--- a/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfileHolder.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfileHolder.kt
@@ -3,6 +3,7 @@ package dev.agentdeck.util
 import android.content.Context
 import android.util.Log
 import dev.agentdeck.AgentDeckApp
+import java.util.concurrent.CopyOnWriteArraySet
 
 /**
  * Process-wide access to the resolved [DeviceProfile].
@@ -27,6 +28,8 @@ object DeviceProfileHolder {
     @Volatile
     private var authoritative = false
 
+    private val listeners = CopyOnWriteArraySet<(DeviceProfile) -> Unit>()
+
     /**
      * Publish the authoritative profile — one resolved *with* the user's panel
      * override applied. Called from `MainActivity.onCreate` and
@@ -34,16 +37,34 @@ object DeviceProfileHolder {
      * value only logs once; a genuine change (the user flipping the override)
      * is logged because it implies an activity recreate.
      */
-    fun install(profile: DeviceProfile) {
+    @Synchronized
+    fun install(profile: DeviceProfile): Boolean {
         val previous = installed
         authoritative = true
-        if (previous == profile) return
+        if (previous == profile) return false
         installed = profile
         if (previous == null) {
             Log.i(TAG, "Device profile: ${profile.describe()}")
         } else {
             Log.i(TAG, "Device profile changed: ${previous.describe()} → ${profile.describe()}")
         }
+        listeners.forEach { listener ->
+            try {
+                listener(profile)
+            } catch (error: Throwable) {
+                Log.w(TAG, "Device profile listener failed: ${error.message}")
+            }
+        }
+        return true
+    }
+
+    /** Subscribe to genuine profile changes. Installing the same value is a no-op. */
+    fun addListener(listener: (DeviceProfile) -> Unit) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: (DeviceProfile) -> Unit) {
+        listeners.remove(listener)
     }
 
     /**

--- a/android/app/src/test/kotlin/dev/agentdeck/net/AndroidDashboardRegistrationTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/net/AndroidDashboardRegistrationTest.kt
@@ -1,0 +1,65 @@
+package dev.agentdeck.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidDashboardRegistrationTest {
+
+    @Test
+    fun `connected profile change publishes new wire kind without reconnect`() {
+        val payloads = mutableListOf<String>()
+        val coordinator = AndroidDashboardRegistrationCoordinator { payload ->
+            payloads += payload
+            true
+        }
+        val tablet = AndroidDashboardIdentity("model", "AgentDeck Tablet", "tablet")
+        val eink = AndroidDashboardIdentity("model", "AgentDeck Tablet", "eink")
+
+        assertTrue(coordinator.socketOpened(tablet))
+        assertTrue(coordinator.profileChanged(eink))
+
+        assertEquals(2, payloads.size)
+        assertTrue(payloads[0].contains("\"kind\":\"tablet\""))
+        assertTrue(payloads[1].contains("\"kind\":\"eink\""))
+    }
+
+    @Test
+    fun `repeated identity does not duplicate registration churn`() {
+        val payloads = mutableListOf<String>()
+        val coordinator = AndroidDashboardRegistrationCoordinator { payload ->
+            payloads += payload
+            true
+        }
+        val identity = AndroidDashboardIdentity("model", "AgentDeck", "eink")
+
+        assertTrue(coordinator.socketOpened(identity))
+        assertFalse(coordinator.profileChanged(identity))
+        assertFalse(coordinator.profileChanged(identity))
+        assertEquals(1, payloads.size)
+    }
+
+    @Test
+    fun `disconnected change is retried when the socket opens`() {
+        val payloads = mutableListOf<String>()
+        var connected = false
+        val coordinator = AndroidDashboardRegistrationCoordinator { payload ->
+            if (connected) {
+                payloads += payload
+                true
+            } else {
+                false
+            }
+        }
+        val eink = AndroidDashboardIdentity("model", "Reader", "eink")
+
+        coordinator.socketClosed()
+        assertFalse(coordinator.profileChanged(eink))
+        assertEquals(0, payloads.size)
+
+        connected = true
+        assertTrue(coordinator.socketOpened(eink))
+        assertEquals(1, payloads.size)
+    }
+}

--- a/android/app/src/test/kotlin/dev/agentdeck/service/PanelPolicyTransitionManagerTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/service/PanelPolicyTransitionManagerTest.kt
@@ -1,0 +1,51 @@
+package dev.agentdeck.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PanelPolicyTransitionManagerTest {
+
+    @Test
+    fun `eink to lcd restores old effects before applying and re-evaluating`() {
+        val events = mutableListOf<String>()
+        val policy = policy(events)
+
+        assertTrue(policy.install(isEink = true))
+        events.clear()
+
+        assertTrue(policy.install(isEink = false))
+        assertEquals(listOf("restore", "apply:lcd", "reapply"), events)
+    }
+
+    @Test
+    fun `lcd to eink uses the same coherent transition`() {
+        val events = mutableListOf<String>()
+        val policy = policy(events)
+
+        assertTrue(policy.install(isEink = false))
+        events.clear()
+
+        assertTrue(policy.install(isEink = true))
+        assertEquals(listOf("restore", "apply:eink", "reapply"), events)
+    }
+
+    @Test
+    fun `installing the active panel policy is a no-op`() {
+        val events = mutableListOf<String>()
+        val policy = policy(events)
+
+        assertTrue(policy.install(isEink = true))
+        events.clear()
+
+        assertFalse(policy.install(isEink = true))
+        assertTrue(events.isEmpty())
+    }
+
+    private fun policy(events: MutableList<String>) = PanelPolicyTransitionManager(
+        restoreCurrent = { events += "restore" },
+        applyNext = { events += if (it) "apply:eink" else "apply:lcd" },
+        reapplyLatestState = { events += "reapply" },
+    )
+}

--- a/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileHolderTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileHolderTest.kt
@@ -1,0 +1,46 @@
+package dev.agentdeck.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceProfileHolderTest {
+
+    @Test
+    fun `listeners receive genuine changes but not repeated installation`() {
+        val original = DeviceProfileHolder.current
+        val first = profile(PanelKind.Lcd, "Holder LCD")
+        val second = profile(PanelKind.EinkMono, "Holder E-ink")
+        DeviceProfileHolder.install(first)
+
+        val seen = mutableListOf<DeviceProfile>()
+        val listener: (DeviceProfile) -> Unit = { seen += it }
+        DeviceProfileHolder.addListener(listener)
+        try {
+            assertTrue(DeviceProfileHolder.install(second))
+            assertFalse(DeviceProfileHolder.install(second))
+            assertEquals(listOf(second), seen)
+        } finally {
+            DeviceProfileHolder.removeListener(listener)
+            DeviceProfileHolder.install(original)
+        }
+    }
+
+    private fun profile(panel: PanelKind, name: String) = DeviceProfile(
+        panel = panel,
+        sizeClass = ScreenSizeClass.Medium,
+        formFactor = if (panel.isEink) FormFactor.Reader else FormFactor.Tablet,
+        support = SupportLevel.Full,
+        unsupportedReason = null,
+        caveats = emptyList(),
+        einkEvidence = if (panel.isEink) EinkEvidence.UserOverride else EinkEvidence.None,
+        shortestWidthDp = 600,
+        overridden = true,
+        displayName = name,
+        shortLabel = if (panel.isEink) "Reader" else "Tablet",
+    )
+}


### PR DESCRIPTION
Closes #91.

## What changed

- make `DeviceProfileHolder` publish genuine profile changes while suppressing repeated installs
- reconfigure a running `MonitorService` when the resolved panel class changes
- restore old brightness, stay-on, keepalive, and pending display effects before applying the new policy
- immediately re-evaluate the latest bridge display snapshot under the new policy
- re-send Android dashboard topology registration on a connected WebSocket when its display name or `wireKind` changes
- remember the last successful registration identity to avoid duplicate churn

## Root cause and impact

`MainActivity` recreated with the new override-aware `DeviceProfile`, but the foreground service and WebSocket singleton only read the profile at startup/open. The UI could therefore show LCD while the service retained E-ink frontlight/wake policy (or the reverse), and daemon topology remained stale until reconnect.

## Validation

- GitHub Actions: CI, Design System, and Android Tests passed
- `./gradlew :app:testDebugUnitTest` — 308 passed
- `./gradlew :app:assembleDebug` — passed
- `pnpm docs:check` — 88 Markdown files passed
- release script attempted per repository workflow; it stopped before build because the clean worktree intentionally has no untracked `android/signing.properties`