### PR TITLE
feat(codex): observe Desktop sessions via OTel and hooks

### DIFF
--- a/bridge/src/__tests__/codex-otel.test.ts
+++ b/bridge/src/__tests__/codex-otel.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANONYMOUS_OTEL_THREAD_ID,
+  CodexOtelTracker,
+  parseCodexSpans,
+  spanNameSummary,
+} from '../codex-otel.js';
+import type { ObservedSession } from '../passive-observer.js';
+
+type AttrValue = string | number | boolean;
+
+function attrs(map: Record<string, AttrValue>): unknown[] {
+  return Object.entries(map).map(([key, value]) => ({
+    key,
+    value: typeof value === 'number'
+      ? { intValue: String(value) }
+      : typeof value === 'boolean'
+        ? { boolValue: value }
+        : { stringValue: value },
+  }));
+}
+
+function envelope(
+  spans: { name: string; traceId?: string; attributes?: Record<string, AttrValue> }[],
+  resourceAttributes: Record<string, AttrValue> = {},
+): unknown {
+  return {
+    resourceSpans: [{
+      resource: { attributes: attrs(resourceAttributes) },
+      scopeSpans: [{
+        spans: spans.map((s) => ({
+          name: s.name,
+          ...(s.traceId ? { traceId: s.traceId } : {}),
+          attributes: attrs(s.attributes ?? {}),
+        })),
+      }],
+    }],
+  };
+}
+
+const THREAD = '019dee40-1234-7aaa-bbbb-ccccddddeeee';
+
+describe('codex OTLP span parser', () => {
+  it('reads a full turn from dotted span names', () => {
+    const events = parseCodexSpans(envelope([
+      { name: 'codex.turn.start', attributes: { 'thread.id': THREAD, 'turn.id': 't1', cwd: '/repo/app' } },
+      { name: 'codex.tool.call', attributes: { 'thread.id': THREAD, 'turn.id': 't1', 'tool.name': 'exec_command' } },
+      { name: 'codex.tool.result', attributes: { 'thread.id': THREAD, 'turn.id': 't1' } },
+      { name: 'codex.turn.end', attributes: { 'thread.id': THREAD, 'turn.id': 't1' } },
+    ]));
+
+    expect(events).toEqual([
+      { kind: 'turnStart', threadId: THREAD, turnId: 't1', cwd: '/repo/app' },
+      { kind: 'toolCall', threadId: THREAD, turnId: 't1', tool: 'exec_command', cwd: '/repo/app' },
+      { kind: 'toolResult', threadId: THREAD, turnId: 't1' },
+      { kind: 'turnEnd', threadId: THREAD, turnId: 't1' },
+    ]);
+  });
+
+  it('normalizes underscore and slash span-name variants', () => {
+    const events = parseCodexSpans(envelope([
+      { name: 'turn/start', attributes: { thread_id: THREAD, turn_id: 't7' } },
+      { name: 'build_tool_call', attributes: { thread_id: THREAD, turn_id: 't7', tool: 'apply_patch' } },
+    ]));
+    expect(events.map((e) => e.kind)).toEqual(['turnStart', 'toolCall']);
+  });
+
+  it('rejects short numeric ids and prefers the durable alias on the same span', () => {
+    // Codex emits BOTH a turn-scoped counter and the real thread UUID; taking
+    // the first non-empty alias would pick the counter and spawn ghost rows.
+    const events = parseCodexSpans(envelope([
+      { name: 'codex.turn.start', attributes: { 'codex.thread_id': 11, 'thread.id': THREAD, 'turn.id': 't1' } },
+    ]));
+    expect(events).toEqual([{ kind: 'turnStart', threadId: THREAD, turnId: 't1', cwd: undefined }]);
+
+    // With only the short id, the span has no usable identity — it falls back
+    // to the anonymous trace key rather than inventing `codex:11`.
+    const shortOnly = parseCodexSpans(envelope([
+      { name: 'codex.turn.start', traceId: 'abc123', attributes: { 'thread.id': 11 } },
+    ]));
+    expect(shortOnly[0]?.threadId).toBe(ANONYMOUS_OTEL_THREAD_ID);
+  });
+
+  it('ignores a tool span own cwd but inherits the thread-scoped one', () => {
+    // `process.cwd` on an exec span is the subprocess's directory; adopting it
+    // would lock the session's project label onto /tmp.
+    const events = parseCodexSpans(envelope([
+      { name: 'codex.turn.start', attributes: { 'thread.id': THREAD, cwd: '/repo/app' } },
+      { name: 'codex.tool.call', attributes: { 'thread.id': THREAD, 'process.cwd': '/tmp/build' } },
+    ]));
+    expect(events[1]).toMatchObject({ kind: 'toolCall', cwd: '/repo/app' });
+
+    const loneTool = parseCodexSpans(envelope([
+      { name: 'codex.tool.call', attributes: { 'thread.id': THREAD, 'process.cwd': '/tmp/build' } },
+    ]));
+    expect(loneTool[0]).toMatchObject({ kind: 'toolCall', cwd: undefined });
+  });
+
+  it('falls through to resource-level attributes', () => {
+    const events = parseCodexSpans(envelope(
+      [{ name: 'codex.turn.start', attributes: { 'turn.id': 't1' } }],
+      { 'thread.id': THREAD, cwd: '/repo/app' },
+    ));
+    expect(events).toEqual([{ kind: 'turnStart', threadId: THREAD, turnId: 't1', cwd: '/repo/app' }]);
+  });
+
+  it('drops unknown spans and spans with no identity at all', () => {
+    expect(parseCodexSpans(envelope([{ name: 'garbage.collect', attributes: { 'thread.id': THREAD } }]))).toEqual([]);
+    expect(parseCodexSpans(envelope([{ name: 'codex.turn.start' }]))).toEqual([]);
+    expect(parseCodexSpans({})).toEqual([]);
+    expect(parseCodexSpans(null)).toEqual([]);
+  });
+
+  it('summarizes span names for diagnostics', () => {
+    const summary = spanNameSummary(envelope([{ name: 'receiving' }, { name: 'handle_responses' }]));
+    expect(summary).toBe('receiving,handle_responses');
+  });
+
+  it('finds no durable identity in a live ChatGPT.app Codex batch', () => {
+    // Captured 2026-08-04 from ChatGPT.app 150.0.7871.182 (service.name
+    // `codex-app-server` 0.146.0-alpha.9.2, telemetry sdk 0.31.0) — trimmed,
+    // attribute shapes verbatim. This build's `thread.id` is the tokio worker
+    // thread, NOT a conversation id, and it emits no turn-boundary span, so
+    // every span folds onto the anonymous key and drives no session state.
+    // The rollout the passive observer already reads carries the identity this
+    // batch lacks; if a future build starts emitting `codex.thread_id` UUIDs or
+    // `turn/start`, this test is where that change will show up first.
+    const live = envelope([
+      {
+        name: 'handle_tool_call_with_source',
+        traceId: '5d0e27fa9d4edb90419b1e56345a143d',
+        attributes: {
+          'code.module.name': 'codex_core::tools::parallel',
+          'thread.id': 6,
+          'thread.name': 'tokio-rt-worker',
+          target: 'codex_core::tools::parallel',
+          busy_ns: 165667,
+        },
+      },
+      {
+        name: 'run_sampling_request',
+        traceId: '5d0e27fa9d4edb90419b1e56345a143d',
+        attributes: {
+          'thread.id': 11,
+          'thread.name': 'tokio-rt-worker',
+          turn_id: '019fc9ef-8a88-7bf1-aaf7-1a7479387855',
+          model: 'gpt-5.6-sol',
+          cwd: '/Users/puritysb/github/BabelForge',
+        },
+      },
+      {
+        name: 'receiving',
+        traceId: '5d0e27fa9d4edb90419b1e56345a143d',
+        attributes: { 'thread.id': 3, 'thread.name': 'tokio-rt-worker' },
+      },
+    ], {
+      'service.name': 'codex-app-server',
+      'service.version': '0.146.0-alpha.9.2',
+      'telemetry.sdk.name': 'opentelemetry',
+    });
+
+    const events = parseCodexSpans(live);
+    // `run_sampling_request` is a mid-turn model call, not a turn boundary — it
+    // is deliberately not in the dispatch table.
+    expect(events.map((e) => e.kind)).toEqual(['toolCall', 'activity']);
+    expect(events.every((e) => e.threadId === ANONYMOUS_OTEL_THREAD_ID)).toBe(true);
+
+    // …and the tracker therefore holds nothing: anonymous spans never create,
+    // rename, or drive a session row.
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(live);
+    expect(tracker.snapshot()).toEqual([]);
+  });
+});
+
+describe('CodexOtelTracker', () => {
+  const observedCodex: ObservedSession = {
+    id: `observed:codex:${THREAD}`,
+    port: 0,
+    pid: 4321,
+    projectName: 'app',
+    agentType: 'codex-cli',
+    alive: true,
+    state: 'idle',
+    controlMode: 'observed',
+    currentTask: 'exec_command pnpm build',
+  };
+
+  function turn(kind: 'turnStart' | 'turnEnd', turnId: string, extra: Record<string, AttrValue> = {}): unknown {
+    return envelope([{
+      name: kind === 'turnStart' ? 'codex.turn.start' : 'codex.turn.end',
+      attributes: { 'thread.id': THREAD, 'turn.id': turnId, ...extra },
+    }]);
+  }
+
+  it('overlays state and tool onto the matching observed row instead of duplicating it', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1', { cwd: '/repo/app' }), 1_000);
+    tracker.ingest(envelope([{
+      name: 'codex.tool.call',
+      attributes: { 'thread.id': THREAD, 'turn.id': 't1', 'tool.name': 'apply_patch' },
+    }]), 1_100);
+
+    const rows = tracker.applyTo([observedCodex], 1_200);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: `observed:codex:${THREAD}`,
+      state: 'processing',
+      currentTask: 'apply_patch',
+    });
+  });
+
+  it('synthesizes a codex-app row only when the process scan found nothing', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1', { cwd: '/repo/app' }), 1_000);
+
+    const rows = tracker.applyTo([], 1_100);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: `observed:codex-app:${THREAD}`,
+      agentType: 'codex-app',
+      state: 'processing',
+      controlMode: 'observed',
+      cwd: '/repo/app',
+      projectName: 'app',
+    });
+  });
+
+  it('rejects a superseded turnEnd so a stale span cannot close the live turn', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    tracker.ingest(turn('turnStart', 't2'), 2_000);
+    tracker.ingest(turn('turnEnd', 't1'), 2_100); // late close for the previous turn
+
+    expect(tracker.snapshot()[0]).toMatchObject({ state: 'processing', servicedTurnId: 't2' });
+
+    tracker.ingest(turn('turnEnd', 't2'), 2_200);
+    expect(tracker.snapshot()[0]).toMatchObject({ state: 'idle' });
+  });
+
+  it('lets a follow-up turn revive a thread its own turnEnd retired', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    tracker.ingest(turn('turnEnd', 't1'), 2_000);
+    tracker.ingest(turn('turnStart', 't2'), 3_000);
+    expect(tracker.snapshot()[0]).toMatchObject({ state: 'processing', terminalAt: undefined });
+  });
+
+  it('expires a finished thread, and a quiet one, instead of pinning a creature', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    tracker.ingest(turn('turnEnd', 't1'), 2_000);
+    expect(tracker.applyTo([], 2_000 + 59_000)).toHaveLength(1);
+    expect(tracker.applyTo([], 2_000 + 61_000)).toHaveLength(0);
+
+    const quiet = new CodexOtelTracker();
+    quiet.ingest(turn('turnStart', 't1'), 1_000);
+    expect(quiet.applyTo([], 1_000 + 4 * 60_000)).toHaveLength(1);
+    expect(quiet.applyTo([], 1_000 + 6 * 60_000)).toHaveLength(0);
+  });
+
+  it('stops overriding observer state once its own observation goes stale', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    // Inside the overlay window OTel wins; past it the rollout tail is fresher.
+    expect(tracker.applyTo([observedCodex], 60_000)[0]).toMatchObject({ state: 'processing' });
+    expect(tracker.applyTo([observedCodex], 200_000)[0]).toMatchObject({ state: 'idle' });
+  });
+
+  it('never lets progress-only activity spans open or revive a thread', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(envelope([{ name: 'receiving', attributes: { 'thread.id': THREAD } }]), 1_000);
+    expect(tracker.snapshot()).toEqual([]);
+
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    tracker.ingest(turn('turnEnd', 't1'), 2_000);
+    tracker.ingest(envelope([{ name: 'receiving', attributes: { 'thread.id': THREAD } }]), 2_500);
+    expect(tracker.snapshot()[0]).toMatchObject({ state: 'idle', lastEventAt: 2_000 });
+  });
+
+  it('leaves non-codex rows untouched', () => {
+    const tracker = new CodexOtelTracker();
+    tracker.ingest(turn('turnStart', 't1'), 1_000);
+    const claude: ObservedSession = { ...observedCodex, id: 'observed:claude:x', agentType: 'claude-code' };
+    const rows = tracker.applyTo([claude], 1_100);
+    expect(rows[0]).toBe(claude);
+  });
+});

