### PR TITLE
feat(codex): discover Desktop rollouts asynchronously

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -100,6 +100,32 @@ workspace TypeScript 검사가 통과했다.
 
 ---
 
+## 2026-08-04 — Node daemon Codex Desktop rollout discovery (#69)
+
+### 문제
+Node passive observer가 `codex app-server`를 제외하고 PID당 rollout 하나만 보존해
+Codex Desktop 대화를 전부 놓쳤다. 단순히 app-server를 허용하면 내부 subagent까지
+세션으로 노출되고, 5초마다 모든 rollout을 동기 read/parse해 daemon event loop도
+막을 수 있었다. 또한 한 app-server PID가 여러 대화를 소유하므로 PID dedupe는
+hook으로 잡힌 한 대화 때문에 모든 sibling 대화를 숨긴다.
+
+### 해결
+- app-server의 open rollout을 1:N으로 수집하고, Desktop 행은 `codex-app` 및
+  `observed:codex-app:<sessionId>`로 분류한다.
+- `session_meta.payload.source: { subagent: ... }`인 내부 rollout은 제외한다.
+- `(path, mtimeMs, size)` 기반 `CodexRolloutCache`를 추가했다. unchanged summary는
+  재사용하고 changed 파일만 `fs/promises` head+tail read/parse하며, 더 이상 open되지
+  않은 path는 즉시 invalidation한다. rollout read는 순차 await로 per-scan 메모리를
+  한 sample로 제한한다.
+- Desktop dedupe는 raw session id를 우선한다. 같은 app-server PID라는 이유로 sibling
+  conversation을 제거하지 않는다. CLI의 기존 managed-PID/descendant dedupe는 유지한다.
+
+### 검증
+app-server 1:N, subagent 제외, cache reuse/change/removal, Desktop sibling dedupe 회귀를
+추가했다. 전체 144 files / 2,383 tests, workspace TypeScript, build가 통과했다.
+
+---
+
 ## 2026-08-03 (3) — Codex 5h 창의 영구 소멸, 그리고 DRM 체크섬이 3일간 죽여둔 플러그인
 
 ### 문제

--- a/bridge/src/__tests__/passive-observer.test.ts
+++ b/bridge/src/__tests__/passive-observer.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CodexRolloutCache,
+  collectCodexSessionsFromRollouts,
+  dedupeObservedSessions,
   isAntigravityProcessCommand,
+  isCodexSessionProcessCommand,
   parseClaudeTranscript,
   parseCodexRollout,
   parseLsofRollouts,
@@ -228,8 +232,117 @@ describe('passive-observer parsers', () => {
       'n/Users/example/.codex/sessions/2026/04/26/rollout-def.jsonl',
     ].join('\n'));
 
