### PR TITLE
fix(android): harden e-ink profile evidence

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -29,6 +29,26 @@ URL 파서에서 앞부분을 userinfo로 바꾸어 loopback이 아닌 호스트
 
 ---
 
+## 2026-08-04 — Hisense LCD TV 오판과 color E-ink evidence 수정 (#92)
+
+### 문제
+혼합 패널 제조사인 Hisense의 E-ink 모델을 `model.contains("a7")` 같은 짧은
+substring으로 판정해, `75A7N`·`43A7N` LCD Google TV도 E-ink로 분류했다. 또한
+`ro.eink.color`/`ro.epd.color` 같은 양성 신호는 색상 승격에만 쓰이고 E-ink evidence
+자체를 만들지 않아, 다른 신호가 없는 실제 color reader를 LCD로 조기 반환했다.
+
+### 해결
+- Hisense A5/A5C, A7/A7CC, A9, HiReader 계열은 양쪽 영숫자 경계와 검증된 접미사로
+  매칭한다. TV의 화면 크기+모델 문자열 중간에 들어간 `A7N`은 더 이상 맞지 않는다.
+- 양성 color E-ink 신호를 `SystemProperty` evidence로 승격해 단독 신호만으로도
+  `EinkColor`까지 도달시킨다. 기존 truthiness 필터는 `0`·`false`·`off` 등
+  false-like property를 계속 거부한다.
+- Hisense LCD TV 2종, 실제 E-ink family 변형 9종, color-only evidence, false-like
+  color property를 회귀 테스트로 고정했다.
+- 검증: Android 단위 테스트 305개, Debug APK 조립, 문서 88개 검사를 통과했다.
+
+---
+
 ## 2026-08-03 (3) — Codex 5h 창의 영구 소멸, 그리고 DRM 체크섬이 3일간 죽여둔 플러그인
 
 ### 문제