--- a/bridge/src/__tests__/hook-codex-sessions.test.ts
+++ b/bridge/src/__tests__/hook-codex-sessions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { HookCodexSessions } from '../hook-codex-sessions.js';
+import type { ObservedSession } from '../passive-observer.js';
+
+const SID = '019fc7c8-23b0-7aa1-bd65-8758d55a56e8';
+const CWD = '/Users/dev/github/BabelForge';
+
+function observedCodex(id = `observed:codex:${SID}`): ObservedSession {
+  return {
+    id,
+    port: 0,
+    pid: 4321,
+    projectName: 'BabelForge',
+    agentType: 'codex-cli',
+    alive: true,
+    state: 'processing',
+    controlMode: 'observed',
+    modelName: 'gpt-5.6-sol high',
+    currentTask: 'exec_command pnpm build',
+  };
+}
+
+describe('HookCodexSessions', () => {
+  it('surfaces a Codex the process scan never found', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_user_prompt_submit', { sessionId: SID, cwd: CWD }, 1_100);
+
+    const rows = hooks.applyTo([], 1_200);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: `observed:codex:${SID}`,
+      agentType: 'codex-cli',
+      controlMode: 'observed',
+      state: 'processing',
+      projectName: 'BabelForge',
+      cwd: CWD,
+    });
+  });
+
+  it('yields to the observer instead of doubling the row', () => {
+    // The observer's row carries model/tokens/goal the hooks can't know; a
+    // second row for the same conversation would render as two creatures.
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+
+    const observed = observedCodex();
+    const rows = hooks.applyTo([observed], 1_100);
+    expect(rows).toEqual([observed]);
+  });
+
+  it('matches the observer row in either id form', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+    expect(hooks.applyTo([observedCodex(`observed:codex-app:${SID}`)], 1_100)).toHaveLength(1);
+  });
+
+  it('tracks tool state through a turn', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_user_prompt_submit', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_tool_start', { sessionId: SID, toolName: 'apply_patch' }, 1_100);
+    expect(hooks.applyTo([], 1_150)[0]).toMatchObject({ state: 'processing', currentTask: 'apply_patch' });
+
+    hooks.note('codex_tool_end', { sessionId: SID, toolName: 'apply_patch' }, 1_200);
+    expect(hooks.applyTo([], 1_250)[0]).toMatchObject({ state: 'processing', currentTask: undefined });
+
+    hooks.note('codex_stop', { sessionId: SID }, 1_300);
+    expect(hooks.applyTo([], 1_350)[0]).toMatchObject({ state: 'idle' });
+  });
+
+  it('reaps a finished session, and one that died without a stop hook', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_user_prompt_submit', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_stop', { sessionId: SID }, 2_000);
+    expect(hooks.applyTo([], 2_000 + 59_000)).toHaveLength(1);
+    expect(hooks.applyTo([], 2_000 + 61_000)).toHaveLength(0);
+
+    // Killed mid-turn: no terminal hook ever arrives, so only the silence TTL
+    // can retire it — otherwise the creature stays "processing" forever.
+    const killed = new HookCodexSessions();
+    killed.note('codex_user_prompt_submit', { sessionId: SID, cwd: CWD }, 1_000);
+    expect(killed.applyTo([], 1_000 + 29 * 60_000)).toHaveLength(1);
+    expect(killed.applyTo([], 1_000 + 31 * 60_000)).toHaveLength(0);
+  });
+
+  it('lets a follow-up prompt revive a finished session', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_stop', { sessionId: SID }, 2_000);
+    hooks.note('codex_user_prompt_submit', { sessionId: SID }, 3_000);
+    expect(hooks.applyTo([], 3_100)[0]).toMatchObject({ state: 'processing' });
+  });
+
+  it('opens a row from a mid-turn hook when the session start predates the daemon', () => {
+    // Daemon restarted (or hooks installed) mid-session: the only events we
+    // will ever see for this turn are tool hooks.
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_tool_start', { sessionId: SID, cwd: CWD, toolName: 'exec_command' }, 1_000);
+    expect(hooks.applyTo([], 1_100)).toHaveLength(1);
+  });
+
+  it('never lets a trailing tool callback resurrect a finished session', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_stop', { sessionId: SID }, 2_000);
+    // Row reaped 60 s later; a late companion-task callback arrives after that.
+    expect(hooks.applyTo([], 2_000 + 61_000)).toHaveLength(0);
+    hooks.note('codex_tool_end', { sessionId: SID, toolName: 'exec' }, 2_000 + 62_000);
+    expect(hooks.applyTo([], 2_000 + 63_000)).toHaveLength(0);
+
+    // …but the same session prompted again is a genuine re-engagement.
+    hooks.note('codex_user_prompt_submit', { sessionId: SID }, 2_000 + 64_000);
+    expect(hooks.applyTo([], 2_000 + 65_000)).toHaveLength(1);
+  });
+
+  it('keeps the first cwd instead of relabelling on a later hook', () => {
+    const hooks = new HookCodexSessions();
+    hooks.note('codex_session_start', { sessionId: SID, cwd: CWD }, 1_000);
+    hooks.note('codex_tool_start', { sessionId: SID, cwd: '/tmp/build', toolName: 'exec' }, 1_100);
+    expect(hooks.applyTo([], 1_200)[0]).toMatchObject({ cwd: CWD, projectName: 'BabelForge' });
+  });
+
+  it('ignores non-codex events and payloads with no session id', () => {
+    const hooks = new HookCodexSessions();
+    expect(hooks.note('SessionStart', { sessionId: SID, cwd: CWD })).toBe(false);
+    expect(hooks.note('opencode_session_start', { sessionId: SID, cwd: CWD })).toBe(false);
+    expect(hooks.note('codex_session_start', { cwd: CWD })).toBe(false);
+    expect(hooks.snapshot()).toEqual([]);
+  });
+});

