### PR TITLE
fix(bridge): track interactive prompt lifecycle

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -75,6 +75,31 @@ substring으로 판정해, `75A7N`·`43A7N` LCD Google TV도 E-ink로 분류했�
 
 ---
 
+## 2026-08-04 — managed PTY interactive prompt lifecycle (#68)
+
+### 문제
+Claude Code가 option/permission UI를 띄운 채 status spinner를 계속 redraw하면
+`OutputParser`가 spinner를 새 processing 신호로 받아 AWAITING을 취소했다. 과거
+시도처럼 append-only buffer에서 `❯ 1.`을 다시 찾거나 고정 시간창을 재무장하면,
+사용자가 이미 답한 뒤에도 오래된 prompt가 실제 processing을 영구 차단한다.
+
+### 해결
+- 현재 PTY chunk의 확정적 증거(`❯ <number>`, permission, diff)로만
+  `interactivePromptActive`를 arm한다. 누적 buffer는 lifecycle 근거로 쓰지 않는다.
+- managed PTY의 입력 경로를 `PtyManager`의 `input` 이벤트로 단일화하고 Claude
+  parser에 전달한다. navigable prompt는 Enter/Esc/Ctrl+C, shortcut prompt는 실제
+  shortcut 입력에서 lifecycle을 해제한다. 방향키 이동은 prompt를 유지한다.
+- lifecycle이 active인 동안 spinner-only redraw는 무시하되, spinner와 prompt가
+  첫 chunk에 함께 온 경우 prompt parser까지 계속 진행한다. idle/reset도 lifecycle을
+  명시적으로 정리한다.
+
+### 회귀 가드
+같은 첫 chunk의 spinner+prompt, 80회 spinner flood, 선택 직후 실제 spinner,
+stale numbered prose 비무장을 추가했다. focused 387 tests, 전체 2,381 tests와
+workspace TypeScript 검사가 통과했다.
+
+---
+
 ## 2026-08-03 (3) — Codex 5h 창의 영구 소멸, 그리고 DRM 체크섬이 3일간 죽여둔 플러그인
 
 ### 문제

