### PR TITLE
feat(glance): add calendar events to Card Feed

### DIFF
--- a/bridge/src/__tests__/calendar.test.ts
+++ b/bridge/src/__tests__/calendar.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseCalendarSettings,
+  unfoldIcsLines,
+  parseIcsInstant,
+  parseIcsEvents,
+  occursOn,
+  buildTodayEvents,
+  CalendarProvider,
+  CALENDAR_CACHE_MS,
+} from '../calendar.js';
+
+// A fixed local instant: 2026-08-04 (Tue) 09:00.
+const NOW = new Date(2026, 7, 4, 9, 0);
+
+const ics = (body: string): string =>
+  `BEGIN:VCALENDAR\r\n${body}\r\nEND:VCALENDAR\r\n`;
+
+const vevent = (lines: string[]): string =>
+  ['BEGIN:VEVENT', ...lines, 'END:VEVENT'].join('\r\n');
+
+describe('parseCalendarSettings', () => {
+  it('accepts a single url or a list, rejects everything else', () => {
+    expect(parseCalendarSettings({ calendar: { ics: 'https://x/a.ics' } }))
+      .toEqual({ urls: ['https://x/a.ics'] });
+    expect(parseCalendarSettings({ calendar: { ics: ['https://x/a.ics', 'https://x/b.ics'] } }))
+      .toEqual({ urls: ['https://x/a.ics', 'https://x/b.ics'] });
+    expect(parseCalendarSettings({})).toBeNull();
+    expect(parseCalendarSettings({ calendar: { ics: 'file:///etc/passwd' } })).toBeNull();
+    expect(parseCalendarSettings({ calendar: { ics: 42 } })).toBeNull();
+  });
+});
+
+describe('ICS parsing', () => {
+  it('unfolds continuation lines', () => {
+    expect(unfoldIcsLines('SUMMARY:Hello\r\n  world\r\nUID:1')).toEqual(['SUMMARY:Hello world', 'UID:1']);
+  });
+
+  it('parses date, local, and UTC instants', () => {
+    expect(parseIcsInstant('20260804')).toEqual({ date: '20260804' });
+    expect(parseIcsInstant('20260804T093000')).toEqual({ date: '20260804', hm: '09:30' });
+    // UTC converts through the daemon clock — assert round-trip consistency
+    // rather than a fixed zone.
+    const z = parseIcsInstant('20260804T000000Z');
+    const local = new Date(Date.UTC(2026, 7, 4, 0, 0));
+    const pad = (n: number) => String(n).padStart(2, '0');
+    expect(z).toEqual({
+      date: `${local.getFullYear()}${pad(local.getMonth() + 1)}${pad(local.getDate())}`,
+      hm: `${pad(local.getHours())}:${pad(local.getMinutes())}`,
+    });
+    expect(parseIcsInstant('garbage')).toBeNull();
+  });
+
+  it('parses VEVENTs with summary escaping and TZID params', () => {
+    const events = parseIcsEvents(ics(vevent([
+      'UID:e1',
+      'DTSTART;TZID=Asia/Seoul:20260804T140000',
+      'DTEND;TZID=Asia/Seoul:20260804T150000',
+      'SUMMARY:Demo\\, part 1',
+    ])));
+    expect(events).toHaveLength(1);
+    expect(events[0].summary).toBe('Demo, part 1');
+    expect(events[0].startDate).toBe('20260804');
+    expect(events[0].startHm).toBe('14:00');
+    expect(events[0].endHm).toBe('15:00');
+  });
+});
+
+describe('occursOn (recurrence)', () => {
+  const base = (rrule: string, start = 'DTSTART:20260707T100000') =>
+    parseIcsEvents(ics(vevent(['UID:r1', start, `RRULE:${rrule}`, 'SUMMARY:R'])))[0];
+
+  it('non-recurring: literal date only', () => {
+    const e = parseIcsEvents(ics(vevent(['UID:x', 'DTSTART:20260804T100000', 'SUMMARY:S'])))[0];
+    expect(occursOn(e, '20260804')).toBe(true);
+    expect(occursOn(e, '20260805')).toBe(false);
+  });
+
+  it('DAILY with INTERVAL and UNTIL', () => {
+    const e = base('FREQ=DAILY;INTERVAL=2');
+    expect(occursOn(e, '20260804')).toBe(true);   // 28 days after 07-07
+    expect(occursOn(e, '20260805')).toBe(false);  // off-interval day
+    const u = base('FREQ=DAILY;UNTIL=20260801T000000');
+    expect(occursOn(u, '20260804')).toBe(false);
+  });
+
+  it('WEEKLY honors BYDAY', () => {
+    // 2026-08-04 is a Tuesday.
+    const e = base('FREQ=WEEKLY;BYDAY=TU,TH');
+    expect(occursOn(e, '20260804')).toBe(true);
+    expect(occursOn(e, '20260805')).toBe(false);  // Wednesday
+  });
+
+  it('DAILY COUNT exhausts', () => {
+    const e = base('FREQ=DAILY;COUNT=5');  // 07-07..07-11
+    expect(occursOn(e, '20260711')).toBe(true);
+    expect(occursOn(e, '20260712')).toBe(false);
+    expect(occursOn(e, '20260804')).toBe(false);
+  });
+
+  it('MONTHLY and YEARLY match the start day', () => {
+    const m = base('FREQ=MONTHLY', 'DTSTART:20260104T100000');
+    expect(occursOn(m, '20260804')).toBe(true);
+    expect(occursOn(m, '20260805')).toBe(false);
+    const y = base('FREQ=YEARLY', 'DTSTART:20250804T100000');
+    expect(occursOn(y, '20260804')).toBe(true);
+  });
+
+  it('EXDATE removes an instance', () => {
+    const e = parseIcsEvents(ics(vevent([
+      'UID:r2', 'DTSTART:20260707T100000', 'RRULE:FREQ=DAILY',
+      'EXDATE:20260804T100000', 'SUMMARY:R',
+    ])))[0];
+    expect(occursOn(e, '20260804')).toBe(false);
+    expect(occursOn(e, '20260803')).toBe(true);
+  });
+});
+
+describe('buildTodayEvents', () => {
+  it('keeps only what is left of today, all-day first, capped and sorted', () => {
+    const events = parseIcsEvents(ics([
+      vevent(['UID:a', 'DTSTART:20260804T080000', 'DTEND:20260804T083000', 'SUMMARY:Past standup']),
+      vevent(['UID:b', 'DTSTART:20260804T140000', 'DTEND:20260804T150000', 'SUMMARY:Demo']),
+      vevent(['UID:c', 'DTSTART:20260804T100000', 'SUMMARY:Call']),
+      vevent(['UID:d', 'DTSTART;VALUE=DATE:20260804', 'DTEND;VALUE=DATE:20260805', 'SUMMARY:Holiday']),
+      vevent(['UID:e', 'DTSTART:20260805T090000', 'SUMMARY:Tomorrow thing']),
+    ].join('\r\n')));
+    expect(buildTodayEvents(events, NOW)).toEqual([
+      { title: 'Holiday' },                                   // all-day first
+      { startHm: '10:00', title: 'Call' },
+      { startHm: '14:00', endHm: '15:00', title: 'Demo' },
+    ]);  // past standup dropped, tomorrow dropped, cap = 3
+  });
+
+  it('an in-progress event survives the past filter via its end time', () => {
+    const events = parseIcsEvents(ics(vevent([
+      'UID:f', 'DTSTART:20260804T083000', 'DTEND:20260804T093000', 'SUMMARY:Ongoing',
+    ])));
+    expect(buildTodayEvents(events, NOW)).toEqual([
+      { startHm: '08:30', endHm: '09:30', title: 'Ongoing' },
+    ]);
+  });
+
+  it('RECURRENCE-ID override replaces the master instance', () => {
+    const events = parseIcsEvents(ics([
+      vevent(['UID:r', 'DTSTART:20260707T100000', 'RRULE:FREQ=DAILY', 'SUMMARY:Standup']),
+      vevent(['UID:r', 'RECURRENCE-ID:20260804T100000', 'DTSTART:20260804T110000', 'SUMMARY:Standup (moved)']),
+    ].join('\r\n')));
+    expect(buildTodayEvents(events, NOW)).toEqual([
+      { startHm: '11:00', title: 'Standup (moved)' },
+    ]);
+  });
+
+  it('trims titles to the UTF-8 byte budget', () => {
+    const long = '아주긴한글제목'.repeat(10);
+    const events = parseIcsEvents(ics(vevent([
+      'UID:g', 'DTSTART:20260804T120000', `SUMMARY:${long}`,
+    ])));
+    const [ev] = buildTodayEvents(events, NOW);
+    expect(new TextEncoder().encode(ev.title).length).toBeLessThanOrEqual(48);
+  });
+});
+
+describe('CalendarProvider', () => {
+  const BODY = ics(vevent(['UID:p', 'DTSTART:20260804T140000', 'SUMMARY:Demo']));
+
+  it('fetches, caches, and re-filters cached parses against the current clock', async () => {
+    const fetchImpl = vi.fn(async () => new Response(BODY, { status: 200 }));
+    const p = new CalendarProvider(fetchImpl as unknown as typeof fetch);
+    const cfg = { urls: ['https://x/a.ics'] };
+    const t0 = NOW.getTime();
+    expect(await p.get(cfg, t0)).toEqual([{ startHm: '14:00', title: 'Demo' }]);
+    expect(await p.get(cfg, t0 + CALENDAR_CACHE_MS - 1000)).toEqual([{ startHm: '14:00', title: 'Demo' }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // Same cache, later clock: the 14:00 event has passed.
+    const evening = new Date(2026, 7, 4, 18, 0).getTime();
+    // (cache expired by then — refetch serves the same body)
+    expect(await p.get(cfg, evening)).toEqual([]);
+  });
+
+  it('resolves undefined when unconfigured or on a cold failure', async () => {
+    const failing = vi.fn(async () => { throw new Error('down'); });
+    const p = new CalendarProvider(failing as unknown as typeof fetch);
+    expect(await p.get(null)).toBeUndefined();
+    expect(await p.get({ urls: ['https://x/a.ics'] }, NOW.getTime())).toBeUndefined();
+  });
+});

--- a/bridge/src/calendar.ts
+++ b/bridge/src/calendar.ts
@@ -1,0 +1,342 @@
+/**
+ * Glance schedule provider (ICS) — daemon-side module for the card-feed sleep
+ * dashboard (M9 stage 2). The device never parses a calendar itself; the
+ * daemon fetches the ICS feed(s), expands today's occurrences, and pre-renders
+ * them into `CardFeedResponse.glance.events` (shared/src/protocol.ts § Glance).
+ *
+ * Config comes from settings.json — one secret-address ICS URL (Google
+ * Calendar / iCloud / Fastmail all export one) or a list:
+ *
+ *   "calendar": { "ics": "https://calendar.google.com/calendar/ical/…/basic.ics" }
+ *   "calendar": { "ics": ["https://…/basic.ics", "https://…/work.ics"] }
+ *
+ * No config → no schedule in the glance (never a guess).
+ *
+ * Deliberately dependency-free, like weather.ts. The parser covers the ICS
+ * subset a personal "what's left of today" needs:
+ *   - VEVENT with SUMMARY / DTSTART / DTEND, line unfolding, text unescaping
+ *   - all-day events (VALUE=DATE), UTC instants (…Z), floating/TZID-local
+ *     times (TZID is assumed to be the daemon's own zone — the common case for
+ *     a personal calendar; a cross-zone TZID renders at its literal HH:MM)
+ *   - RRULE FREQ=DAILY/WEEKLY(BYDAY)/MONTHLY(BYMONTHDAY)/YEARLY with
+ *     INTERVAL / UNTIL / COUNT, expanded by bounded day-walk from DTSTART
+ *   - EXDATE and RECURRENCE-ID overrides (override replaces that instance)
+ */
+
+import type { GlanceEvent } from '@agentdeck/shared';
+import { GLANCE_MAX_EVENTS, GLANCE_EVENT_TITLE_MAX_BYTES } from '@agentdeck/shared';
+import { trimUtf8Bytes } from './card-feed.js';
+
+export interface CalendarSettings {
+  urls: string[];
+}
+
+/** Serve from cache inside this window — schedule cadence is slower than the
+ *  fastest pull cadence (900s). */
+export const CALENDAR_CACHE_MS = 30 * 60 * 1000;
+/** After a fetch failure, keep serving the last good parse up to this age. */
+export const CALENDAR_STALE_SERVE_MS = 6 * 60 * 60 * 1000;
+/** External peer await — timeout is first-line, not optional. */
+export const CALENDAR_FETCH_TIMEOUT_MS = 8000;
+/** Recurrence day-walk bound (~10 years) — a runaway RRULE must terminate. */
+const MAX_RECURRENCE_WALK_DAYS = 3700;
+
+export function parseCalendarSettings(settings: Record<string, unknown>): CalendarSettings | null {
+  const c = settings?.calendar as Record<string, unknown> | undefined;
+  if (!c || typeof c !== 'object') return null;
+  const raw = c.ics;
+  const urls = (Array.isArray(raw) ? raw : [raw])
+    .filter((u): u is string => typeof u === 'string' && /^https?:\/\//.test(u));
+  return urls.length > 0 ? { urls } : null;
+}
+
+// ── ICS parsing ──
+
+interface IcsEvent {
+  uid: string;
+  summary: string;
+  /** "YYYYMMDD" of DTSTART (local, see header note). */
+  startDate: string;
+  /** "HH:MM" or undefined for all-day / date-only starts. */
+  startHm?: string;
+  endDate?: string;
+  endHm?: string;
+  rrule?: Map<string, string>;
+  exdates: Set<string>;
+  /** "YYYYMMDD" this VEVENT overrides in its UID's recurrence set. */
+  recurrenceId?: string;
+}
+
+/** RFC 5545 line unfolding: CRLF followed by space/tab continues the line. */
+export function unfoldIcsLines(text: string): string[] {
+  const raw = text.split(/\r?\n/);
+  const out: string[] = [];
+  for (const line of raw) {
+    if ((line.startsWith(' ') || line.startsWith('\t')) && out.length > 0) {
+      out[out.length - 1] += line.slice(1);
+    } else if (line.length > 0) {
+      out.push(line);
+    }
+  }
+  return out;
+}
+
+function unescapeIcsText(s: string): string {
+  return s.replace(/\\n/gi, ' ').replace(/\\([,;\\])/g, '$1');
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+const dateKey = (d: Date): string => `${d.getFullYear()}${pad2(d.getMonth() + 1)}${pad2(d.getDate())}`;
+const hmKey = (d: Date): string => `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+
+/** One DTSTART/DTEND/EXDATE value → local date + optional HH:MM.
+ *  `…Z` converts through the daemon clock; floating/TZID read literally. */
+export function parseIcsInstant(value: string): { date: string; hm?: string } | null {
+  const m = value.match(/^(\d{8})(?:T(\d{2})(\d{2})(\d{2})?(Z)?)?$/);
+  if (!m) return null;
+  const [, ymd, hh, mm, , zulu] = m;
+  if (!hh) return { date: ymd };
+  if (zulu) {
+    const d = new Date(Date.UTC(
+      Number(ymd.slice(0, 4)), Number(ymd.slice(4, 6)) - 1, Number(ymd.slice(6, 8)),
+      Number(hh), Number(mm),
+    ));
+    return { date: dateKey(d), hm: hmKey(d) };
+  }
+  return { date: ymd, hm: `${hh}:${mm}` };
+}
+
+export function parseIcsEvents(text: string): IcsEvent[] {
+  const events: IcsEvent[] = [];
+  let cur: Partial<IcsEvent> & { exdates: Set<string> } | null = null;
+  for (const line of unfoldIcsLines(text)) {
+    if (line === 'BEGIN:VEVENT') {
+      cur = { exdates: new Set() };
+      continue;
+    }
+    if (line === 'END:VEVENT') {
+      if (cur && cur.summary && cur.startDate) {
+        events.push({ ...cur, uid: cur.uid ?? '', summary: cur.summary, startDate: cur.startDate,
+          exdates: cur.exdates });
+      }
+      cur = null;
+      continue;
+    }
+    if (!cur) continue;
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const lhs = line.slice(0, colon);
+    const value = line.slice(colon + 1);
+    const name = lhs.split(';')[0].toUpperCase();
+    if (name === 'SUMMARY') cur.summary = unescapeIcsText(value.trim());
+    else if (name === 'UID') cur.uid = value.trim();
+    else if (name === 'DTSTART') {
+      const t = parseIcsInstant(value.trim());
+      if (t) { cur.startDate = t.date; if (t.hm !== undefined) cur.startHm = t.hm; }
+    } else if (name === 'DTEND') {
+      const t = parseIcsInstant(value.trim());
+      if (t) { cur.endDate = t.date; if (t.hm !== undefined) cur.endHm = t.hm; }
+    } else if (name === 'RRULE') {
+      cur.rrule = new Map(value.split(';').map((kv) => {
+        const eq = kv.indexOf('=');
+        return [kv.slice(0, eq).toUpperCase(), kv.slice(eq + 1)] as [string, string];
+      }));
+    } else if (name === 'EXDATE') {
+      for (const v of value.split(',')) {
+        const t = parseIcsInstant(v.trim());
+        if (t) cur.exdates.add(t.date);
+      }
+    } else if (name === 'RECURRENCE-ID') {
+      const t = parseIcsInstant(value.trim());
+      if (t) cur.recurrenceId = t.date;
+    }
+  }
+  return events;
+}
+
+// ── Recurrence: does this event occur on `day`? ──
+
+const WEEKDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+const dayFromKey = (key: string): Date =>
+  new Date(Number(key.slice(0, 4)), Number(key.slice(4, 6)) - 1, Number(key.slice(6, 8)));
+const daysBetween = (a: Date, b: Date): number =>
+  Math.round((b.getTime() - a.getTime()) / 86_400_000);
+
+/** Occurrence check by bounded day-walk from DTSTART — one predicate per
+ *  FREQ, counting matches so COUNT/UNTIL terminate exactly. */
+export function occursOn(ev: IcsEvent, dayKey: string): boolean {
+  if (!ev.rrule) return ev.startDate === dayKey;
+  if (ev.exdates.has(dayKey)) return false;
+  const freq = ev.rrule.get('FREQ') ?? '';
+  const interval = Math.max(1, Number(ev.rrule.get('INTERVAL') ?? '1') || 1);
+  const count = Number(ev.rrule.get('COUNT') ?? '0') || 0;
+  const untilRaw = ev.rrule.get('UNTIL');
+  const until = untilRaw ? parseIcsInstant(untilRaw)?.date : undefined;
+  if (until && dayKey > until) return false;
+  if (dayKey < ev.startDate) return false;
+
+  const start = dayFromKey(ev.startDate);
+  const target = dayFromKey(dayKey);
+  const span = daysBetween(start, target);
+  if (span < 0 || span > MAX_RECURRENCE_WALK_DAYS) return false;
+
+  const byday = (ev.rrule.get('BYDAY') ?? '').split(',').filter(Boolean)
+    .map((d) => d.replace(/^[+-]?\d+/, ''));  // ordinal BYDAY (1MO) → plain weekday
+  const bymonthday = Number(ev.rrule.get('BYMONTHDAY') ?? '0') || start.getDate();
+
+  const matches = (d: Date, daysFromStart: number): boolean => {
+    switch (freq) {
+      case 'DAILY':
+        return daysFromStart % interval === 0;
+      case 'WEEKLY': {
+        const wd = WEEKDAY_CODES[d.getDay()];
+        const inSet = byday.length > 0 ? byday.includes(wd) : d.getDay() === start.getDay();
+        // Interval counts weeks from DTSTART's week (weeks begin on Monday).
+        const mondayOffset = (dd: Date): number => (dd.getDay() + 6) % 7;
+        const weeks = Math.floor((daysFromStart + mondayOffset(start)) / 7);
+        return inSet && weeks % interval === 0;
+      }
+      case 'MONTHLY': {
+        const months = (d.getFullYear() - start.getFullYear()) * 12 + (d.getMonth() - start.getMonth());
+        return d.getDate() === bymonthday && months % interval === 0;
+      }
+      case 'YEARLY':
+        return d.getMonth() === start.getMonth() && d.getDate() === start.getDate()
+          && (d.getFullYear() - start.getFullYear()) % interval === 0;
+      default:
+        return false;
+    }
+  };
+
+  if (!matches(target, span)) return false;
+  if (count > 0) {
+    // The target only counts if it is within the first COUNT occurrences.
+    let seen = 0;
+    for (let i = 0; i <= span; i++) {
+      const d = new Date(start.getFullYear(), start.getMonth(), start.getDate() + i);
+      if (matches(d, i)) {
+        seen++;
+        if (seen > count) return false;
+      }
+    }
+  }
+  return true;
+}
+
+// ── Today's glance events ──
+
+/** Expand all feeds' events into today's remaining schedule: all-day first,
+ *  then by start time; events already over are dropped; recurrence overrides
+ *  (RECURRENCE-ID) replace their master instance. */
+export function buildTodayEvents(events: IcsEvent[], now: Date): GlanceEvent[] {
+  const today = dateKey(now);
+  const nowHm = hmKey(now);
+  const overridden = new Set(
+    events.filter((e) => e.recurrenceId).map((e) => `${e.uid}@${e.recurrenceId}`),
+  );
+
+  const picked: { allDay: boolean; startHm: string; ev: GlanceEvent }[] = [];
+  for (const e of events) {
+    let onToday: boolean;
+    if (e.recurrenceId) {
+      onToday = e.startDate === today;  // override instance: literal date only
+    } else {
+      onToday = occursOn(e, today) && !(e.uid && overridden.has(`${e.uid}@${today}`));
+      // Multi-day timed event started earlier and still running → show as all-day.
+      if (!onToday && !e.rrule && e.startDate < today && (e.endDate ?? e.startDate) >= today) {
+        picked.push({ allDay: true, startHm: '', ev: { title: trimTitle(e.summary) } });
+        continue;
+      }
+    }
+    if (!onToday) continue;
+    const allDay = e.startHm === undefined;
+    if (!allDay) {
+      const endHm = e.endHm && e.startDate === (e.endDate ?? e.startDate) ? e.endHm : undefined;
+      // Drop events that already ended (what's LEFT of today).
+      if ((endHm ?? e.startHm!) < nowHm) continue;
+      const ev: GlanceEvent = { startHm: e.startHm!, title: trimTitle(e.summary) };
+      if (endHm) ev.endHm = endHm;
+      picked.push({ allDay: false, startHm: e.startHm!, ev });
+    } else {
+      // DTEND of an all-day event is exclusive; a single-day event ends tomorrow.
+      picked.push({ allDay: true, startHm: '', ev: { title: trimTitle(e.summary) } });
+    }
+  }
+
+  picked.sort((a, b) =>
+    a.allDay !== b.allDay ? (a.allDay ? -1 : 1) : a.startHm.localeCompare(b.startHm));
+  // Dedup (same title + time can arrive from two feeds).
+  const seen = new Set<string>();
+  const out: GlanceEvent[] = [];
+  for (const p of picked) {
+    const key = `${p.ev.startHm ?? ''}|${p.ev.title}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p.ev);
+    if (out.length >= GLANCE_MAX_EVENTS) break;
+  }
+  return out;
+}
+
+const trimTitle = (s: string): string => trimUtf8Bytes(s, GLANCE_EVENT_TITLE_MAX_BYTES);
+
+// ── Provider (fetch + cache), mirroring WeatherProvider ──
+
+interface CacheEntry {
+  key: string;
+  at: number;
+  events: IcsEvent[];
+}
+
+export class CalendarProvider {
+  private cache: CacheEntry | null = null;
+  private inflight: Promise<IcsEvent[] | undefined> | null = null;
+
+  constructor(
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly log: (msg: string) => void = () => {},
+  ) {}
+
+  /** Today's remaining glance events for `cfg`, from cache when fresh.
+   *  Resolves `undefined` when unconfigured or when no parse (fresh or
+   *  stale-servable) exists — the glance simply omits the schedule. Today's
+   *  filter always runs against the CURRENT clock, so a cached parse still
+   *  drops events as they pass. Never throws. */
+  async get(cfg: CalendarSettings | null, now: number = Date.now()): Promise<GlanceEvent[] | undefined> {
+    if (!cfg) return undefined;
+    const key = cfg.urls.join('\n');
+    const cached = this.cache;
+    if (cached && cached.key === key && now - cached.at < CALENDAR_CACHE_MS) {
+      return buildTodayEvents(cached.events, new Date(now));
+    }
+    if (this.inflight) {
+      const ev = await this.inflight;
+      return ev ? buildTodayEvents(ev, new Date(now)) : undefined;
+    }
+    this.inflight = this.fetchFresh(cfg, key, now).finally(() => { this.inflight = null; });
+    const ev = await this.inflight;
+    return ev ? buildTodayEvents(ev, new Date(now)) : undefined;
+  }
+
+  private async fetchFresh(cfg: CalendarSettings, key: string, now: number): Promise<IcsEvent[] | undefined> {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), CALENDAR_FETCH_TIMEOUT_MS);
+    try {
+      const all: IcsEvent[] = [];
+      for (const url of cfg.urls) {
+        const res = await this.fetchImpl(url, { signal: ctl.signal });
+        if (!res.ok) throw new Error(`ics HTTP ${res.status}`);
+        all.push(...parseIcsEvents(await res.text()));
+      }
+      this.cache = { key, at: now, events: all };
+      return all;
+    } catch (err) {
+      this.log(`[calendar] fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+      const cached = this.cache;
+      if (cached && cached.key === key && now - cached.at < CALENDAR_STALE_SERVE_MS) return cached.events;
+      return undefined;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/bridge/src/card-feed.ts
+++ b/bridge/src/card-feed.ts
@@ -14,6 +14,7 @@ import type {
   FeedCard,
   CardFeedResponse,
   CardFeedGlance,
+  GlanceEvent,
   GlanceUsageRow,
   GlanceWeather,
   OutboxDecision,
@@ -151,6 +152,7 @@ export function buildGlance(input: {
   sessions: SessionInfo[];
   usage?: UsageEvent;
   weather?: GlanceWeather;
+  events?: GlanceEvent[];
 }): CardFeedGlance | undefined {
   const glance: CardFeedGlance = {};
   if (input.weather) glance.weather = input.weather;
@@ -158,6 +160,7 @@ export function buildGlance(input: {
   if (usage.length > 0) glance.usage = usage;
   const wrapup = buildGlanceWrapup(input.sessions);
   if (wrapup.length > 0) glance.wrapup = wrapup;
+  if (input.events && input.events.length > 0) glance.events = input.events;
   return Object.keys(glance).length > 0 ? glance : undefined;
 }
 

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -140,6 +140,7 @@ import {
   normalizeClientIp, parsePullTelemetry,
 } from './card-feed.js';
 import { WeatherProvider, parseWeatherSettings } from './weather.js';
+import { CalendarProvider, parseCalendarSettings } from './calendar.js';
 import { renderGlanceFrame, GLANCE_FRAME_BOARDS } from './glance-frame.js';
 import type { UsageEvent } from './types.js';
 import { mergeRelayedSessionUsage } from './usage-event.js';
@@ -246,6 +247,10 @@ const feedPulls = new FeedPullTracker();
  *  settings.json per pull (cheap; honors edits without a restart); the
  *  provider caches the upstream fetch itself. */
 const glanceWeather = new WeatherProvider();
+
+/** Glance schedule (today's ICS events) — same config/caching contract as
+ *  weather: settings.json `calendar: {ics}`, 30 min cache, never throws. */
+const glanceCalendar = new CalendarProvider();
 
 /** Name a pulling client from the WiFi WS roster. A board that has been
  *  deep-sleeping may have aged out of that roster, which is why the tracker
@@ -1406,6 +1411,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           sessions: sessions as unknown as SessionInfo[],
           usage: core.buildUsage() as UsageEvent,
           weather: await glanceWeather.get(parseWeatherSettings(loadDaemonSettings())),
+          events: await glanceCalendar.get(parseCalendarSettings(loadDaemonSettings())),
         });
         const d = new Date();
         const serverHm = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
@@ -1457,6 +1463,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             sessions: sessions as unknown as SessionInfo[],
             usage: core.buildUsage() as UsageEvent,
             weather: await glanceWeather.get(parseWeatherSettings(loadDaemonSettings())),
+            events: await glanceCalendar.get(parseCalendarSettings(loadDaemonSettings())),
           });
           const feed = buildCardFeed(sessions as unknown as SessionInfo[], Date.now(), undefined, {
             glance,

--- a/bridge/src/glance-frame.ts
+++ b/bridge/src/glance-frame.ts
@@ -263,6 +263,19 @@ export function renderGlanceFrameSvg(input: GlanceFrameInput): string {
     yL += weatherBlock(c, colX, yL, colW, g.weather) + 18;
   }
 
+  // ── Today's schedule (left column, under weather) ──
+  const events = g.events ?? [];
+  if (events.length > 0) {
+    sectionLabel(c, colX, yL, 'TODAY');
+    yL += 34;
+    for (const e of events) {
+      const time = e.startHm ? (e.endHm ? `${e.startHm}–${e.endHm}` : e.startHm) : 'All day';
+      text(c, colX, yL, 20, fitText(`${time}  ·  ${e.title}`, colW, 20));
+      yL += 32;
+    }
+    yL += 10;
+  }
+
   // ── Quota ──
   let qx = colX, qy = yL, qw = colW;
   if (landscape) { qx = rightX; qy = yR; qw = W - M - rightX; }

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -939,6 +939,16 @@ export interface GlanceUsageRow {
   stale: boolean;
 }
 
+/** One of today's remaining calendar events (M9 stage 2). Times are the
+ *  daemon's local "HH:MM" — absolute only, same honesty rule as the rest of
+ *  the glance. `startHm` absent = all-day event. */
+export interface GlanceEvent {
+  startHm?: string;
+  endHm?: string;
+  /** Pre-trimmed to `GLANCE_EVENT_TITLE_MAX_BYTES` UTF-8 bytes. */
+  title: string;
+}
+
 export interface CardFeedGlance {
   weather?: GlanceWeather;
   /** Provider quota rows, at most `GLANCE_MAX_USAGE_ROWS`. */
@@ -947,12 +957,19 @@ export interface CardFeedGlance {
    *  first, at most `GLANCE_MAX_WRAPUP_LINES`, each ≤ `GLANCE_LINE_MAX_BYTES`
    *  UTF-8 bytes. Pre-rendered by the daemon; devices draw them verbatim. */
   wrapup?: string[];
+  /** Today's remaining schedule, all-day first then by start time, at most
+   *  `GLANCE_MAX_EVENTS`. Config: settings.json `calendar: {ics}`
+   *  (bridge/src/calendar.ts); no config → absent. */
+  events?: GlanceEvent[];
 }
 
 export const GLANCE_MAX_WRAPUP_LINES = 4;
 export const GLANCE_MAX_USAGE_ROWS = 3;
+export const GLANCE_MAX_EVENTS = 3;
 /** Per-line UTF-8 byte budget (fits a 528px 1-bit panel row in KR16). */
 export const GLANCE_LINE_MAX_BYTES = 64;
+/** Event-title UTF-8 byte budget (leaves room for "HH:MM–HH:MM " on a row). */
+export const GLANCE_EVENT_TITLE_MAX_BYTES = 48;
 /** Hourly rain probability at or above this counts as a rain window. */
 export const GLANCE_RAIN_PROBABILITY_MIN = 40;
 


### PR DESCRIPTION
## What changed

- add a bounded calendar provider for upcoming events
- project calendar items into Card Feed and glance output
- carry calendar event metadata through the shared protocol
- cover filtering, ordering, truncation, timezone, and invalid-input behavior

## Stack

This is 2/4. It is based on #111 so this PR shows only the Calendar/Card Feed delta. ESP32 pull-OTA staging and Adaptive Pocket follow above it.

## Validation

Validated on the complete rebased stack:

- focused Calendar/Card Feed/glance suite included in 110 targeted passing tests
- `pnpm build`
- `pnpm test` — 147 files, 2,435 tests passed
- `pnpm typecheck`
- docs/design/preview checks passed
- protocol regeneration produced no diff
- `git diff --check`