--- a/bridge/src/__tests__/passive-observer.test.ts
+++ b/bridge/src/__tests__/passive-observer.test.ts
@@ -255,6 +255,11 @@ describe('passive-observer parsers', () => {
       '/Applications/ChatGPT.app/Contents/Resources/codex -c features.code_mode_host=true app-server',
     )).toBe(true);
     expect(isCodexSessionProcessCommand('/opt/homebrew/bin/codex --model gpt-5.4')).toBe(true);
+    // ChatGPT's Electron helpers carry a capital-`Codex` basename, and the
+    // code-mode host is a different binary — neither owns a rollout.
+    expect(isCodexSessionProcessCommand(
+      '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/Codex (Renderer).app/Contents/MacOS/Codex (Renderer) --type=renderer',
+    )).toBe(false);
     expect(isCodexSessionProcessCommand('/Applications/ChatGPT.app/Contents/Resources/codex-code-mode-host')).toBe(false);
     expect(isCodexSessionProcessCommand('grep codex')).toBe(false);
   });
@@ -343,6 +348,40 @@ describe('passive-observer parsers', () => {
     const result = dedupeObservedSessions(observed as never, managed as never, processes);
 
     expect(result.map((session) => session.id)).toEqual(['observed:codex-app:sibling']);
+  });
+
+  it('counts Codex cached input once when the producer folds it into input_tokens', () => {
+    // Live rollouts satisfy total_tokens === input + output, i.e. cached is
+    // already inside input_tokens. Re-adding it read one session at 105%
+    // context and roughly doubled its token total.
+    const summary = parseCodexRollout(jsonl([
+      { type: 'turn_context', payload: { model: 'gpt-5.6-sol', effort: 'high', model_context_window: 258_400 } },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            model_context_window: 258_400,
+            total_token_usage: {
+              input_tokens: 26_805_300,
+              cached_input_tokens: 26_281_216,
+              output_tokens: 97_519,
+              total_tokens: 26_902_819,
+            },
+            last_token_usage: {
+              input_tokens: 159_649,
+              cached_input_tokens: 158_464,
+              output_tokens: 191,
+              total_tokens: 159_840,
+            },
+          },
+        },
+      },
+    ]));
+
+    expect(summary.totalTokens).toBe(26_902_819);
+    expect(summary.contextPercent).toBeCloseTo((159_649 / 258_400) * 100, 5);
+    expect(summary.contextPercent ?? 0).toBeLessThan(100);
   });
 
   it('recognizes standalone Antigravity processes for CLI daemon passive discovery', () => {

--- a/bridge/src/codex-otel.ts
+++ b/bridge/src/codex-otel.ts
@@ -1,0 +1,516 @@
+// codex-otel.ts — Ingest OTLP/HTTP JSON spans emitted by Codex (CLI and the
+// ChatGPT.app Codex desktop app) and turn them into session state.
+//
+// Codex's OTel exporter is configured to POST at the daemon
+// (`[otel.trace_exporter.otlp-http] endpoint = ".../otel/v1/traces"`), but only
+// the Swift daemon implemented that route — the Node daemon answered 404 and
+// every span was discarded. This is the Node port of
+// `apple/AgentDeck/Daemon/Modules/CodexTelemetryModule.swift`; keep the two
+// aligned when Codex's span vocabulary moves. The parser half is a faithful
+// mirror (same span names, attribute aliases, cwd tiers, durable-id rules); the
+// tracker half is deliberately Node-specific, because this daemon also has the
+// ps/lsof passive observer that Swift (App Store, no subprocesses) cannot have —
+// see `CodexOtelTracker`.
+//
+// Codex's OTel keys are not a documented stable API, so we accept several
+// naming variants (dotted vs underscored, `codex.thread_id` vs `thread.id`) and
+// silently drop anything unrecognized.
+//
+// What today's builds actually emit (measured 2026-08-04 against ChatGPT.app
+// 150.0.7871.182 / `codex-app-server` 0.146.0-alpha.9.2, 11.5k spans):
+// **no conversation identity at all**. `thread.id` there is the tokio worker
+// thread ("3", "8", …) — which `isDurableSessionId` correctly rejects — and the
+// build emits no turn-boundary span, only mid-turn `run_sampling_request` /
+// `receiving` / tool spans. So every span folds onto the anonymous key and this
+// module drives nothing for that build; the session comes from the ps/lsof
+// observer, whose rollout carries the identity the spans lack. See the live
+// fixture in `__tests__/codex-otel.test.ts` — that test is where a future build
+// gaining `codex.thread_id` UUIDs or `turn/start` spans will show up first.
+// Ingest cost on that traffic is ~0.44 ms per batch, so serving the route is
+// cheap even while it yields nothing.
+
+import { rawSessionId } from '@agentdeck/shared';
+import type { ObservedSession } from './passive-observer.js';
+import { resolveProjectNameFromCwdCached } from './utils/project-name.js';
+
+/** Distilled span events — the only vocabulary the daemon acts on. */
+export type CodexSpanEvent =
+  | { kind: 'turnStart'; threadId: string; turnId: string; cwd?: string }
+  | { kind: 'toolCall'; threadId: string; turnId: string; tool: string; cwd?: string }
+  | { kind: 'toolResult'; threadId: string; turnId: string }
+  | { kind: 'turnEnd'; threadId: string; turnId: string }
+  | { kind: 'activity'; threadId: string; turnId: string; name: string; cwd?: string };
+
+/** Singleton key for trace-backed spans that carry no durable thread id. */
+export const ANONYMOUS_OTEL_THREAD_ID = 'otel-active';
+
+/**
+ * Route Codex's OTel exporter posts to. `hooks/src/codex-install.ts`
+ * (`buildOtelEndpoint`) writes this path into `~/.codex/config.toml` and
+ * `CodexOtelRoutes` serves it on the Swift daemon — the three must agree. The
+ * hooks package carries its own literal because it has no workspace deps.
+ */
+export const CODEX_OTEL_TRACES_PATH = '/otel/v1/traces';
+
+type Attrs = Record<string, string | number | boolean>;
+
+/**
+ * Span names that start a user turn. Their own `cwd` attribute is session-level
+ * (the workspace), unlike tool spans whose `cwd` may be subprocess-scoped. Keep
+ * aligned with the `turnStart` dispatch case below.
+ */
+const TURN_START_SPAN_NAMES = new Set([
+  'codex.turn',
+  'codex.turn.start',
+  'turn.start',
+  'op.dispatch.user.turn',
+  'op.dispatch.user.input.with.turn.context',
+]);
+
+const TOOL_CALL_SPAN_NAMES = new Set([
+  'codex.tool.call', 'tool.call', 'turn.tool.call', 'build.tool.call',
+  'handle.tool.call', 'handle.tool.call.with.source', 'exec.command', 'mcp.tools.call',
+]);
+
+const TOOL_RESULT_SPAN_NAMES = new Set([
+  'codex.tool.result', 'tool.result', 'tool.call.duration.ms',
+  'dispatch.tool.call.with.code.mode.result', 'handle.output.item.done',
+]);
+
+const TURN_END_SPAN_NAMES = new Set(['codex.turn.end', 'turn.end', 'session.task.turn']);
+
+const ACTIVITY_SPAN_NAMES = new Set([
+  'receiving', 'handle.responses', 'responses.websocket.stream.request',
+  'model.client.stream.responses.websocket', 'stream.request',
+]);
+
+/**
+ * Attribute aliases under which Codex builds have been observed publishing the
+ * workspace directory. Centralised so the resource-level scan, the span-level
+ * scan, and the classifier read the same list.
+ */
+const CWD_ATTRIBUTE_KEYS = [
+  'cwd', 'codex.cwd', 'working.directory', 'working_directory', 'working.dir',
+  'workdir', 'workspace.path', 'workspace.root', 'workspace_root',
+  'project.path', 'project.root', 'project_root', 'repo.path',
+  'repository.path', 'terminal.cwd', 'process.cwd',
+];
+
+const THREAD_ID_KEYS = ['codex.thread_id', 'codex.thread.id', 'thread.id', 'thread_id', 'threadId'];
+const TURN_ID_KEYS = ['codex.turn_id', 'turn.id', 'turn_id'];
+const TOOL_NAME_KEYS = ['tool.name', 'tool', 'codex.tool', 'mcp.tool.name', 'mcp.tool'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+/**
+ * OTLP attributes are arrays of `{ key, value: { <type>Value } }`. Flatten to a
+ * plain map so callers can dot-key into it without re-parsing the envelope.
+ */
+function flattenAttrs(raw: unknown): Attrs {
+  const out: Attrs = {};
+  for (const kv of recordArray(raw)) {
+    const key = kv.key;
+    const wrap = kv.value;
+    if (typeof key !== 'string' || !isRecord(wrap)) continue;
+    if (typeof wrap.stringValue === 'string') { out[key] = wrap.stringValue; continue; }
+    if (wrap.intValue !== undefined) {
+      // OTLP encodes int64 as a number or a stringified number depending on SDK
+      // version — accept both so an exporter swap doesn't silently drop keys.
+      if (typeof wrap.intValue === 'number') out[key] = wrap.intValue;
+      else if (typeof wrap.intValue === 'string' && /^-?\d+$/.test(wrap.intValue)) out[key] = Number(wrap.intValue);
+      continue;
+    }
+    if (typeof wrap.boolValue === 'boolean') { out[key] = wrap.boolValue; continue; }
+    if (typeof wrap.doubleValue === 'number') { out[key] = wrap.doubleValue; continue; }
+  }
+  return out;
+}
+
+/** First non-empty string/int attribute among `keys`. */
+function stringAttr(attrs: Attrs, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = attrs[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+    if (typeof value === 'number') return String(value);
+  }
+  return undefined;
+}
+
+function stripCodexPrefix(raw: string): string {
+  return raw.startsWith('codex:') ? raw.slice('codex:'.length) : raw;
+}
+
+/**
+ * A thread id worth synthesizing a session row for: long enough to be a real
+ * conversation id and not purely numeric. Short numeric ids (`thread.id: "11"`)
+ * are turn-scoped companion-task counters — accepting them spawned ghost
+ * creatures on the dashboard.
+ */
+function isDurableSessionId(raw: string): boolean {
+  const trimmed = stripCodexPrefix(raw).trim();
+  if (trimmed.length < 12) return false;
+  return /\D/.test(trimmed);
+}
+
+/**
+ * First attribute among `keys` whose value is durable — a preference order, not
+ * a winner-take-all early exit. Some Codex builds emit both a turn-scoped short
+ * id (`codex.thread_id: "11"`) and the real UUID (`thread.id: "019dee40-…"`) on
+ * the same span; taking the first non-empty one would drop the good id.
+ */
+function firstDurableAttr(attrs: Attrs, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = attrs[key];
+    if (typeof value === 'string' && value.length > 0 && isDurableSessionId(value)) return value;
+    if (typeof value === 'number' && isDurableSessionId(String(value))) return String(value);
+  }
+  return undefined;
+}
+
+function threadIdAttr(attrs: Attrs): string | undefined {
+  const threadId = firstDurableAttr(attrs, THREAD_ID_KEYS);
+  if (threadId) return stripCodexPrefix(threadId);
+  const sessionId = firstDurableAttr(attrs, ['session_id', 'session.id']);
+  if (sessionId) return stripCodexPrefix(sessionId);
+  return undefined;
+}
+
+function traceIdAttr(span: Record<string, unknown>): string | undefined {
+  for (const key of ['traceId', 'traceID', 'trace_id']) {
+    const value = span[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Some Codex App / app-server batches carry useful progress spans but omit a
+ * durable thread id. Rather than drop them, fold them onto one anonymous key so
+ * liveness is still observable — a singleton, so internal traces can't spawn one
+ * sprite each. Real thread ids always win.
+ */
+function anonymousThreadIdIfTraceBacked(span: Record<string, unknown>): string | undefined {
+  return traceIdAttr(span) === undefined ? undefined : ANONYMOUS_OTEL_THREAD_ID;
+}
+
+function normalizeSpanName(rawName: string): string {
+  return rawName.replaceAll('_', '.').replaceAll('/', '.');
+}
+
+function isTurnStartSpan(span: Record<string, unknown>): boolean {
+  const rawName = span.name;
+  if (typeof rawName !== 'string') return false;
+  return TURN_START_SPAN_NAMES.has(normalizeSpanName(rawName));
+}
+
+function cwdFromAttributes(attrs: Attrs): string | undefined {
+  return stringAttr(attrs, CWD_ATTRIBUTE_KEYS);
+}
+
+function inferredToolName(normalizedSpanName: string): string {
+  return normalizedSpanName === 'exec.command' ? 'exec' : 'tool';
+}
+
+function* eachSpan(json: Record<string, unknown>): Generator<{ span: Record<string, unknown>; resourceAttrs: Attrs }> {
+  for (const resource of recordArray(json.resourceSpans)) {
+    const resourceAttrs = flattenAttrs(isRecord(resource.resource) ? resource.resource.attributes : undefined);
+    for (const scope of recordArray(resource.scopeSpans)) {
+      for (const span of recordArray(scope.spans)) {
+        yield { span, resourceAttrs };
+      }
+    }
+  }
+}
+
+/**
+ * Per-thread session cwd, in two priority tiers — never batch-wide (that leaks
+ * A→B across concurrent sessions) and never from a tool/activity span's own cwd
+ * attribute (those carry per-call subprocess cwd like `exec_command`'s
+ * `process.cwd` pointing at /tmp). A wrong first value would permanently lock a
+ * session's project label, because the tracker's upgrade guard only fires once.
+ *
+ *  Tier 1 — turnStart spans' own cwd. Session-level per Codex's contract.
+ *  Tier 2 — resource-level cwd. Workspace-scoped for every thread under it.
+ */
+function buildCwdByThread(json: Record<string, unknown>): Map<string, string> {
+  const cwdByThread = new Map<string, string>();
+  for (const { span, resourceAttrs } of eachSpan(json)) {
+    if (!isTurnStartSpan(span)) continue;
+    const spanAttrs = flattenAttrs(span.attributes);
+    const cwd = cwdFromAttributes(spanAttrs);
+    if (!cwd) continue;
+    const merged = { ...resourceAttrs, ...spanAttrs };
+    const threadId = threadIdAttr(merged) ?? anonymousThreadIdIfTraceBacked(span);
+    if (threadId && !cwdByThread.has(threadId)) cwdByThread.set(threadId, cwd);
+  }
+  for (const { span, resourceAttrs } of eachSpan(json)) {
+    const resourceCwd = cwdFromAttributes(resourceAttrs);
+    if (!resourceCwd) continue;
+    const merged = { ...resourceAttrs, ...flattenAttrs(span.attributes) };
+    const threadId = threadIdAttr(merged) ?? anonymousThreadIdIfTraceBacked(span);
+    if (threadId && !cwdByThread.has(threadId)) cwdByThread.set(threadId, resourceCwd);
+  }
+  return cwdByThread;
+}
+
+function classify(
+  span: Record<string, unknown>,
+  resourceAttrs: Attrs,
+  cwdByThread: Map<string, string>,
+): CodexSpanEvent | undefined {
+  const rawName = span.name;
+  if (typeof rawName !== 'string') return undefined;
+  const attrs = { ...resourceAttrs, ...flattenAttrs(span.attributes) };
+
+  const threadId = threadIdAttr(attrs) ?? anonymousThreadIdIfTraceBacked(span);
+  if (!threadId) return undefined;
+  const turnId = stringAttr(attrs, TURN_ID_KEYS) ?? traceIdAttr(span) ?? '';
+
+  // turnStart trusts its own cwd attr, falling back to the thread map. Every
+  // other span type IGNORES its own cwd attr (subprocess-scoped) and uses only
+  // the thread-scoped fallback built above.
+  const cwd = isTurnStartSpan(span)
+    ? (cwdFromAttributes(attrs) ?? cwdByThread.get(threadId))
+    : cwdByThread.get(threadId);
+
+  const normalized = normalizeSpanName(rawName);
+  if (TURN_START_SPAN_NAMES.has(normalized)) return { kind: 'turnStart', threadId, turnId, cwd };
+  if (TOOL_CALL_SPAN_NAMES.has(normalized)) {
+    const tool = stringAttr(attrs, TOOL_NAME_KEYS) ?? inferredToolName(normalized);
+    return { kind: 'toolCall', threadId, turnId, tool, cwd };
+  }
+  if (TOOL_RESULT_SPAN_NAMES.has(normalized)) return { kind: 'toolResult', threadId, turnId };
+  if (TURN_END_SPAN_NAMES.has(normalized)) return { kind: 'turnEnd', threadId, turnId };
+  if (ACTIVITY_SPAN_NAMES.has(normalized)) return { kind: 'activity', threadId, turnId, name: rawName, cwd };
+  return undefined;
+}
+
+/** Parse an OTLP/HTTP `ExportTraceServiceRequest` body into ordered events. */
+export function parseCodexSpans(json: unknown): CodexSpanEvent[] {
+  if (!isRecord(json)) return [];
+  const cwdByThread = buildCwdByThread(json);
+  const events: CodexSpanEvent[] = [];
+  for (const { span, resourceAttrs } of eachSpan(json)) {
+    const event = classify(span, resourceAttrs, cwdByThread);
+    if (event) events.push(event);
+  }
+  return events;
+}
+
+/** Diagnostic for unrecognized future schemas — span names, not whole bodies. */
+export function spanNameSummary(json: unknown, limit = 12): string {
+  if (!isRecord(json)) return '';
+  const names: string[] = [];
+  for (const { span } of eachSpan(json)) {
+    if (typeof span.name === 'string' && span.name.length > 0) names.push(span.name);
+    if (names.length >= limit) break;
+  }
+  return names.join(',');
+}
+
+/**
+ * A thread OTel is reporting on. `turnEnd` sets `terminalAt`; a later
+ * `turnStart` clears it (the same re-engagement Swift allows on
+ * `codex_user_prompt_submit`), so a follow-up prompt revives the row instead of
+ * leaving the creature dead until the next scan.
+ */
+export interface CodexOtelThread {
+  threadId: string;
+  cwd?: string;
+  state: 'processing' | 'idle';
+  currentTool?: string;
+  servicedTurnId?: string;
+  startedAt: number;
+  lastEventAt: number;
+  terminalAt?: number;
+}
+
+/** A turn OTel says ended stops driving a synthesized row after this long. */
+const POST_TERMINAL_TTL_MS = 60_000;
+/** Any thread this quiet is dropped — a dead exporter must not pin a creature. */
+const THREAD_IDLE_TTL_MS = 5 * 60_000;
+/**
+ * How long an OTel observation may override the ps observer's state. Beyond
+ * this the rollout tail is the fresher signal again.
+ */
+const STATE_OVERLAY_TTL_MS = 2 * 60_000;
+
+/**
+ * Thread state distilled from OTLP spans, projected onto the sessions list.
+ *
+ * The division of labour is Node-specific. Swift has no process visibility, so
+ * there OTel is the *only* Codex-app session source. Here the ps/lsof observer
+ * already produces a richer row (model, tokens, goal, context) for any Codex
+ * that holds a rollout open, so OTel plays two narrower parts:
+ *
+ *  1. Overlay — turn boundaries land in milliseconds, where the observer only
+ *     re-reads the rollout tail every scan interval. When both describe the same
+ *     thread, a fresh OTel state/tool wins.
+ *  2. Fallback — when no observed row matches (rollout not open, lsof blind,
+ *     a Codex the process scan can't see), synthesize a `codex-app` row so the
+ *     session still appears. This is the Swift-parity path.
+ */
+export class CodexOtelTracker {
+  private readonly threads = new Map<string, CodexOtelThread>();
+
+  /** Fired when ingestion changed something worth broadcasting. */
+  onChanged: (() => void) | undefined;
+
+  /** Ingest one OTLP body. Returns the number of recognized events. */
+  ingest(json: unknown, now = Date.now()): number {
+    const events = parseCodexSpans(json);
+    let changed = false;
+    for (const event of events) {
+      // Anonymous trace-backed spans are liveness noise, not an identity: they
+      // must never synthesize or drive a session row (Swift parity —
+      // `shouldUseCodexOtelThreadForSessionState`).
+      if (event.threadId === ANONYMOUS_OTEL_THREAD_ID) continue;
+      changed = this.apply(event, now) || changed;
+    }
+    this.sweep(now);
+    if (changed) this.onChanged?.();
+    return events.length;
+  }
+
+  private apply(event: CodexSpanEvent, now: number): boolean {
+    const existing = this.threads.get(event.threadId);
+    // Progress-only spans keep a live turn from ageing out; they must never
+    // revive a finished or idle thread, nor open one (Swift
+    // `shouldUseCodexOtelActivityForState`). Bailing before the `lastEventAt`
+    // bump is what keeps a dead thread expiring on schedule.
+    if (event.kind === 'activity'
+      && (!existing || existing.terminalAt !== undefined || existing.state !== 'processing')) {
+      return false;
+    }
+    const thread: CodexOtelThread = existing ?? {
+      threadId: event.threadId,
+      state: 'idle',
+      startedAt: now,
+      lastEventAt: now,
+    };
+    const before = JSON.stringify(thread);
+    thread.lastEventAt = now;
+
+    // cwd upgrades once, empty→set. Later spans can only carry a subprocess cwd
+    // (the parser already restricts the source), so overwriting would lock the
+    // project label onto the wrong path.
+    if (!thread.cwd && event.kind !== 'toolResult' && event.kind !== 'turnEnd' && event.cwd) {
+      thread.cwd = event.cwd;
+    }
+
+    switch (event.kind) {
+      case 'turnStart':
+        thread.servicedTurnId = event.turnId;
+        thread.terminalAt = undefined;
+        thread.state = 'processing';
+        thread.currentTool = undefined;
+        break;
+      case 'toolCall':
+        if (thread.terminalAt !== undefined) break; // late span from a finished turn
+        thread.state = 'processing';
+        thread.currentTool = usefulToolName(event.tool);
+        break;
+      case 'toolResult':
+        if (thread.terminalAt !== undefined) break;
+        thread.state = 'processing';
+        thread.currentTool = undefined;
+        break;
+      case 'turnEnd':
+        // Stop-drift guard: a `turnEnd` can land seconds late, by which point a
+        // newer prompt already opened a fresh turn. Close only the turn OTel is
+        // actually servicing; when OTel never saw this turn's start, let it
+        // close (nothing else here knows better).
+        if (thread.servicedTurnId && event.turnId && thread.servicedTurnId !== event.turnId) break;
+        thread.state = 'idle';
+        thread.currentTool = undefined;
+        thread.servicedTurnId = undefined;
+        thread.terminalAt = now;
+        break;
+      case 'activity':
+        // Guarded above; reaching here only refreshes `lastEventAt`.
+        break;
+    }
+
+    this.threads.set(event.threadId, thread);
+    return JSON.stringify(thread) !== before;
+  }
+
+  private sweep(now: number): void {
+    for (const [threadId, thread] of this.threads) {
+      const terminalExpired = thread.terminalAt !== undefined
+        && now - thread.terminalAt > POST_TERMINAL_TTL_MS;
+      if (terminalExpired || now - thread.lastEventAt > THREAD_IDLE_TTL_MS) {
+        this.threads.delete(threadId);
+      }
+    }
+  }
+
+  /** Live thread snapshot (diagnostics / tests). */
+  snapshot(): CodexOtelThread[] {
+    return [...this.threads.values()];
+  }
+
+  /**
+   * Overlay fresh OTel state onto matching observed rows, and append a
+   * `codex-app` row for every thread the process scan didn't find.
+   */
+  applyTo(observed: ObservedSession[], now = Date.now()): ObservedSession[] {
+    this.sweep(now);
+    if (this.threads.size === 0) return observed;
+
+    const matched = new Set<string>();
+    const overlaid = observed.map((session) => {
+      if (session.agentType !== 'codex-cli' && session.agentType !== 'codex-app') return session;
+      const thread = this.threads.get(rawSessionId(session.id));
+      if (!thread) return session;
+      matched.add(thread.threadId);
+      if (now - thread.lastEventAt > STATE_OVERLAY_TTL_MS) return session;
+      return {
+        ...session,
+        state: thread.state,
+        // `currentTask` is the observer's rollout-derived label; only replace it
+        // while OTel has a tool in flight, so a finished turn falls back to the
+        // richer text instead of blanking.
+        ...(thread.currentTool ? { currentTask: thread.currentTool } : {}),
+      };
+    });
+
+    const synthesized: ObservedSession[] = [];
+    for (const thread of this.threads.values()) {
+      if (matched.has(thread.threadId)) continue;
+      const cwd = thread.cwd;
+      synthesized.push({
+        id: `observed:codex-app:${thread.threadId}`,
+        port: 0,
+        pid: 0,
+        // No cwd yet means no project: borrowing a sibling session's name is how
+        // the macOS dashboard once labelled Codex with a neighbour's project.
+        projectName: cwd ? resolveProjectNameFromCwdCached(cwd) : 'Codex',
+        agentType: 'codex-app',
+        alive: true,
+        state: thread.state,
+        controlMode: 'observed',
+        cwd,
+        currentTask: thread.currentTool,
+        startedAt: new Date(thread.startedAt).toISOString(),
+      });
+    }
+    return synthesized.length > 0 ? [...overlaid, ...synthesized] : overlaid;
+  }
+}
+
+/**
+ * Drop tool labels that carry no information for a dashboard row. Codex emits
+ * `tool`/`unknown` placeholders on spans whose name attribute is missing.
+ */
+function usefulToolName(tool: string): string | undefined {
+  const trimmed = tool.trim();
+  if (!trimmed || trimmed === 'tool' || trimmed === 'unknown') return undefined;
+  return trimmed;
+}

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -104,7 +104,9 @@ import { loadIDotMatrixDevices } from './idotmatrix/idotmatrix-settings.js';
 import { handlePixooWake } from './pixoo/pixoo-client.js';
 import { triggerMdnsRecovery } from './mdns.js';
 import { rgbToBmp, pixooLiveHtml } from './hook-server.js';
-import { enableDebugLog, debug } from './logger.js';
+import { enableDebugLog, debug, debugThrottled } from './logger.js';
+import { CodexOtelTracker, CODEX_OTEL_TRACES_PATH, spanNameSummary } from './codex-otel.js';
+import { HookCodexSessions } from './hook-codex-sessions.js';
 import { initApme, isTimelineProjectionEnabled, loadApmeConfig, type ApmeModule } from './apme/index.js';
 import { FallbackTaskTimeline } from './fallback-task-timeline.js';
 import { handleApmeRequest } from './apme/http.js';
@@ -142,7 +144,7 @@ import { renderGlanceFrame, GLANCE_FRAME_BOARDS } from './glance-frame.js';
 import type { UsageEvent } from './types.js';
 import { mergeRelayedSessionUsage } from './usage-event.js';
 import { CARD_FEED_PATH, CARD_OUTBOX_PATH, GLANCE_FRAME_PATH, type SessionInfo, type OutboxPushRequest } from '@agentdeck/shared';
-import { readFileSync, statSync } from 'fs';
+import { readFileSync, statSync, appendFileSync } from 'fs';
 import { readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -1025,6 +1027,14 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   // threshold). Declared before the HTTP handlers that populate it.
   const hookSessionsSeen = new Set<string>();
 
+  // Codex OTel span state. Declared before the HTTP server because the
+  // `/otel/v1/traces` handler closes over it — Codex's exporter can POST before
+  // the rest of daemon startup finishes.
+  const codexOtel = new CodexOtelTracker();
+  // Codex sessions known only from `codex_*` hooks — the backstop for when the
+  // process scan can't see one (lsof timeout, no rollout held open).
+  const hookCodexSessions = new HookCodexSessions();
+
   // Declare early — HTTP /health handler references this in its closure.
   // Must be declared before the HTTP server so it's initialized (not in TDZ)
   // when the first /health request arrives.
@@ -1513,6 +1523,11 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           billingType: snap.billingType,
         },
         wsClients: core.wsServer.getClientCount(),
+        // Codex observation backstops — which sessions each source believes in.
+        // A session present here but absent from sessions_list means the ps
+        // observer found it too and won, which is the expected steady state.
+        hookCodexSessions: hookCodexSessions.snapshot(),
+        codexOtelThreads: codexOtel.snapshot(),
         recentJournal: [],
         ptyTail: '',
         journalDir: join(homedir(), '.agentdeck'),
@@ -1626,6 +1641,18 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             ? ''
             : JSON.stringify({ received: true }));
           return;
+        }
+        // Hook-derived Codex session rows. Placed after the child-hook return so
+        // subagent lifecycle never drives the parent row, and kept independent
+        // of the state machine: this only decides whether a Codex the process
+        // scan can't see still has a session. See bridge/src/hook-codex-sessions.ts.
+        if (eventName.startsWith('codex_')) {
+          hookCodexSessions.note(eventName, {
+            sessionId: typeof json.session_id === 'string' ? json.session_id : undefined,
+            cwd: earlyHookCwd || undefined,
+            projectName: earlyHookProject,
+            toolName: typeof json.tool_name === 'string' ? json.tool_name : undefined,
+          });
         }
         // State machine
         if (mapped === 'session_start') core.stateMachine.handleHookEvent('SessionStart', json);
@@ -2065,6 +2092,39 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         } else {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ received: true }));
+        }
+      });
+      return;
+    }
+
+    // Codex OTel exporter target. Codex (CLI and the ChatGPT.app desktop app)
+    // POSTs OTLP/HTTP JSON spans here when `[otel.trace_exporter.otlp-http]`
+    // points at the daemon. Only the Swift daemon used to implement this, so a
+    // Node-daemon host answered 404 and dropped every span. Always 200: an OTel
+    // exporter that sees errors backs off, and nothing here is worth telling
+    // Codex about. See bridge/src/codex-otel.ts.
+    if (req.method === 'POST' && (pathname === CODEX_OTEL_TRACES_PATH || pathname === '/v1/traces')) {
+      let body = '';
+      req.on('data', (c: Buffer) => { body += c; if (body.length > 8_000_000) req.destroy(); });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        try {
+          const json: unknown = body ? JSON.parse(body) : {};
+          // Dev capture. Codex's span vocabulary is not a stable API, so when it
+          // shifts the only way to re-derive the dispatch table is to look at
+          // real batches: `AGENTDECK_CODEX_OTEL_DUMP=/tmp/otel.jsonl agentdeck
+          // daemon start`. Bodies are pretty-printed and large — point it at a
+          // scratch path and delete it afterwards.
+          if (process.env.AGENTDECK_CODEX_OTEL_DUMP) {
+            try { appendFileSync(process.env.AGENTDECK_CODEX_OTEL_DUMP, `${body}\n`); } catch { /* dev only */ }
+          }
+          if (codexOtel.ingest(json) === 0) {
+            debugThrottled('codex-otel', 'no-recognized-spans', 60_000,
+              `no recognized spans; len=${body.length} names=${spanNameSummary(json)}`);
+          }
+        } catch {
+          debugThrottled('codex-otel', 'unparsable-body', 60_000, `unparsable body len=${body.length}`);
         }
       });
       return;