--- a/bridge/src/__tests__/output-parser.test.ts
+++ b/bridge/src/__tests__/output-parser.test.ts
@@ -666,6 +666,67 @@ describe('OutputParser', () => {
   // === Interactive Prompt During Spinner ===
 
   describe('interactive prompt during spinner', () => {
+    it('parses a navigable prompt when spinner and prompt share the first chunk', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+
+      const starts = collectEvents(p, 'spinner_start');
+      const options = collectEvents(p, 'option_prompt');
+
+      p.feed('✳ Cooking…\nWhich approach?\n❯ 1. Safe\n  2. Fast\n');
+      vi.advanceTimersByTime(200);
+
+      expect(starts).toHaveLength(0);
+      expect(options).toHaveLength(1);
+      expect(options[0].options.map((option: PromptOption) => option.label)).toEqual(['Safe', 'Fast']);
+    });
+
+    it('keeps a visible prompt active through spinner redraw floods', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+
+      const starts = collectEvents(p, 'spinner_start');
+      const options = collectEvents(p, 'option_prompt');
+
+      p.feed('Which approach?\n❯ 1. Safe\n  2. Fast\n');
+      for (let i = 0; i < 80; i++) {
+        p.feed(`${i % 2 === 0 ? '✻' : '✽'} Running build…\n`);
+        vi.advanceTimersByTime(100);
+      }
+
+      expect(options).toHaveLength(1);
+      expect(starts).toHaveLength(0);
+    });
+
+    it('allows real processing immediately after the prompt is selected', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+
+      const starts = collectEvents(p, 'spinner_start');
+      const options = collectEvents(p, 'option_prompt');
+
+      p.feed('Choose one:\n❯ 1. Alpha\n  2. Beta\n');
+      vi.advanceTimersByTime(200);
+      expect(options).toHaveLength(1);
+
+      p.notifyUserInput('\r');
+      p.feed('✻ Running the selected action\n');
+
+      expect(starts).toHaveLength(1);
+    });
+
+    it('does not arm prompt lifecycle from stale numbered prose', () => {
+      const p = armParser();
+      vi.advanceTimersByTime(500);
+
+      const starts = collectEvents(p, 'spinner_start');
+
+      p.feed('1. Historical note\n2. Another note\n');
+      p.feed('✻ Running the selected action\n');
+
+      expect(starts).toHaveLength(1);
+    });
+
     it('stops spinner when permission prompt arrives', () => {
       const p = armParser();
       vi.advanceTimersByTime(500); // clear idle timer from boot

--- a/bridge/src/adapters/claude-code.ts
+++ b/bridge/src/adapters/claude-code.ts
@@ -18,6 +18,9 @@ export class ClaudeCodeAdapter extends PtyAdapter {
   constructor() {
     super();
     this.outputParser = new OutputParser();
+    this.ptyManager.on('input', (data: string) => {
+      this.outputParser.notifyUserInput(data);
+    });
   }
 
   protected getDefaultCommand(): string {

--- a/bridge/src/output-parser.ts
+++ b/bridge/src/output-parser.ts
@@ -168,6 +168,13 @@ export class OutputParser extends EventEmitter {
   // Cooldown after emitting permission/diff prompt — suppresses false idle
   // from user prompt echo (❯ text) in the same PTY batch
   private interactiveCooldown: ReturnType<typeof setTimeout> | null = null;
+  // Explicit lifecycle for a prompt that is currently visible in the managed
+  // terminal. This is armed only from the current PTY chunk (never historical
+  // buffer contents) and cleared by authoritative user input / idle / reset.
+  // While armed, Claude's concurrent status-line spinner redraws must not turn
+  // AWAITING back into PROCESSING.
+  private interactivePromptActive = false;
+  private interactivePromptNavigable = false;
   private remoteUrl: string | null = null;
 
   feed(rawData: string): void {
@@ -394,6 +401,17 @@ export class OutputParser extends EventEmitter {
       DIFF_PROMPT.test(chunk) || YES_NO_ALWAYS.test(chunk) ||
       PERMISSION_YN.test(chunk) ||
       OPTION_NUMBERED.test(chunk) || OPTION_BULLET.test(chunk);
+    const hasNavigablePrompt = /^\s*❯\s*\d{1,2}[.)]/m.test(chunk);
+    const hasAuthoritativePrompt =
+      DIFF_PROMPT.test(chunk) || YES_NO_ALWAYS.test(chunk) ||
+      PERMISSION_YN.test(chunk) || hasNavigablePrompt;
+
+    // Arm from fresh evidence only. Re-reading the append-only buffer here can
+    // resurrect an answered prompt and suppress real processing indefinitely.
+    if (hasAuthoritativePrompt) {
+      this.interactivePromptActive = true;
+      this.interactivePromptNavigable = hasNavigablePrompt;
+    }
 
     // --- Spinner + prompt handling ---
     if (this.spinnerActive) {
@@ -435,24 +453,32 @@ export class OutputParser extends EventEmitter {
       // This prevents matching spinner chars in large text blocks (responses, banners)
       const nonWs = chunk.replace(/\s/g, '').length;
       if (nonWs < 80) {
-        if (!this.spinnerActive) {
-          this.spinnerActive = true;
-          this.clearSuggestion();
-          debug('Parser', 'EMIT spinner_start');
-          this.emit('spinner_start');
-        }
-        this.resetSpinnerTimer();
-        this.spinnerTimer = setTimeout(() => {
-          if (this.spinnerActive) {
-            this.spinnerActive = false;
-            debug('Parser', 'EMIT spinner_stop (debounced)');
-            this.emit('spinner_stop');
+        if (this.interactivePromptActive) {
+          debug('Parser', 'spinner ignored — interactive prompt is active');
+          // A first prompt chunk may contain both the spinner and `❯ 1.`. It
+          // still needs to reach the prompt parser below. Later spinner-only
+          // redraws stop here so they cannot cancel the option debounce.
+          if (!hasAuthoritativePrompt) return;
+        } else {
+          if (!this.spinnerActive) {
+            this.spinnerActive = true;
+            this.clearSuggestion();
+            debug('Parser', 'EMIT spinner_start');
+            this.emit('spinner_start');
           }
-        }, SPINNER_DEBOUNCE_MS);
-        // Cancel idle & option timers — we're processing now
-        this.resetIdleTimer();
-        this.resetOptionTimer();
-        return;
+          this.resetSpinnerTimer();
+          this.spinnerTimer = setTimeout(() => {
+            if (this.spinnerActive) {
+              this.spinnerActive = false;
+              debug('Parser', 'EMIT spinner_stop (debounced)');
+              this.emit('spinner_stop');
+            }
+          }, SPINNER_DEBOUNCE_MS);
+          // Cancel idle & option timers — we're processing now
+          this.resetIdleTimer();
+          this.resetOptionTimer();
+          return;
+        }
       }
     }
 
@@ -617,6 +643,7 @@ export class OutputParser extends EventEmitter {
       // Genuine idle prompt or bare idle line — clear navigable state, fall through
       this.lastNavigableEmit = false;
       this.lastCursorIndex = 0;
+      this.clearInteractivePrompt();
       this.resetOptionTimer(); // cancel stale timer from ANSI reposition handler
     }
 
@@ -653,6 +680,7 @@ export class OutputParser extends EventEmitter {
         debug('Parser', 'idle prompt ignored — interactive cooldown active');
         return;
       }
+      this.clearInteractivePrompt();
       if (!this.seenFirstIdle) {
         this.seenFirstIdle = true;
         debug('Parser', 'first idle prompt seen — spinner detection now armed');
@@ -1245,6 +1273,31 @@ export class OutputParser extends EventEmitter {
     }, 200);
   }
 
+  /**
+   * Observe input forwarded to the managed PTY. Navigable prompts remain active
+   * through arrow-key movement and resolve on Enter/Esc/Ctrl+C. Shortcut-style
+   * prompts resolve on any non-navigation input.
+   */
+  notifyUserInput(data: string): void {
+    if (!this.interactivePromptActive || !data) return;
+
+    const withoutNavigation = data.replace(/\x1b\[[ABCD]/g, '');
+    const hasEnter = /[\r\n]/.test(withoutNavigation);
+    const hasInterrupt = withoutNavigation.includes('\x03');
+    const hasEscape = withoutNavigation.includes('\x1b');
+    const hasShortcut = /[^\x00-\x20\x7f]/.test(withoutNavigation);
+
+    if (hasEnter || hasInterrupt || hasEscape || (!this.interactivePromptNavigable && hasShortcut)) {
+      debug('Parser', 'interactive prompt resolved by PTY input');
+      this.clearInteractivePrompt();
+    }
+  }
+
+  private clearInteractivePrompt(): void {
+    this.interactivePromptActive = false;
+    this.interactivePromptNavigable = false;
+  }
+
   private resetInteractiveCooldown(): void {
     if (this.interactiveCooldown) { clearTimeout(this.interactiveCooldown); this.interactiveCooldown = null; }
   }
@@ -1280,6 +1333,7 @@ export class OutputParser extends EventEmitter {
     this.lastSuggestedPrompt = null;
     this.lastNavigableEmit = false;
     this.lastCursorIndex = 0;
+    this.clearInteractivePrompt();
     this.resetSpinnerTimer();
     this.resetIdleTimer();
     this.resetOptionTimer();

--- a/bridge/src/pty-manager.ts
+++ b/bridge/src/pty-manager.ts
@@ -90,6 +90,7 @@ export class PtyManager extends EventEmitter {
       const preview = data.replace(/\n/g, '\\n').replace(/[\x00-\x1f]/g, (c) => `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`);
       debug('PTY', `write(${data.length}): "${preview.slice(0, 80)}"`);
     }
+    this.emit('input', data);
     this.ptyProcess.write(data);
   }
 
@@ -111,7 +112,7 @@ export class PtyManager extends EventEmitter {
     // Proxy user's stdin to PTY
     stdin.on('data', (data: Buffer) => {
       if (this.ptyProcess) {
-        this.ptyProcess.write(data.toString());
+        this.write(data.toString());
       }
     });
 


### PR DESCRIPTION
Closes #68.

## What changed

- track a visible interactive prompt from fresh PTY chunk evidence only, never append-only buffer history
- forward managed terminal and device input through a single PTY input signal
- keep navigable prompts active through arrow movement and resolve them on Enter, Esc, or Ctrl+C
- resolve shortcut-style prompts on their actual shortcut input
- ignore concurrent spinner-only redraws while a prompt is active
- still parse a prompt when the spinner and `❯` option block arrive in the same first chunk
- clear prompt lifecycle on authoritative idle and parser reset

## Why

The previous time-window proposal could re-arm from stale `❯ 1.` text in the historical buffer and suppress genuine processing indefinitely. The managed PTY already observes both terminal and AgentDeck input, so input provides the missing explicit lifecycle boundary.

## Validation

- `pnpm build`
- `pnpm test` — 144 files, 2,381 tests passed
- focused parser/state-machine/adapter suites — 387 passed
- `pnpm -r exec tsc --noEmit`
- `git diff --check`

Regression coverage includes same-initial-chunk spinner+prompt, 80 spinner redraws while the prompt remains visible, real processing immediately after selection, and stale numbered prose not arming the lifecycle.