-    expect(rollouts.get(123)).toBe('/Users/example/.codex/sessions/2026/04/26/rollout-abc.jsonl');
-    expect(rollouts.get(456)).toBe('/Users/example/.codex/sessions/2026/04/26/rollout-def.jsonl');
+    expect(rollouts.get(123)).toEqual(['/Users/example/.codex/sessions/2026/04/26/rollout-abc.jsonl']);
+    expect(rollouts.get(456)).toEqual(['/Users/example/.codex/sessions/2026/04/26/rollout-def.jsonl']);
+  });
+
+  it('keeps every rollout a desktop app-server pid holds open, deduped', () => {
+    const rollouts = parseLsofRollouts([
+      'p999',
+      'n/Users/example/.codex/sessions/2026/08/03/rollout-one.jsonl',
+      'n/Users/example/.codex/sessions/2026/08/03/rollout-two.jsonl',
+      'n/Users/example/.codex/sessions/2026/08/03/rollout-one.jsonl',
+    ].join('\n'));
+
+    expect(rollouts.get(999)).toEqual([
+      '/Users/example/.codex/sessions/2026/08/03/rollout-one.jsonl',
+      '/Users/example/.codex/sessions/2026/08/03/rollout-two.jsonl',
+    ]);
+  });
+
+  it('admits Codex Desktop app-server but rejects helper lookalikes', () => {
+    expect(isCodexSessionProcessCommand(
+      '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server',
+    )).toBe(true);
+    expect(isCodexSessionProcessCommand('/opt/homebrew/bin/codex --model gpt-5.4')).toBe(true);
+    expect(isCodexSessionProcessCommand('/Applications/ChatGPT.app/Contents/Resources/codex-code-mode-host')).toBe(false);
+    expect(isCodexSessionProcessCommand('grep codex')).toBe(false);
+  });
+
+  it('marks internal subagent rollouts from session_meta source', () => {
+    const parent = parseCodexRollout(jsonl([
+      { type: 'session_meta', payload: { id: 'parent', source: 'vscode', originator: 'Codex Desktop' } },
+    ]));
+    const child = parseCodexRollout(jsonl([
+      { type: 'session_meta', payload: { id: 'child', source: { subagent: 'review' }, originator: 'codex_exec' } },
+    ]));
+
+    expect(parent.isSubagent).toBe(false);
+    expect(child.isSubagent).toBe(true);
+  });
+
+  it('reuses unchanged rollout summaries and invalidates changes/removals', async () => {
+    let info = { mtimeMs: 1, size: 10 };
+    let reads = 0;
+    let raw = jsonl([{ type: 'session_meta', payload: { id: 'one', source: 'vscode' } }]);
+    const cache = new CodexRolloutCache({
+      stat: async () => info,
+      read: async () => { reads += 1; return raw; },
+    });
+
+    expect((await cache.get('/rollout.jsonl'))?.summary.sessionId).toBe('one');
+    expect((await cache.get('/rollout.jsonl'))?.summary.sessionId).toBe('one');
+    expect(reads).toBe(1);
+
+    info = { mtimeMs: 2, size: 20 };
+    raw = jsonl([{ type: 'session_meta', payload: { id: 'two', source: 'vscode' } }]);
+    expect((await cache.get('/rollout.jsonl'))?.summary.sessionId).toBe('two');
+    expect(reads).toBe(2);
+
+    cache.retain(new Set());
+    expect(cache.size).toBe(0);
+  });
+
+  it('surfaces top-level Desktop rollouts and excludes internal subagents', async () => {
+    const process = {
+      pid: 999,
+      ppid: 1,
+      rssKb: 100,
+      command: '/Applications/ChatGPT.app/Contents/Resources/codex app-server',
+    };
+    const cache = new CodexRolloutCache({
+      stat: async () => ({ mtimeMs: 10, size: 10 }),
+      read: async (path) => jsonl([{
+        type: 'session_meta',
+        payload: path.includes('child')
+          ? { id: 'child', cwd: '/repo/child', source: { subagent: 'review' } }
+          : { id: 'parent', cwd: '/repo/parent', source: 'vscode', originator: 'Codex Desktop' },
+      }]),
+    });
+
+    const sessions = await collectCodexSessionsFromRollouts(
+      [process],
+      new Map([[999, ['/rollout-parent.jsonl', '/rollout-child.jsonl']]]),
+      cache,
+    );
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'observed:codex-app:parent',
+      agentType: 'codex-app',
+      pid: 999,
+      cwd: '/repo/parent',
+    });
+  });
+
+  it('dedupes a hook-observed Desktop conversation without hiding sibling rollouts', () => {
+    const observed = ['parent', 'sibling'].map((id) => ({
+      id: `observed:codex-app:${id}`,
+      agentType: 'codex-app',
+      pid: 999,
+      port: 0,
+      projectName: id,
+      alive: true,
+      state: 'idle',
+      startedAt: '2026-08-04T00:00:00.000Z',
+      controlMode: 'observed',
+    }));
+    const managed = [{ id: 'parent', pid: 999 }];
+    const processes = [{ pid: 999, ppid: 1, rssKb: 10, command: '/Applications/ChatGPT.app/codex app-server' }];
+
+    const result = dedupeObservedSessions(observed as never, managed as never, processes);
+
+    expect(result.map((session) => session.id)).toEqual(['observed:codex-app:sibling']);
   });
 
   it('recognizes standalone Antigravity processes for CLI daemon passive discovery', () => {

--- a/bridge/src/passive-observer.ts
+++ b/bridge/src/passive-observer.ts
@@ -1,5 +1,11 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import {
+  open as openAsync,
+  readdir as readdirAsync,
+  readlink as readlinkAsync,
+  stat as statAsync,
+} from 'node:fs/promises';
 
 const execFileAsync = promisify(execFile);
 import {
@@ -8,7 +14,6 @@ import {
   lstatSync,
   openSync,
   readFileSync,
-  readlinkSync,
   readSync,
   readdirSync,
   statSync,
@@ -45,6 +50,16 @@ export interface TranscriptSummary {
   goal?: string;
   totalTokens?: number;
   contextPercent?: number;
+}
+
+export interface CodexRolloutSummary extends TranscriptSummary {
+  sessionId?: string;
+  cwd?: string;
+  startedAt?: number;
+  effort?: string;
+  hasPendingCalls?: boolean;
+  /** Internal companion rollouts never become top-level dashboard sessions. */
+  isSubagent: boolean;
 }
 
 /** Pull display text out of a Claude user message (string or text blocks). */
@@ -112,10 +127,74 @@ const MAX_SAMPLE_BYTES = 1024 * 1024;
 /** Rollout silence (no writes) after which an end-event-less turn is presumed dead. */
 const STALE_TURN_MS = 10 * 60 * 1000;
 
+interface CodexRolloutFileInfo {
+  mtimeMs: number;
+  size: number;
+}
+
+interface CodexRolloutCacheEntry extends CodexRolloutFileInfo {
+  summary: CodexRolloutSummary;
+}
+
+export interface CodexRolloutCacheDependencies {
+  stat(path: string): Promise<CodexRolloutFileInfo>;
+  read(path: string, headBytes: number, tailBytes: number): Promise<string>;
+}
+
+const defaultCodexRolloutCacheDependencies: CodexRolloutCacheDependencies = {
+  stat: async (path) => {
+    const info = await statAsync(path);
+    return { mtimeMs: info.mtimeMs, size: info.size };
+  },
+  read: readFileHeadAndTailAsync,
+};
+
+/**
+ * Bounded per-rollout summary cache. A scan only stats open rollout paths;
+ * unchanged `(path, mtime, size)` entries reuse their parsed summary. Changed
+ * files are read asynchronously, and paths no longer held open are invalidated.
+ */
+export class CodexRolloutCache {
+  private entries = new Map<string, CodexRolloutCacheEntry>();
+
+  constructor(private deps: CodexRolloutCacheDependencies = defaultCodexRolloutCacheDependencies) {}
+
+  async get(path: string): Promise<CodexRolloutCacheEntry | undefined> {
+    let info: CodexRolloutFileInfo;
+    try {
+      info = await this.deps.stat(path);
+    } catch {
+      this.entries.delete(path);
+      return undefined;
+    }
+
+    const cached = this.entries.get(path);
+    if (cached && cached.mtimeMs === info.mtimeMs && cached.size === info.size) return cached;
+
+    const raw = await this.deps.read(path, 256 * 1024, MAX_SAMPLE_BYTES).catch(() => '');
+    if (!raw) {
+      this.entries.delete(path);
+      return undefined;
+    }
+    const entry = { ...info, summary: parseCodexRollout(raw) };
+    this.entries.set(path, entry);
+    return entry;
+  }
+
+  retain(paths: ReadonlySet<string>): void {
+    for (const path of this.entries.keys()) {
+      if (!paths.has(path)) this.entries.delete(path);
+    }
+  }
+
+  get size(): number { return this.entries.size; }
+}
+
 export class PassiveSessionObserver {
   private lastScanAt = 0;
   private cached: ObservedSession[] = [];
   private scanInFlight = false;
+  private codexRolloutCache = new CodexRolloutCache();
 
   /** Fired after a background scan changed the cached list. Wire to a
    *  debounced sessions broadcast so fresh observations reach clients
@@ -147,7 +226,7 @@ export class PassiveSessionObserver {
     const processes = await collectProcessInfo();
     const observed = [
       ...collectClaudeSessions(processes),
-      ...(await collectCodexSessions(processes)),
+      ...(await collectCodexSessions(processes, this.codexRolloutCache)),
       ...(await collectOpenCodeSessions(processes)),
       ...(await collectAntigravitySessions(processes)),
     ];
@@ -262,7 +341,7 @@ export function parseClaudeTranscript(raw: string): TranscriptSummary {
   };
 }
 
-export function parseCodexRollout(raw: string): TranscriptSummary & { sessionId?: string; cwd?: string; startedAt?: number; effort?: string; hasPendingCalls?: boolean } {
+export function parseCodexRollout(raw: string): CodexRolloutSummary {
   let sessionId: string | undefined;
   let cwd: string | undefined;
   let startedAt: number | undefined;
@@ -273,6 +352,7 @@ export function parseCodexRollout(raw: string): TranscriptSummary & { sessionId?
   let totalTokens = 0;
   let lastContextTokens = 0;
   let contextWindow = 0;
+  let isSubagent = false;
   // A turn is in flight from task_started/user_message until task_complete/
   // turn_aborted. Mid-turn events (agent_message, function_call) must NOT end
   // it: most of a working turn is the thinking gap between a tool result and
@@ -291,6 +371,8 @@ export function parseCodexRollout(raw: string): TranscriptSummary & { sessionId?
       sessionId = stringAt(payload, 'id') ?? sessionId;
       cwd = stringAt(payload, 'cwd') ?? cwd;
       startedAt = timestampMs(stringAt(payload, 'timestamp')) ?? startedAt;
+      const source = payload.source;
+      isSubagent = isSubagent || (isRecord(source) && 'subagent' in source);
     } else if (type === 'event_msg') {
       const payload = objectAt(value, 'payload');
       if (!payload) continue;
@@ -374,6 +456,7 @@ export function parseCodexRollout(raw: string): TranscriptSummary & { sessionId?
   const state = turnActive || pendingCalls.size > 0 ? 'processing' : 'idle';
   return {
     hasPendingCalls: pendingCalls.size > 0,
+    isSubagent,
     sessionId,
     cwd,
     startedAt,
@@ -466,55 +549,78 @@ function collectClaudeSessions(processes: ProcInfo[]): ObservedSession[] {
   return sessions;
 }
 
-async function collectCodexSessions(processes: ProcInfo[]): Promise<ObservedSession[]> {
+async function collectCodexSessions(
+  processes: ProcInfo[],
+  rolloutCache: CodexRolloutCache,
+): Promise<ObservedSession[]> {
+  const codex = processes.filter((p) => isCodexSessionProcessCommand(p.command));
+  const rolloutsByPid = await mapCodexPidsToRollouts(codex.map((p) => p.pid));
+  return collectCodexSessionsFromRollouts(processes, rolloutsByPid, rolloutCache);
+}
+
+/** Testable async projection from open rollout paths to top-level sessions. */
+export async function collectCodexSessionsFromRollouts(
+  processes: ProcInfo[],
+  rolloutsByPid: Map<number, string[]>,
+  rolloutCache: CodexRolloutCache,
+): Promise<ObservedSession[]> {
   const byPid = new Map(processes.map((p) => [p.pid, p]));
-  const codex = processes.filter((p) =>
-    cmdHasBinary(p.command, 'codex') &&
-    !p.command.includes('app-server') &&
-    !p.command.includes('grep')
-  );
-  const rolloutByPid = await mapCodexPidsToRollouts(codex.map((p) => p.pid));
+  const codex = processes.filter((p) => isCodexSessionProcessCommand(p.command));
+  const activeRollouts = new Set<string>();
+  for (const paths of rolloutsByPid.values()) {
+    for (const path of paths) activeRollouts.add(path);
+  }
+  rolloutCache.retain(activeRollouts);
   const sessions: ObservedSession[] = [];
+  const seen = new Set<string>();
   for (const proc of codex) {
-    const rollout = rolloutByPid.get(proc.pid);
-    if (!rollout) continue;
-    const sample = readFileHeadAndTail(rollout, 256 * 1024, MAX_SAMPLE_BYTES);
-    if (!sample) continue;
-    const parsed = parseCodexRollout(sample);
-    // Ghost backstop: a turn whose end event never made it into the rollout
-    // (killed mid-turn, writer race) would read as processing forever. A live
-    // turn between tool calls writes the rollout every few seconds, so a long
-    // silence with no in-flight tool means the turn is dead. In-flight tools
-    // (pending call) are exempt — a quiet 10-minute build is legitimate.
-    let state = parsed.state;
-    if (state === 'processing' && !parsed.hasPendingCalls && rolloutAgeMs(rollout) > STALE_TURN_MS) {
-      state = 'idle';
+    for (const rollout of rolloutsByPid.get(proc.pid) ?? []) {
+      // Sequential awaits deliberately bound memory/read pressure to one rollout
+      // sample at a time while still yielding the daemon event loop.
+      const snapshot = await rolloutCache.get(rollout);
+      if (!snapshot || snapshot.summary.isSubagent) continue;
+      const parsed = snapshot.summary;
+      let state = parsed.state;
+      if (state === 'processing' && !parsed.hasPendingCalls && Date.now() - snapshot.mtimeMs > STALE_TURN_MS) {
+        state = 'idle';
+      }
+      const sessionId = parsed.sessionId ?? codexRolloutId(rollout);
+      if (seen.has(sessionId)) continue;
+      seen.add(sessionId);
+      const cwd = parsed.cwd;
+      const desktop = proc.command.includes('app-server');
+      sessions.push({
+        id: desktop ? `observed:codex-app:${sessionId}` : `observed:codex:${sessionId}`,
+        port: 0,
+        pid: proc.pid,
+        projectName: cwd ? projectNameFromCwd(cwd) : 'Codex',
+        agentType: desktop ? 'codex-app' : 'codex-cli',
+        tty: proc.tty,
+        appName: proc.tty ? undefined : resolveHostApp(proc.pid, byPid),
+        alive: true,
+        state,
+        modelName: parsed.modelName,
+        startedAt: parsed.startedAt ? new Date(parsed.startedAt).toISOString() : new Date().toISOString(),
+        controlMode: 'observed',
+        cwd,
+        currentTask: parsed.currentTask,
+        goal: parsed.goal,
+        contextPercent: parsed.contextPercent,
+        totalTokens: parsed.totalTokens,
+        lastActivityAt: snapshot.mtimeMs,
+      });
     }
-    const sessionId = parsed.sessionId ?? String(proc.pid);
-    const cwd = parsed.cwd;
-    sessions.push({
-      id: `observed:codex:${sessionId}`,
-      port: 0,
-      pid: proc.pid,
-      projectName: cwd ? projectNameFromCwd(cwd) : 'Codex',
-      agentType: 'codex-cli',
-      // Same injection targets as observed Claude: answering or dictating into
-      // a Codex session means typing into the terminal that owns it.
-      tty: proc.tty,
-      appName: proc.tty ? undefined : resolveHostApp(proc.pid, byPid),
-      alive: true,
-      state,
-      modelName: parsed.modelName,
-      startedAt: parsed.startedAt ? new Date(parsed.startedAt).toISOString() : new Date().toISOString(),
-      controlMode: 'observed',
-      cwd,
-      currentTask: parsed.currentTask,
-      goal: parsed.goal,
-      contextPercent: parsed.contextPercent,
-      totalTokens: parsed.totalTokens,
-    });
   }
   return sessions;
+}
+
+/** A standalone CLI or app-server process that owns user-facing rollouts. */
+export function isCodexSessionProcessCommand(command: string): boolean {
+  return cmdHasBinary(command, 'codex') && !command.includes('grep');
+}
+
+function codexRolloutId(rolloutPath: string): string {
+  return basename(rolloutPath).replace(/^rollout-/, '').replace(/\.jsonl$/, '');
 }
 
 /**
@@ -628,13 +734,14 @@ async function cwdForPids(pids: number[]): Promise<Map<number, string>> {
   return map;
 }
 
-function dedupeObservedSessions(
+export function dedupeObservedSessions(
   observed: ObservedSession[],
   managedSessions: EnrichedSession[],
   processes: ProcInfo[],
 ): ObservedSession[] {
   const byPid = new Map(processes.map((p) => [p.pid, p]));
   const managedIds = new Set(managedSessions.map((s) => s.id));
+  const managedRawIds = new Set(managedSessions.map((s) => rawSessionId(s.id)));
   const managedPids = managedSessions
     .map((s) => (s as EnrichedSession & { pid?: number }).pid)
     .filter((pid): pid is number => typeof pid === 'number' && pid > 0);
@@ -642,7 +749,11 @@ function dedupeObservedSessions(
   return observed.filter((session) => {
     if (managedIds.has(session.id)) return false;
     const rawId = rawSessionId(session.id);
-    if (managedIds.has(rawId)) return false;
+    if (managedIds.has(rawId) || managedRawIds.has(rawId)) return false;
+    // One Desktop app-server owns many independent rollouts. A hook-observed
+    // conversation sharing that process must suppress only its matching id,
+    // not every sibling conversation under the same pid.
+    if (session.agentType === 'codex-app') return true;
     return !managedPids.some((pid) => pid === session.pid || isDescendantOf(session.pid, pid, byPid));
   });
 }
@@ -701,19 +812,18 @@ function findClaudeTranscript(configDirs: string[], cwd: string, sessionId: stri
   return null;
 }
 
-async function mapCodexPidsToRollouts(pids: number[]): Promise<Map<number, string>> {
+async function mapCodexPidsToRollouts(pids: number[]): Promise<Map<number, string[]>> {
   if (pids.length === 0) return new Map();
   if (process.platform === 'linux') {
-    const map = new Map<number, string>();
+    const map = new Map<number, string[]>();
     for (const pid of pids) {
       try {
-        for (const fd of readdirSync(`/proc/${pid}/fd`)) {
-          const path = readlinkSync(`/proc/${pid}/fd/${fd}`);
-          if (isCodexRolloutPath(path)) {
-            map.set(pid, path);
-            break;
-          }
+        const paths = new Set<string>();
+        for (const fd of await readdirAsync(`/proc/${pid}/fd`)) {
+          const path = await readlinkAsync(`/proc/${pid}/fd/${fd}`);
+          if (isCodexRolloutPath(path)) paths.add(path);
         }
+        if (paths.size > 0) map.set(pid, [...paths]);
       } catch {
         // /proc permission/race failures are normal.
       }
@@ -734,26 +844,21 @@ async function mapCodexPidsToRollouts(pids: number[]): Promise<Map<number, strin
   }
 }
 
-export function parseLsofRollouts(output: string): Map<number, string> {
-  const map = new Map<number, string>();
+export function parseLsofRollouts(output: string): Map<number, string[]> {
+  const map = new Map<number, string[]>();
   let currentPid: number | null = null;
   for (const line of output.split('\n')) {
     if (line.startsWith('p')) {
       currentPid = Number(line.slice(1));
     } else if (line.startsWith('n') && currentPid != null) {
       const path = line.slice(1);
-      if (isCodexRolloutPath(path)) map.set(currentPid, path);
+      if (!isCodexRolloutPath(path)) continue;
+      const paths = map.get(currentPid) ?? [];
+      if (!paths.includes(path)) paths.push(path);
+      map.set(currentPid, paths);
     }
   }
   return map;
-}
-
-function rolloutAgeMs(path: string): number {
-  try {
-    return Date.now() - statSync(path).mtimeMs;
-  } catch {
-    return 0;
-  }
 }
 
 /** Epoch-ms of a file's last write, or undefined if it can't be stat'd. */
@@ -787,6 +892,28 @@ function readFileHeadAndTail(path: string, headBytes: number, tailBytes: number)
     return '';
   } finally {
     if (fd !== null) closeSync(fd);
+  }
+}
+
+async function readFileHeadAndTailAsync(path: string, headBytes: number, tailBytes: number): Promise<string> {
+  const file = await openAsync(path, 'r');
+  try {
+    const { size } = await file.stat();
+    if (size <= headBytes + tailBytes) {
+      const buffer = Buffer.alloc(size);
+      await file.read(buffer, 0, size, 0);
+      return buffer.toString('utf8');
+    }
+
+    const head = Buffer.alloc(headBytes);
+    await file.read(head, 0, headBytes, 0);
+    const tail = Buffer.alloc(tailBytes);
+    await file.read(tail, 0, tailBytes, size - tailBytes);
+    const tailText = tail.toString('utf8');
+    const firstNewline = tailText.indexOf('\n');
+    return `${head.toString('utf8')}\n${firstNewline >= 0 ? tailText.slice(firstNewline + 1) : ''}`;
+  } finally {
+    await file.close();
   }
 }
 


### PR DESCRIPTION
Closes #69.

## What changed

- admit `codex app-server` as a session-owning process
- retain every open rollout per PID instead of only the last one
- classify app-server conversations as `codex-app` with `observed:codex-app:<sessionId>` identity
- exclude internal companion rollouts whose `session_meta.payload.source` carries `subagent`
- add a per-observer `(path, mtimeMs, size)` rollout summary cache
- read changed rollout head/tail samples through `fs/promises`, sequentially bounded to one sample at a time
- invalidate changed, unreadable, and no-longer-open rollout entries
- dedupe Desktop sessions by raw conversation ID so a hook-observed conversation does not hide sibling rollouts sharing the same app-server PID
- preserve the existing managed PID/descendant dedupe for CLI sessions

## Validation

- `pnpm build`
- `pnpm test` — 144 files, 2,383 tests passed
- `pnpm -r exec tsc --noEmit`
- focused passive observer suite — 16 passed
- `git diff --check`

Regression coverage includes app-server 1:N rollout mapping, top-level Desktop surfacing, subagent exclusion, unchanged-cache reuse, changed/removal invalidation, and hook-observed sibling dedupe.