### PR TITLE
feat(esp32): stage firmware for pull OTA

### DIFF
--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -1226,6 +1226,7 @@ program
   .option('-e, --env <env>', 'PlatformIO environment for default firmware path')
   .option('-f, --firmware <path>', 'Firmware .bin path')
   .option('--build', 'Build the PlatformIO environment before upload')
+  .option('--stage', 'Stage for pull OTA: the board installs it on its next feed pull (no live WS needed)')
   .action(async (target, opts) => {
     const { readDaemonInfo, findDaemonPort } = await import('./session-registry.js');
     const info = readDaemonInfo();
@@ -1248,6 +1249,22 @@ program
     // `target` against device_info.board, so `ttgo` must become `ttgo_t_display`.
     const daemonTarget = resolveEsp32OtaDaemonTarget(target);
     const firmwarePath = resolveEsp32FirmwarePath(target, opts.env, opts.firmware);
+    if (opts.stage) {
+      // Pull-OTA staging: for wake-sync-sleep boards (XTeink X3/X4) that never
+      // hold a live WS. The daemon adverts the build on the board's feed pulls;
+      // the board downloads + flashes itself on its next wake.
+      const { statusCode, body } = await postJsonWithTimeout<Record<string, any>>(
+        `http://127.0.0.1:${port}/esp32/ota`,
+        { target: daemonTarget, firmwarePath, stage: true },
+        30_000,
+      );
+      if (statusCode < 200 || statusCode >= 300 || body.ok === false) {
+        throw new Error(String(body.error ?? `HTTP ${statusCode}`));
+      }
+      log(`Staged for ${body.board}: ${formatBytes(body.bytes)} md5=${body.md5}`);
+      log('The board installs it on its next feed pull (battery cadence: typically within 15-60 min).');
+      return;
+    }
     log(`Uploading ${firmwarePath} to ${daemonTarget} via daemon :${port}...`);
     let { statusCode, body } = await postJsonWithTimeout<Record<string, any>>(
       `http://127.0.0.1:${port}/esp32/ota`,

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -144,8 +144,8 @@ import { CalendarProvider, parseCalendarSettings } from './calendar.js';
 import { renderGlanceFrame, GLANCE_FRAME_BOARDS } from './glance-frame.js';
 import type { UsageEvent } from './types.js';
 import { mergeRelayedSessionUsage } from './usage-event.js';
-import { CARD_FEED_PATH, CARD_OUTBOX_PATH, GLANCE_FRAME_PATH, type SessionInfo, type OutboxPushRequest } from '@agentdeck/shared';
-import { readFileSync, statSync, appendFileSync } from 'fs';
+import { CARD_FEED_PATH, CARD_OUTBOX_PATH, GLANCE_FRAME_PATH, type CardFeedResponse, type SessionInfo, type OutboxPushRequest } from '@agentdeck/shared';
+import { readFileSync, statSync, writeFileSync, appendFileSync } from 'fs';
 import { readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -252,6 +252,71 @@ const glanceWeather = new WeatherProvider();
  *  weather: settings.json `calendar: {ics}`, 30 min cache, never throws. */
 const glanceCalendar = new CalendarProvider();
 
+// ===== Pull OTA (feed-carried) — staged firmware per board =====
+//
+// WS OTA can only reach a board holding a live socket, which a wake-sync-sleep
+// battery client (XTeink X3/X4) never does. Staging flips the direction: the
+// daemon remembers one firmware per board (`esp32-ota <board> --firmware …
+// --stage`), every `GET /feed` response adverts it as `fw: {size, md5}`, and
+// the device downloads `GET /esp32/fw` + flashes itself on its next pull.
+// Persisted across daemon restarts; a device that already took an md5 skips it
+// (its applied-marker), so a stale staging is harmless.
+interface StagedFw { firmwarePath: string; md5: string; size: number; stagedAt: number; }
+const stagedFwByBoard = new Map<string, StagedFw>();
+const stagedFwStatePath = (): string => join(homedir(), '.agentdeck', 'staged-fw.json');
+
+function loadStagedFw(): void {
+  try {
+    const raw = JSON.parse(readFileSync(stagedFwStatePath(), 'utf8')) as Record<string, StagedFw>;
+    for (const [board, s] of Object.entries(raw)) {
+      if (s && typeof s.firmwarePath === 'string' && typeof s.md5 === 'string' && typeof s.size === 'number') {
+        stagedFwByBoard.set(board, s);
+      }
+    }
+  } catch { /* no staging file — nothing staged */ }
+}
+loadStagedFw();
+
+function saveStagedFw(): void {
+  try {
+    writeFileSync(stagedFwStatePath(), JSON.stringify(Object.fromEntries(stagedFwByBoard), null, 2));
+  } catch (err) {
+    log(`[agentdeck] staged-fw persist failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Stage a build for a board. Reads the file once to fingerprint it; the file
+ *  itself is re-read at device download time (a rebuild at the same path is
+ *  re-fingerprinted by re-staging). */
+function stageEsp32Fw(board: string, firmwarePath: string): { board: string; bytes: number; md5: string } {
+  const firmware = readFileSync(firmwarePath);
+  const md5 = createHash('md5').update(firmware).digest('hex');
+  stagedFwByBoard.set(board, { firmwarePath, md5, size: firmware.length, stagedAt: Date.now() });
+  saveStagedFw();
+  log(`[agentdeck] staged firmware for ${board}: ${firmware.length} bytes md5=${md5} — installs on its next feed pull`);
+  return { board, bytes: firmware.length, md5 };
+}
+
+/** The staged advert for a feed response, re-validated against the file on
+ *  disk so a rebuilt-in-place binary never adverts a stale md5. */
+function stagedFwAdvert(board: string | undefined): { size: number; md5: string } | undefined {
+  if (!board) return undefined;
+  const staged = stagedFwByBoard.get(board);
+  if (!staged) return undefined;
+  try {
+    const firmware = readFileSync(staged.firmwarePath);
+    const md5 = createHash('md5').update(firmware).digest('hex');
+    if (md5 !== staged.md5 || firmware.length !== staged.size) {
+      stagedFwByBoard.set(board, { ...staged, md5, size: firmware.length });
+      saveStagedFw();
+      return { size: firmware.length, md5 };
+    }
+    return { size: staged.size, md5: staged.md5 };
+  } catch {
+    return undefined;  // file gone — advert nothing rather than a dead download
+  }
+}
+
 /** Name a pulling client from the WiFi WS roster. A board that has been
  *  deep-sleeping may have aged out of that roster, which is why the tracker
  *  keeps its own IP→board memory once it has learned one. */
@@ -351,6 +416,12 @@ function registerWifiEsp32(d: Record<string, unknown>, ws: WebSocket): void {
   wifiEsp32Sockets.set(key, ws);
   if (previous?.uptimeSec != null && uptimeSec != null && uptimeSec + 10 < previous.uptimeSec) {
     log(`[agentdeck] ESP32 reboot observed: ${key} uptime ${previous.uptimeSec}s -> ${uptimeSec}s reset=${resetReason ?? 'unknown'} code=${resetReasonCode ?? 'unknown'}`);
+  }
+  // Plain-log a board APPEARING on WS (absent or stale before) — a sleeping
+  // battery board's brief interactive window is exactly when a WS OTA can
+  // land, and this line is the only wake signal an operator/script can tail.
+  if (!previous || Date.now() - previous.lastSeenMs > 90_000) {
+    log(`[agentdeck] ESP32 WiFi registered: ${key}`);
   }
   debug('daemon', `WiFi ESP32 registered: ${key} v${String(d.version ?? '')} build=${String(d.buildHash ?? '')} uptime=${String(uptimeSec ?? '')} reset=${String(resetReason ?? '')}`);
 }
@@ -1370,6 +1441,11 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         if (!target || !firmwarePath) {
           throw new Error('target and firmwarePath are required');
         }
+        // Pull-OTA staging: remember the build; the board installs it on its
+        // next feed pull (no live WS needed). See stagedFwByBoard.
+        if (body.stage === true) {
+          return { ok: true, staged: true, ...stageEsp32Fw(target, firmwarePath) };
+        }
         return performWifiEsp32Ota(core, target, firmwarePath);
       })().then((result) => {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -1378,6 +1454,55 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
       });
+      return;
+    }
+    // ===== Pull OTA (feed-carried) — staged firmware download =====
+    // The board saw `fw: {size, md5}` on its feed pull and fetches the image
+    // here. Auth mirrors the feed routes (LAN needs the pairing token).
+    if (req.method === 'GET' && pathname === '/esp32/fw') {
+      const ip = req.socket.remoteAddress ?? '';
+      if (!isLocalConnection(ip)) {
+        const token = parsedUrl.searchParams.get('token') ?? '';
+        if (!validateToken(token)) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Unauthorized — token required for firmware download' }));
+          return;
+        }
+      }
+      const board = parsedUrl.searchParams.get('board') ?? '';
+      const staged = stagedFwByBoard.get(board);
+      if (!staged) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: `nothing staged for board "${board}"` }));
+        return;
+      }
+      try {
+        const firmware = readFileSync(staged.firmwarePath);
+        // Resumable download: `?from=<offset>` serves the remainder. A 5 MB
+        // image over a marginal link never survives one connection (this
+        // bridge host's two-NICs-on-one-subnet setup black-holes full-MTU
+        // segments in one direction, and a restart-from-zero download can
+        // never converge there). The device appends whatever arrives and
+        // re-asks from where it stopped, so partial transfers accumulate.
+        const fromRaw = Number(parsedUrl.searchParams.get('from') ?? 0);
+        const from = Number.isFinite(fromRaw) && fromRaw > 0 ? Math.min(Math.floor(fromRaw), firmware.length) : 0;
+        const body = from > 0 ? firmware.subarray(from) : firmware;
+        log(`[agentdeck] pull-OTA download: ${board} (${ip}) ← ${body.length} bytes`
+          + (from > 0 ? ` (resume from ${from}/${firmware.length})` : ''));
+        res.writeHead(from > 0 ? 206 : 200, {
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': String(body.length),
+          ...(from > 0
+            ? { 'Content-Range': `bytes ${from}-${Math.max(from, firmware.length - 1)}/${firmware.length}` }
+            : {}),
+          'X-FW-MD5': staged.md5,
+          'Cache-Control': 'no-store',
+        });
+        res.end(body);
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+      }
       return;
     }
     // ===== Card Feed pull sync (M6) — wake-sync-sleep battery clients =====
@@ -1468,7 +1593,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           const feed = buildCardFeed(sessions as unknown as SessionInfo[], Date.now(), undefined, {
             glance,
             echoSig: parsedUrl.searchParams.get('sig') ?? undefined,
-          });
+          }) as CardFeedResponse & { fw?: { size: number; md5: string } };
+          // Pull-OTA advert: rides full AND `unchanged` responses, so a
+          // sleeping board learns about a staged build on any pull. Board
+          // identity from the query (newer firmware) or the IP memory.
+          const pullBoard = parsedUrl.searchParams.get('board') ?? boardForClientIp(ip);
+          const fwAdvert = stagedFwAdvert(pullBoard ?? undefined);
+          if (fwAdvert) feed.fw = fwAdvert;
           // A sleeping client's whole visit is this one request: no body, no
           // board id, nothing pushed. Record it, because the gap between two
           // pulls is the only evidence that the timer wake fired at all.

--- a/docs/esp32-client-contract.md
+++ b/docs/esp32-client-contract.md
@@ -193,11 +193,40 @@ and pull while on battery.
   `shared/src/protocol.ts` § Glance; producers: `buildGlance` in
   `bridge/src/card-feed.ts` + `bridge/src/weather.ts` (Open-Meteo, 30 min
   cache, bounded fetch, stale-serve up to 3 h).
+- **Glance events (today's schedule, M9 stage 2, 2026-08-04)**: `glance` may
+  additionally carry `events` — today's *remaining* schedule, ≤3 entries,
+  all-day first then by start time: `{startHm?, endHm?, title}` where a
+  missing `startHm` means all-day and `title` arrives pre-trimmed to ≤48
+  UTF-8 bytes. Same absolute-`HH:MM` honesty rule as the rest of the glance.
+  Produced only when the host's settings.json configures
+  `calendar: {ics: <url | url[]>}` (secret-address ICS feeds — Google
+  Calendar / iCloud both export one); absent otherwise, and older daemons
+  simply never send it — devices must treat the field as optional. Producer:
+  `bridge/src/calendar.ts` (dependency-free ICS subset parser: all-day /
+  UTC / local times, RRULE DAILY/WEEKLY/MONTHLY/YEARLY with
+  INTERVAL/UNTIL/COUNT, EXDATE, RECURRENCE-ID overrides; 30 min cache,
+  bounded fetch, stale-serve up to 6 h).
 - **Pull telemetry (2026-07-31)**: a `GET /feed` may append `batt` (percent
   0–100), `mv` (battery millivolts), and `rssi` (WiFi dBm, negative) to the
   query string — the only battery/link observability a wake-sync-sleep device
   has. Out-of-range values are dropped server-side. Reported per-client in the
-  pull log line and `agentdeck devices` › `Card feed`.
+  pull log line and `agentdeck devices` › `Card feed`. Newer firmware also
+  appends `board=<id>` so the daemon can target board-specific adverts (Pull
+  OTA below) without relying on its IP→board memory.
+- **Pull OTA (feed-carried firmware, 2026-08-04)**: WS OTA needs a live
+  socket, which a battery client on the pull cadence never holds. Instead the
+  host stages a build — `agentdeck esp32-ota <board> --firmware <bin>
+  --stage` — and every `GET /feed` response (full AND `unchanged`) carries
+  `fw: {size, md5}` for that board. On its next pull the device: checks the
+  md5 against its applied-marker (`/.crosspoint/agentdeck-fw-applied.txt` —
+  written *before* flashing so a bad image can't re-download every pull),
+  guards battery ≥30% and the OTA slot size, downloads `GET
+  /esp32/fw?board=<id>&token=<t>` to the shared SD OTA cache, validates
+  (whole-file MD5 + bootloader-mirror structural check), and flashes +
+  restarts on that same wake. Staging persists across daemon restarts
+  (`~/.agentdeck/staged-fw.json`); re-staging a rebuilt binary refreshes the
+  md5. Device: `src/agentdeck/ota_pull.*` (crosspoint-agentdeck fork); daemon:
+  `stagedFwByBoard` in `bridge/src/daemon-server.ts`.
 - **Glance Frame (M8, 2026-07-31)**: `GET /glance-frame?board=<id>` returns
   the daemon-**rendered** glance as packed 1bpp framebuffer rows (MSB-first,
   bit 1 = white) with `X-Frame-Width`/`X-Frame-Height`/`X-Frame-Sig` headers —


### PR DESCRIPTION
## What changed

- stage firmware artifacts in the daemon for device-initiated pull OTA
- add CLI support for publishing staged firmware
- expose bounded metadata and download routes for ESP32 clients
- document the pull-OTA contract and failure behavior

## Stack

This is 3/4. It is based on #112 so this PR shows only the pull-OTA delta. Adaptive Pocket is #110 above this branch.

## Validation

Validated on the complete rebased stack:

- `pnpm build`
- `pnpm test` — 147 files, 2,435 tests passed
- `pnpm typecheck`
- `pnpm docs:check`
- design/preview checks and protocol regeneration clean
- `git diff --check`

Hardware delivery remains intentionally outside this code-only PR; no device was flashed during branch cleanup.