@@ -2721,6 +2781,11 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   // immediately). When a scan lands fresh observations, push them out via
   // the debounced broadcast so clients don't wait for the next 10 s poll.
   passiveSessionObserver.onRefreshed = () => core.maybeBroadcastSessionsList();
+  // OTel turn boundaries arrive in milliseconds where the observer only re-reads
+  // the rollout tail every scan interval, so a span that changed thread state is
+  // worth a broadcast of its own.
+  codexOtel.onChanged = () => core.maybeBroadcastSessionsList();
+  hookCodexSessions.onChanged = () => core.maybeBroadcastSessionsList();
 
   // ===== Gateway adapter lifecycle =====
   // (gatewayAdapter + gatewayConnecting declared earlier, before HTTP server)
@@ -2734,7 +2799,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     // the 5s-throttled observer, so a Notification arriving mid-window still
     // surfaces within one frame. Key = the Claude session UUID embedded in
     // `observed:claude:<uuid>`.
-    const observed = applyAwaitingOverlayToObserved(passiveSessionObserver.collect(sessions))
+    // Codex OTel spans overlay state/tool onto the matching ps-observed row and
+    // synthesize a `codex-app` row for any thread the process scan missed —
+    // Swift's only Codex-app source, here a second opinion on top of the
+    // observer. See bridge/src/codex-otel.ts.
+    const observed = applyAwaitingOverlayToObserved(
+      hookCodexSessions.applyTo(codexOtel.applyTo(passiveSessionObserver.collect(sessions))),
+    )
       .map((s) => {
         // Steering feedback for observed Claude sessions: devices render
         // "stopping at next tool" / queued-directive badges from these.

--- a/bridge/src/hook-codex-sessions.ts
+++ b/bridge/src/hook-codex-sessions.ts
@@ -1,0 +1,195 @@
+// hook-codex-sessions.ts — Codex sessions derived from lifecycle hooks alone.
+//
+// The Node daemon has always let the ps/lsof passive observer own observed
+// Codex session identity and state, with `codex_*` hooks feeding only the
+// timeline (see the dispatch comment in daemon-server.ts). That works right up
+// until the process scan can't answer: `lsof` is a 2 s-timeout subprocess, and
+// when it times out — or a Codex holds no rollout open — the row disappears
+// from every deck even though hooks are still arriving. The Swift daemon never
+// had this failure mode because it has no process visibility at all and
+// synthesizes a session from `codex_session_start` directly
+// (`DaemonServer.handleHookEvent`). This is that path, ported.
+//
+// Ownership rules, so the two sources can't fight:
+//   • The observer wins whenever it sees the session. A hook row is emitted only
+//     for a session id no observed row carries — never a second row for one
+//     conversation.
+//   • Hook rows are deliberately thin (id, project, state, tool). Model, token
+//     counts, context %, and goal come from the rollout and stay the observer's
+//     job; a hook row that guessed them would flicker against the real values
+//     the moment the scan recovered.
+
+import type { ObservedSession } from './passive-observer.js';
+import { resolveProjectNameFromCwdCached } from './utils/project-name.js';
+
+/** Reaped this long after the turn-ending hook — Swift's `codexPostTerminalTTL`. */
+const POST_TERMINAL_TTL_MS = 60_000;
+/**
+ * Reaped this long after ANY hook when no terminal event arrived. A session
+ * killed mid-turn (SIGKILL, closed laptop) fires no `codex_stop`, and without
+ * this its creature would sit "processing" forever.
+ */
+const SILENT_TTL_MS = 30 * 60_000;
+
+/** Hook events that may create a row. */
+const OPENING_EVENTS = new Set(['codex_session_start', 'codex_user_prompt_submit']);
+/** Hook events that end a turn. `codex_turn_complete` is the notify-only fallback. */
+const TERMINAL_EVENTS = new Set(['codex_stop', 'codex_session_end', 'codex_turn_complete']);
+/**
+ * A finished session stays un-resurrectable this long — longer than its row
+ * lives, so a trailing tool callback can't revive a creature 90 s after the turn
+ * ended. Only an explicit opening event clears it.
+ */
+const TOMBSTONE_TTL_MS = 30 * 60_000;
+
+export interface HookCodexSession {
+  sessionId: string;
+  projectName: string;
+  cwd?: string;
+  state: 'idle' | 'processing';
+  currentTool?: string;
+  startedAt: number;
+  lastHookAt: number;
+  terminalAt?: number;
+}
+
+export interface HookCodexPayload {
+  sessionId?: string;
+  cwd?: string;
+  projectName?: string;
+  toolName?: string;
+}
+
+export class HookCodexSessions {
+  private readonly sessions = new Map<string, HookCodexSession>();
+  /** sessionId → epoch ms of its last terminal hook, outliving the row. */
+  private readonly terminated = new Map<string, number>();
+
+  /** Fired when a hook changed something worth broadcasting. */
+  onChanged: (() => void) | undefined;
+
+  /**
+   * Record a `codex_*` lifecycle hook. Returns true when the sessions list
+   * should be rebroadcast.
+   */
+  note(event: string, payload: HookCodexPayload, now = Date.now()): boolean {
+    const sessionId = payload.sessionId?.trim();
+    if (!sessionId || !event.startsWith('codex_')) return false;
+
+    if (OPENING_EVENTS.has(event)) this.terminated.delete(sessionId);
+
+    const existing = this.sessions.get(sessionId);
+    if (!existing) {
+      // A mid-turn event may open a row too — that's how a session whose start
+      // hook predates this daemon (restart, or hooks installed mid-session)
+      // becomes visible at all. But only when the session has no tombstone: a
+      // trailing tool callback from a finished companion task must not
+      // resurrect a creature. Swift layers the same tombstone-gated bypass over
+      // `shouldSynthesizeUnknownHookSession`.
+      if (!OPENING_EVENTS.has(event) && !isProgressEvent(event)) return false;
+      if (this.terminated.has(sessionId)) return false;
+    }
+
+    const session: HookCodexSession = existing ?? {
+      sessionId,
+      projectName: '',
+      state: 'idle',
+      startedAt: now,
+      lastHookAt: now,
+    };
+    const before = JSON.stringify(session);
+    session.lastHookAt = now;
+
+    // cwd/project upgrade once, empty→set: later hooks on the same session can
+    // carry a subcommand's directory, and overwriting would relabel the row.
+    if (!session.cwd && payload.cwd) {
+      session.cwd = payload.cwd;
+      session.projectName = resolveProjectNameFromCwdCached(payload.cwd);
+    }
+    if (!session.projectName && payload.projectName) session.projectName = payload.projectName;
+
+    if (TERMINAL_EVENTS.has(event)) {
+      session.state = 'idle';
+      session.currentTool = undefined;
+      session.terminalAt = now;
+      this.terminated.set(sessionId, now);
+    } else {
+      // Any non-terminal hook means the turn is live again — including a
+      // follow-up prompt on a session whose previous turn ended.
+      session.terminalAt = undefined;
+      session.state = 'processing';
+      if (event === 'codex_tool_start') session.currentTool = payload.toolName || undefined;
+      else if (event === 'codex_tool_end') session.currentTool = undefined;
+      else if (event === 'codex_user_prompt_submit') session.currentTool = undefined;
+    }
+
+    this.sessions.set(sessionId, session);
+    this.reap(now);
+    const changed = JSON.stringify(session) !== before || !existing;
+    if (changed) this.onChanged?.();
+    return changed;
+  }
+
+  /** Drop a session immediately (explicit end, not a timeout). */
+  forget(sessionId: string): void {
+    if (this.sessions.delete(sessionId)) this.onChanged?.();
+  }
+
+  snapshot(): HookCodexSession[] {
+    return [...this.sessions.values()];
+  }
+
+  private reap(now: number): void {
+    for (const [sessionId, session] of this.sessions) {
+      const finished = session.terminalAt !== undefined
+        && now - session.terminalAt > POST_TERMINAL_TTL_MS;
+      if (finished || now - session.lastHookAt > SILENT_TTL_MS) this.sessions.delete(sessionId);
+    }
+    for (const [sessionId, at] of this.terminated) {
+      if (now - at > TOMBSTONE_TTL_MS) this.terminated.delete(sessionId);
+    }
+  }
+
+  /**
+   * Append a row for every hook-known Codex the process scan didn't produce.
+   * Sessions the observer already found are left entirely alone — its row is
+   * strictly richer.
+   */
+  applyTo(observed: ObservedSession[], now = Date.now()): ObservedSession[] {
+    this.reap(now);
+    if (this.sessions.size === 0) return observed;
+
+    const seen = new Set<string>();
+    for (const session of observed) {
+      // `observed:codex:<uuid>` / `observed:codex-app:<uuid>` → the bare uuid
+      // hooks use. Both id forms name the same conversation.
+      const match = /^observed:codex(?:-app)?:(.+)$/.exec(session.id);
+      if (match?.[1]) seen.add(match[1]);
+    }
+
+    const extra: ObservedSession[] = [];
+    for (const session of this.sessions.values()) {
+      if (seen.has(session.sessionId)) continue;
+      extra.push({
+        id: `observed:codex:${session.sessionId}`,
+        port: 0,
+        pid: 0,
+        projectName: session.projectName || 'Codex',
+        agentType: 'codex-cli',
+        alive: true,
+        state: session.state,
+        controlMode: 'observed',
+        cwd: session.cwd,
+        currentTask: session.currentTool,
+        startedAt: new Date(session.startedAt).toISOString(),
+        lastActivityAt: session.lastHookAt,
+      });
+    }
+    return extra.length > 0 ? [...observed, ...extra] : observed;
+  }
+}
+
+/** Mid-turn hooks: progress on a session that must already be known. */
+function isProgressEvent(event: string): boolean {
+  return event === 'codex_tool_start' || event === 'codex_tool_end';
+}

--- a/bridge/src/logger.ts
+++ b/bridge/src/logger.ts
@@ -75,3 +75,23 @@ export function debug(tag: string, ...args: unknown[]): void {
   const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
   debugStream.write(`${ts} [${tag}] ${args.map(String).join(' ')}\n`);
 }
+
+const throttledDebugAt = new Map<string, number>();
+
+/**
+ * Debug logging for events that repeat on a timer — an unrecognized OTel span
+ * batch, a periodic probe failure. Emits at most once per `minIntervalMs` per
+ * `key`, so `--debug` stays readable instead of thousands of lines a minute.
+ */
+export function debugThrottled(
+  tag: string,
+  key: string,
+  minIntervalMs: number,
+  ...args: unknown[]
+): void {
+  if (!debugEnabled || !debugStream) return;
+  const now = Date.now();
+  if (now - (throttledDebugAt.get(key) ?? 0) < minIntervalMs) return;
+  throttledDebugAt.set(key, now);
+  debug(tag, ...args);
+}

--- a/bridge/src/passive-observer.ts
+++ b/bridge/src/passive-observer.ts
@@ -341,6 +341,36 @@ export function parseClaudeTranscript(raw: string): TranscriptSummary {
   };
 }
 
+/**
+ * Codex reports `input_tokens` INCLUSIVE of `cached_input_tokens` — the live
+ * rollouts satisfy `total_tokens === input_tokens + output_tokens`. Adding the
+ * cached count on top double-counts it, which pushed one observed session to
+ * 105% context and roughly doubled its token total. Older producers that report
+ * cached separately have no `total_tokens`, so the additive form stays the
+ * fallback and their accounting is unchanged.
+ */
+function codexCachedIsIncluded(usage: Record<string, unknown>): boolean {
+  const reported = numberAt(usage, 'total_tokens');
+  if (reported <= 0) return false;
+  return numberAt(usage, 'input_tokens') + numberAt(usage, 'output_tokens') === reported;
+}
+
+function codexCachedInput(usage: Record<string, unknown>): number {
+  return numberAt(usage, 'cached_input_tokens') || numberAt(usage, 'cache_read_input_tokens');
+}
+
+/** Whole-session token spend (prompt + completion, cached counted once). */
+function codexUsageTotal(usage: Record<string, unknown>): number {
+  const base = numberAt(usage, 'input_tokens') + numberAt(usage, 'output_tokens');
+  return codexCachedIsIncluded(usage) ? base : base + codexCachedInput(usage);
+}
+
+/** Context-window occupancy: the prompt side of the most recent request only. */
+function codexUsageContext(usage: Record<string, unknown>): number {
+  const input = numberAt(usage, 'input_tokens');
+  return codexCachedIsIncluded(usage) ? input : input + codexCachedInput(usage);
+}
+
 export function parseCodexRollout(raw: string): CodexRolloutSummary {
   let sessionId: string | undefined;
   let cwd: string | undefined;
@@ -408,18 +438,9 @@ export function parseCodexRollout(raw: string): CodexRolloutSummary {
           const info = objectAt(payload, 'info');
           if (!info) break;
           const total = objectAt(info, 'total_token_usage');
-          if (total) {
-            totalTokens =
-              numberAt(total, 'input_tokens') +
-              numberAt(total, 'output_tokens') +
-              (numberAt(total, 'cached_input_tokens') || numberAt(total, 'cache_read_input_tokens'));
-          }
+          if (total) totalTokens = codexUsageTotal(total);
           const last = objectAt(info, 'last_token_usage');
-          if (last) {
-            lastContextTokens =
-              numberAt(last, 'input_tokens') +
-              (numberAt(last, 'cached_input_tokens') || numberAt(last, 'cache_read_input_tokens'));
-          }
+          if (last) lastContextTokens = codexUsageContext(last);
           contextWindow = numberAt(info, 'model_context_window') || contextWindow;
           break;
         }
@@ -614,11 +635,27 @@ export async function collectCodexSessionsFromRollouts(
   return sessions;
 }
 
-/** A standalone CLI or app-server process that owns user-facing rollouts. */
+/**
+ * A Codex process that can own a user session.
+ *
+ * `codex app-server` was excluded here originally because it was only ever an
+ * IDE extension's headless backend. The ChatGPT.app Codex desktop app now runs
+ * exactly that command for a real, user-facing session
+ * (`/Applications/ChatGPT.app/Contents/Resources/codex … app-server`), so the
+ * process shape no longer separates the two and the exclusion made every
+ * desktop-app session invisible — no session row, no creature — even though its
+ * lifecycle hooks were landing in the timeline the whole time.
+ *
+ * Admission is settled downstream instead, by whether the pid holds an open
+ * rollout file: an app-server with no conversation holds none and is dropped in
+ * `collectCodexSessions`. The Electron helpers ship a capital-`Codex` basename
+ * (`Codex (Renderer)`), so `cmdHasBinary` already excludes them.
+ */
 export function isCodexSessionProcessCommand(command: string): boolean {
   return cmdHasBinary(command, 'codex') && !command.includes('grep');
 }
 
+/** Fallback session id for a rollout with no parsable `session_meta`. */
 function codexRolloutId(rolloutPath: string): string {
   return basename(rolloutPath).replace(/^rollout-/, '').replace(/\.jsonl$/, '');
 }
@@ -812,6 +849,11 @@ function findClaudeTranscript(configDirs: string[], cwd: string, sessionId: stri
   return null;
 }
 
+/**
+ * Open rollout files per pid. A terminal `codex` owns exactly one, but a desktop
+ * app-server pid owns one per open conversation — so this is 1:N and every entry
+ * becomes its own session.
+ */
 async function mapCodexPidsToRollouts(pids: number[]): Promise<Map<number, string[]>> {
   if (pids.length === 0) return new Map();
   if (process.platform === 'linux') {
@@ -854,6 +896,7 @@ export function parseLsofRollouts(output: string): Map<number, string[]> {
       const path = line.slice(1);
       if (!isCodexRolloutPath(path)) continue;
       const paths = map.get(currentPid) ?? [];
+      // The same rollout can appear twice (dup'd fd); one session per file.
       if (!paths.includes(path)) paths.push(path);
       map.set(currentPid, paths);
     }

--- a/hooks/src/codex-install.ts
+++ b/hooks/src/codex-install.ts
@@ -86,6 +86,10 @@ function currentDaemonHttpPort(): number | null {
   return null;
 }
 
+// The path must match what the daemons actually serve — Node
+// `CODEX_OTEL_TRACES_PATH` (bridge/src/codex-otel.ts) and Swift
+// `CodexOtelRoutes`. Spelled out here rather than imported because this package
+// has no workspace dependencies (it bootstraps setups that lack them).
 function buildOtelEndpoint(daemonHttpPort?: number): string {
   const port = isValidPort(daemonHttpPort)
     ? daemonHttpPort


### PR DESCRIPTION
## What changed

- ingest Codex Desktop OTLP traces at `/otel/v1/traces`
- correlate lifecycle hooks with observed Codex App sessions and keep a bounded daemon backstop
- expose diagnostics for OTel and hook-observed sessions
- throttle repetitive debug logging
- preserve the async 1:N rollout discovery/cache from #109
- fix Codex token accounting when cached input is already included in `input_tokens`

## Stack

This is 1/4 in the local integration stack. The next PR adds Calendar Card Feed events; ESP32 pull-OTA staging and Adaptive Pocket follow above it.

## Validation

Validated after rebasing the complete stack onto current `master`:

- `pnpm build`
- focused Codex OTel/hook/passive-observer suite
- `pnpm test` — 147 files, 2,435 tests passed
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm design-system:check`
- preview mirror sync and protocol regeneration clean
- `git diff --check`