--- a/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfile.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfile.kt
@@ -356,6 +356,10 @@ private fun resolvePanel(fp: DeviceFingerprint, override: PanelOverride): PanelR
 private fun einkEvidence(fp: DeviceFingerprint): EinkEvidence {
     if (fp.hasVendorEinkApi) return EinkEvidence.VendorApi
     if (fp.hasEinkSystemProperty) return EinkEvidence.SystemProperty
+    // `ro.eink.color` / `ro.epd.color` is not merely a colour hint: a positive
+    // value proves that the underlying panel is e-ink even when the vendor
+    // exposes no generic e-ink property or SDK.
+    if (fp.hasColorEinkSignal) return EinkEvidence.SystemProperty
 
     val characteristics = fp.characteristics.lowercase()
     if (EINK_TOKENS.any { characteristics.contains(it) }) return EinkEvidence.BuildCharacteristics
@@ -371,10 +375,20 @@ private fun einkEvidence(fp: DeviceFingerprint): EinkEvidence {
     val model = fp.model.lowercase()
     for ((vendor, models) in MIXED_VENDOR_EINK_MODELS) {
         if (identity.none { it.contains(vendor) }) continue
-        if (models.any { model.contains(it) }) return EinkEvidence.KnownModel
+        if (matchesMixedVendorEinkModel(vendor, model, models)) return EinkEvidence.KnownModel
     }
 
     return EinkEvidence.None
+}
+
+private fun matchesMixedVendorEinkModel(
+    vendor: String,
+    model: String,
+    models: Set<String>,
+): Boolean = if (vendor == "hisense") {
+    HISENSE_EINK_MODEL_PATTERN.containsMatchIn(model)
+} else {
+    models.any { model.contains(it) }
 }
 
 private fun isColorEink(fp: DeviceFingerprint): Boolean {
@@ -475,9 +489,9 @@ private val EINK_ONLY_VENDORS = setOf(
 
 /**
  * Vendors that ship both panel types: an e-ink verdict requires a model token.
- * Tokens may be short here precisely because the vendor gate already ran — a
- * bare `"note"` cannot reach a Redmi, and `"paper"` cannot reach anything but
- * a Huawei.
+ * Most tokens are distinctive within their vendor. Hisense's A5/A7/A9 names
+ * are handled by [HISENSE_EINK_MODEL_PATTERN] instead of substring matching,
+ * because ordinary TVs also contain strings such as `75A7N` and `43A7N`.
  */
 private val MIXED_VENDOR_EINK_MODELS: Map<String, Set<String>> = mapOf(
     // Q5 is deliberately absent: the Hisense Q5 (HITV105C) is a monochrome
@@ -492,6 +506,15 @@ private val MIXED_VENDOR_EINK_MODELS: Map<String, Set<String>> = mapOf(
     "fujitsu" to setOf("quaderno"),
     "sony" to setOf("dpt"),
     "rockchip" to setOf("boox", "crema", "pantone", "inkpalm"),
+)
+
+/**
+ * Verified Hisense E-ink phone/reader families. The surrounding non-alphanumeric
+ * boundaries are the critical part: A7 and its A7CC colour variant match, while
+ * television size/model strings such as 75A7N cannot match in the middle.
+ */
+private val HISENSE_EINK_MODEL_PATTERN = Regex(
+    "(?:^|[^a-z0-9])(?:a5c?|a7(?:cc)?|a9|hi[\\s_-]*reader)(?:$|[^a-z0-9])",
 )
 
 /**

--- a/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileTest.kt
@@ -88,6 +88,34 @@ class DeviceProfileTest {
         assertEquals(EinkEvidence.KnownModel, profile.einkEvidence)
     }
 
+    @Test
+    fun `hisense lcd television model numbers do not match short eink families`() {
+        listOf("75A7N", "43A7N").forEach { model ->
+            val profile = classifyDevice(
+                fingerprint(
+                    manufacturer = "Hisense",
+                    model = model,
+                    hasTouchScreen = false,
+                    uiModeType = Configuration.UI_MODE_TYPE_TELEVISION,
+                    shortestWidthDp = 960,
+                )
+            )
+            assertEquals("$model must remain LCD", PanelKind.Lcd, profile.panel)
+            assertEquals(FormFactor.Television, profile.formFactor)
+            assertEquals(EinkEvidence.None, profile.einkEvidence)
+        }
+    }
+
+    @Test
+    fun `verified hisense eink families retain model detection`() {
+        listOf("A5", "A5 Pro", "A5C", "A7", "A7 CC", "A7CC", "A9", "A9 Pro", "HiReader")
+            .forEach { model ->
+                val profile = classifyDevice(fingerprint(manufacturer = "Hisense", model = model))
+                assertTrue("$model must remain e-ink", profile.panel.isEink)
+                assertEquals(EinkEvidence.KnownModel, profile.einkEvidence)
+            }
+    }
+
     // MARK: - Devices the previous detector recognised must keep working
 
     @Test
@@ -181,6 +209,19 @@ class DeviceProfileTest {
         assertEquals(PanelKind.EinkColor, profile.panel)
     }
 
+    @Test
+    fun `color signal alone establishes eink evidence`() {
+        val profile = classifyDevice(
+            fingerprint(
+                manufacturer = "Unknown",
+                model = "Color Reader",
+                hasColorEinkSignal = true,
+            )
+        )
+        assertEquals(PanelKind.EinkColor, profile.panel)
+        assertEquals(EinkEvidence.SystemProperty, profile.einkEvidence)
+    }
+
     // MARK: - System property truthiness
 
     @Test
@@ -191,6 +232,14 @@ class DeviceProfileTest {
         listOf("", "  ", "0", "false", "FALSE", " False ", "off", "no", "none", "null", "unset", "unknown", "disabled")
             .forEach { value ->
                 assertFalse("\"$value\" must not count as a signal", isTruthySystemProperty(value))
+            }
+    }
+
+    @Test
+    fun `false-like color property values remain rejected`() {
+        listOf("", "0", "false", "off", "no", "none", "null", "disabled")
+            .forEach { value ->
+                assertFalse("color property \"$value\" must not count as a signal", isTruthySystemProperty(value))
             }
     }
 


### PR DESCRIPTION
Closes #92.

## What changed

- replace Hisense A5/A7/A9 substring detection with bounded, verified family matching
- keep A5/A5C, A7/A7CC, A9, and HiReader variants recognized
- prevent LCD television models such as `75A7N` and `43A7N` from being classified as E-ink
- treat a positive color E-ink property as `SystemProperty` E-ink evidence, not only as a color upgrade
- preserve false-like system-property filtering

## Root cause and impact

Hisense ships both LCD and E-ink devices, but short `model.contains("a7")`-style checks matched ordinary television model strings. Separately, color E-ink signals were evaluated only after generic E-ink evidence, so a device with only `ro.eink.color`/`ro.epd.color` evidence returned LCD before color promotion.

## Validation

- GitHub Actions: CI, Design System, and Android Tests passed
- `./gradlew :app:testDebugUnitTest` — 305 passed
- `./gradlew :app:assembleDebug` — passed
- `node scripts/check-docs.mjs` — 88 Markdown files passed