### PR TITLE
fix(voice,deck): repair host push-to-talk end to end and stop the Gateway model from claiming other rows

### DIFF
--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -5438,7 +5438,7 @@ final class DaemonServer {
                     Task { @DaemonActor in self.finishHostPtt(text: nil, sessionId: sid) }
                     return
                 }
-                let text = await ptt.end(preferredLocales: [Locale.current, Locale(identifier: "en_US")])
+                let text = await ptt.end(preferredLocales: VoiceSpeechTranscriber.dictationLocales())
                 Task { @DaemonActor in
                     self.finishHostPtt(text: text, sessionId: sid)
                 }
@@ -5495,7 +5495,9 @@ final class DaemonServer {
         guard !sid.isEmpty, sid == armed else { return }
         pttArmedSessionId = nil
         let raw = (entry["detail"] as? String) ?? (entry["raw"] as? String) ?? ""
-        let spoken = Self.speakableReply(raw)
+        // Read the lead, not the transcript — see spokenDigest in
+        // shared/src/voice-reply-digest.ts for why speech and screen differ.
+        let spoken = Self.spokenDigest(raw)
         guard !spoken.isEmpty else {
             DaemonLogger.shared.debug("Voice", "PTT reply held nothing speakable — skipped")
             return
@@ -5513,7 +5515,7 @@ final class DaemonServer {
             options: .regularExpression)
     }
 
-    /// Mirror of `speakableReply` in bridge/src/device-voice-reply.ts: strip
+    /// Mirror of `speakableReply` in shared/src/voice-reply-digest.ts: strip
     /// what makes no sense read aloud (code fences, markdown scaffolding,
     /// bare URLs) and cap at a sentence boundary.
     nonisolated static func speakableReply(_ raw: String, maxChars: Int = 700) -> String {
@@ -5544,6 +5546,122 @@ final class DaemonServer {
             }
         }
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Ceiling for the digest — reached only by a single very long sentence.
+    /// Mirror of `SPOKEN_DIGEST_MAX_CHARS`.
+    nonisolated static let spokenDigestMaxChars = 240
+
+    // `nonisolated` because the class is @DaemonActor: a static property would
+    // otherwise inherit that isolation and be unreachable from the nonisolated
+    // text helpers below (which must stay callable off the daemon executor).
+    private nonisolated static let spokenSummaryLabels = [
+        "요약", "한 줄 요약", "한줄 요약", "결론", "정리",
+        "TL;DR", "TLDR", "Summary", "In short", "In summary", "Bottom line",
+    ]
+    private nonisolated static let spokenTerminators: Set<Character> =
+        [".", "!", "?", "。", "！", "？", "…"]
+
+    /// Mirror of `spokenDigest` in shared/src/voice-reply-digest.ts — the one
+    /// thing worth reading aloud out of a full reply: an explicit summary line
+    /// when the answer has one, otherwise its first sentence. A written answer
+    /// and a spoken one are different artifacts; the listener cannot skim.
+    ///
+    /// Parity is asserted against that file's `SPOKEN_DIGEST_CASES` in
+    /// `SpokenDigestParityTests` — add a case in both places or they drift.
+    nonisolated static func spokenDigest(
+        _ raw: String,
+        maxChars: Int = spokenDigestMaxChars,
+        full: Bool = false
+    ) -> String {
+        let readable = speakableReply(raw, maxChars: full ? 700 : Int.max)
+        if readable.isEmpty { return "" }
+        if full { return readable }
+
+        let lines = readable.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        var unit = ""
+        for (index, line) in lines.enumerated() {
+            guard let summary = spokenSummaryOnLine(line) else { continue }
+            unit = summary.isEmpty ? (index + 1 < lines.count ? lines[index + 1] : "") : summary
+            if !unit.isEmpty { break }
+        }
+
+        if unit.isEmpty {
+            // Skip a leading section label ("원인", "Result") when prose follows
+            // it: reading a heading alone tells the listener nothing.
+            var start = 0
+            while start < lines.count - 1
+                    && !spokenHasTerminator(lines[start])
+                    && lines[start].count <= 24 {
+                start += 1
+            }
+            unit = spokenFirstSentence(start < lines.count ? lines[start] : "")
+        }
+
+        unit = unit.trimmingCharacters(in: .whitespacesAndNewlines)
+        if unit.isEmpty { return "" }
+        if unit.count <= maxChars { return unit }
+        // A single sentence over the cap: cut on a word boundary, not mid-word.
+        let head = String(unit.prefix(maxChars))
+        if let space = head.lastIndex(of: " "),
+           head.distance(from: head.startIndex, to: space) > Int(Double(maxChars) * 0.6) {
+            return String(head[..<space]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return head.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The summary a line declares, or nil. A bare label line yields "" so the
+    /// caller takes the line after it.
+    private nonisolated static func spokenSummaryOnLine(_ line: String) -> String? {
+        let lower = line.lowercased()
+        for label in spokenSummaryLabels {
+            guard lower.hasPrefix(label.lowercased()) else { continue }
+            let afterLabel = String(line.dropFirst(label.count))
+            let separatorStripped = afterLabel.replacingOccurrences(
+                of: "^\\s*[:：\\-—–.]\\s*", with: "", options: .regularExpression)
+                .trimmingCharacters(in: .whitespaces)
+            let plain = afterLabel.trimmingCharacters(in: .whitespaces)
+            // "Summarywise …" and "요약 대신 …" are prose, not labels; require a
+            // separator (or end of line) before taking the remainder.
+            if separatorStripped == plain, !separatorStripped.isEmpty,
+               let first = separatorStripped.first,
+               first.isLetter || first.isNumber || first == "_" {
+                continue
+            }
+            return separatorStripped
+        }
+        return nil
+    }
+
+    /// True when a line ends a sentence — the cheap test for "prose, not a heading".
+    private nonisolated static func spokenHasTerminator(_ line: String) -> Bool {
+        return line.contains { spokenTerminators.contains($0) }
+    }
+
+    /// The first sentence of `text`, or all of it when it has no terminator.
+    private nonisolated static func spokenFirstSentence(_ text: String) -> String {
+        let chars = Array(text)
+        for index in chars.indices {
+            guard spokenTerminators.contains(chars[index]) else { continue }
+            let next: Character? = index + 1 < chars.count ? chars[index + 1] : nil
+            let previous: Character? = index > 0 ? chars[index - 1] : nil
+            // "1.0" and "v1.2.3" are not sentence ends.
+            if chars[index] == ".", let previous, previous.isNumber,
+               let next, next.isNumber {
+                continue
+            }
+            guard let next else { return String(chars[0..<(index + 1)]) }
+            if next.isWhitespace || "\"'”’)]".contains(next) {
+                // Run out repeated terminators ("!?", "...") so they stay together.
+                var end = index + 1
+                while end < chars.count && spokenTerminators.contains(chars[end]) { end += 1 }
+                return String(chars[0..<end])
+            }
+        }
+        return text
     }
 
     private func handleObservedClaudeCommand(sessionId: String, command: [String: Any]) {

--- a/apple/AgentDeck/Daemon/Voice/DaemonPttVoice.swift
+++ b/apple/AgentDeck/Daemon/Voice/DaemonPttVoice.swift
@@ -18,10 +18,118 @@ import Foundation
 import AVFoundation
 import Speech
 
+/**
+ Receives tap buffers from AVFAudio's realtime thread and writes them to disk.
+
+ Declared at file scope and deliberately NOT actor-isolated. A closure written
+ inside an isolated method inherits that isolation *statically*, and when Swift
+ has to hand it to a non-isolated API it compiles an executor assertion into the
+ closure's entry. AVFAudio invokes an installTap block on its own realtime queue
+ (`RealtimeMessenger.mServiceQueue`), so that assertion fired the instant
+ recording started and took the whole app down with SIGTRAP in
+ `dispatch_assert_queue`. Hopping to the actor *inside* the block does not help —
+ the check runs before the first statement. Same family as the
+ `@convention(c)` rule in CLAUDE.md: a callback that a foreign thread invokes
+ must be built where no isolation can attach to it.
+ */
+private final class PttFileSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var file: AVAudioFile?
+    private var failure: String?
+
+    init(file: AVAudioFile) { self.file = file }
+
+    func append(_ buffer: AVAudioPCMBuffer) {
+        lock.lock(); defer { lock.unlock() }
+        guard let file else { return }
+        do {
+            try file.write(from: buffer)
+        } catch {
+            // Keep the first failure only: a broken file fails every buffer, and
+            // 4096-frame buffers would flood the log at ~12 Hz.
+            if failure == nil { failure = error.localizedDescription }
+        }
+    }
+
+    /// Stop accepting buffers and release the file so it finalizes on disk.
+    func close() -> String? {
+        lock.lock(); defer { lock.unlock() }
+        file = nil
+        return failure
+    }
+}
+
+/**
+ Loudest sample in a captured buffer, 0…1.
+
+ A silent capture and a failed recognizer are indistinguishable in the log
+ otherwise — both end as "No speech detected" — so the level is worth one line
+ before the file is deleted. Handles the two layouts an input node hands over:
+ float32 (the usual) and int16.
+ */
+private func pttPeakAmplitude(_ buffer: AVAudioPCMBuffer) -> Float {
+    let frames = Int(buffer.frameLength)
+    guard frames > 0 else { return 0 }
+    let channels = Int(buffer.format.channelCount)
+    var peak: Float = 0
+    if let float = buffer.floatChannelData {
+        for ch in 0..<channels {
+            let data = float[ch]
+            for i in 0..<frames { peak = max(peak, abs(data[i])) }
+        }
+    } else if let int16 = buffer.int16ChannelData {
+        for ch in 0..<channels {
+            let data = int16[ch]
+            for i in 0..<frames { peak = max(peak, abs(Float(data[i]) / 32768)) }
+        }
+    }
+    return peak
+}
+
+/// Average level of a captured buffer, 0…1. Peak alone cannot tell a single
+/// click apart from someone talking; RMS moving with the peak is what says the
+/// buffer really holds speech.
+private func pttRMSAmplitude(_ buffer: AVAudioPCMBuffer) -> Float {
+    let frames = Int(buffer.frameLength)
+    guard frames > 0 else { return 0 }
+    let channels = Int(buffer.format.channelCount)
+    var sum: Double = 0
+    var counted = 0
+    if let float = buffer.floatChannelData {
+        for ch in 0..<channels {
+            let data = float[ch]
+            for i in 0..<frames { sum += Double(data[i] * data[i]) }
+            counted += frames
+        }
+    } else if let int16 = buffer.int16ChannelData {
+        for ch in 0..<channels {
+            let data = int16[ch]
+            for i in 0..<frames {
+                let v = Double(data[i]) / 32768
+                sum += v * v
+            }
+            counted += frames
+        }
+    }
+    return counted > 0 ? Float((sum / Double(counted)).squareRoot()) : 0
+}
+
+/// Installs the capture tap from a non-isolated context — see `PttFileSink` for
+/// why this cannot be written inline inside `begin()`.
+private func installPttTap(
+    on input: AVAudioInputNode,
+    format: AVAudioFormat,
+    sink: PttFileSink
+) {
+    input.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+        sink.append(buffer)
+    }
+}
+
 @MainActor
 final class DaemonPttVoice {
     private var engine: AVAudioEngine?
-    private var file: AVAudioFile?
+    private var sink: PttFileSink?
     private var url: URL?
     private var maxTimer: Task<Void, Never>?
     private let synthesizer = AVSpeechSynthesizer()
@@ -64,24 +172,17 @@ final class DaemonPttVoice {
         // every write throw).
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("agentdeck-ptt-\(UUID().uuidString).caf")
+        let sink: PttFileSink
         do {
-            file = try AVAudioFile(forWriting: url, settings: format.settings)
+            sink = PttFileSink(file: try AVAudioFile(forWriting: url, settings: format.settings))
         } catch {
             DaemonLogger.shared.error("PTT: audio file create failed: \(error)")
             return "record_failed"
         }
         self.url = url
+        self.sink = sink
 
-        input.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
-            // The tap runs on a realtime audio queue; hop to the actor that
-            // owns `file` instead of writing from the callback thread.
-            Task { @MainActor in
-                guard let self, self.engine != nil else { return }
-                do { try self.file?.write(from: buffer) } catch {
-                    DaemonLogger.shared.debug("Voice", "PTT buffer write failed: \(error.localizedDescription)")
-                }
-            }
-        }
+        installPttTap(on: input, format: format, sink: sink)
 
         do {
             try engine.start()
@@ -115,6 +216,7 @@ final class DaemonPttVoice {
             DaemonLogger.shared.debug("Voice", "PTT capture too small (\(size)B)")
             return nil
         }
+        logCaptureLevel(url)
         guard SFSpeechRecognizer.authorizationStatus() == .authorized else {
             DaemonLogger.shared.debug("Voice", "PTT: speech recognition not authorized")
             return nil
@@ -139,6 +241,44 @@ final class DaemonPttVoice {
         synthesizer.speak(utterance)
     }
 
+    /// One line saying how much audio, at what level, actually reached the file.
+    /// Cheap, and it is the difference between "your mic is muted" and "the
+    /// recognizer could not make it out" — which the SFSpeech error alone hides.
+    private func logCaptureLevel(_ url: URL) {
+        guard let probe = try? AVAudioFile(forReading: url) else {
+            DaemonLogger.shared.debug("Voice", "PTT capture unreadable for level probe")
+            return
+        }
+        let rate = probe.processingFormat.sampleRate
+        let seconds = rate > 0 ? Double(probe.length) / rate : 0
+        let frames = AVAudioFrameCount(min(probe.length, Int64(rate * 30)))
+        guard frames > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: probe.processingFormat, frameCapacity: frames),
+              (try? probe.read(into: buffer)) != nil else {
+            DaemonLogger.shared.debug("Voice", "PTT capture \(String(format: "%.1f", seconds))s — level unavailable")
+            return
+        }
+        let peak = pttPeakAmplitude(buffer)
+        let fmt = probe.processingFormat
+        DaemonLogger.shared.debug(
+            "Voice",
+            "PTT capture \(String(format: "%.1f", seconds))s peak=\(String(format: "%.4f", peak))"
+                + " rms=\(String(format: "%.4f", pttRMSAmplitude(buffer)))"
+                + " fmt=\(Int(fmt.sampleRate))Hz/\(fmt.channelCount)ch/"
+                + (fmt.commonFormat == .pcmFormatFloat32 ? "f32" : "\(fmt.commonFormat.rawValue)")
+                + (peak < 0.01 ? " — effectively silent" : ""))
+
+        // Debug-only: keep the capture so its waveform can be inspected when the
+        // recognizer keeps reporting no speech. Off unless explicitly asked for —
+        // retaining dictation audio is not a default anyone opted into.
+        if ProcessInfo.processInfo.environment["AGENTDECK_KEEP_PTT_CAPTURE"] == "1" {
+            let kept = url.deletingLastPathComponent().appendingPathComponent("agentdeck-ptt-last.caf")
+            try? FileManager.default.removeItem(at: kept)
+            try? FileManager.default.copyItem(at: url, to: kept)
+            DaemonLogger.shared.debug("Voice", "PTT capture kept at \(kept.path)")
+        }
+    }
+
     private func stopEngine() {
         maxTimer?.cancel()
         maxTimer = nil
@@ -146,13 +286,19 @@ final class DaemonPttVoice {
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         self.engine = nil
-        self.file = nil
+        // Closing after the tap is removed guarantees no buffer is in flight,
+        // and surfaces a write failure that was invisible on the audio thread.
+        if let failure = sink?.close() {
+            DaemonLogger.shared.debug("Voice", "PTT buffer write failed: \(failure)")
+        }
+        sink = nil
     }
 
     private func cleanupFile() {
         if let url { try? FileManager.default.removeItem(at: url) }
         url = nil
-        file = nil
+        _ = sink?.close()
+        sink = nil
     }
 }
 #endif

--- a/apple/AgentDeck/Daemon/Voice/DaemonPttVoice.swift
+++ b/apple/AgentDeck/Daemon/Voice/DaemonPttVoice.swift
@@ -114,6 +114,31 @@ private func pttRMSAmplitude(_ buffer: AVAudioPCMBuffer) -> Float {
     return counted > 0 ? Float((sum / Double(counted)).squareRoot()) : 0
 }
 
+/**
+ Delete leftover captures matching `prefix` in the temp directory.
+
+ `end()`/`cancel()` remove the file they created, but neither runs when the
+ process dies mid-capture — a crash, a force-quit, a signal shutdown that times
+ out — and dictation audio then sits in the container until the OS decides to
+ clear its tmp, which is not a promise. Two such files were found after this
+ path crashed. Call this where nothing of that prefix can be in flight: one
+ capture at a time per owner, so at the start of a capture the only files left
+ are dead ones.
+ */
+func sweepStaleVoiceCaptures(prefix: String) {
+    let dir = FileManager.default.temporaryDirectory
+    guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return }
+    var removed = 0
+    for name in names where name.hasPrefix(prefix) {
+        if (try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))) != nil {
+            removed += 1
+        }
+    }
+    if removed > 0 {
+        DaemonLogger.shared.debug("Voice", "Swept \(removed) stale capture(s) matching \(prefix)*")
+    }
+}
+
 /// Installs the capture tap from a non-isolated context — see `PttFileSink` for
 /// why this cannot be written inline inside `begin()`.
 private func installPttTap(
@@ -148,6 +173,9 @@ final class DaemonPttVoice {
     /// on a voice_state error event.
     func begin() -> String? {
         guard engine == nil else { return "busy" }
+        // Nothing of ours can be in flight here, so anything left is a corpse
+        // from a crash or a force-quit — see sweepStaleVoiceCaptures.
+        sweepStaleVoiceCaptures(prefix: "agentdeck-ptt-")
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
             break
@@ -267,16 +295,6 @@ final class DaemonPttVoice {
                 + " fmt=\(Int(fmt.sampleRate))Hz/\(fmt.channelCount)ch/"
                 + (fmt.commonFormat == .pcmFormatFloat32 ? "f32" : "\(fmt.commonFormat.rawValue)")
                 + (peak < 0.01 ? " — effectively silent" : ""))
-
-        // Debug-only: keep the capture so its waveform can be inspected when the
-        // recognizer keeps reporting no speech. Off unless explicitly asked for —
-        // retaining dictation audio is not a default anyone opted into.
-        if ProcessInfo.processInfo.environment["AGENTDECK_KEEP_PTT_CAPTURE"] == "1" {
-            let kept = url.deletingLastPathComponent().appendingPathComponent("agentdeck-ptt-last.caf")
-            try? FileManager.default.removeItem(at: kept)
-            try? FileManager.default.copyItem(at: url, to: kept)
-            DaemonLogger.shared.debug("Voice", "PTT capture kept at \(kept.path)")
-        }
     }
 
     private func stopEngine() {

--- a/apple/AgentDeck/Daemon/Voice/DaemonVoiceAssistant.swift
+++ b/apple/AgentDeck/Daemon/Voice/DaemonVoiceAssistant.swift
@@ -78,6 +78,8 @@ final class DaemonVoiceAssistant {
 
     func startRecording() {
         guard state == .idle else { return }
+        // Same corpse sweep as the PTT path, for this path's own prefix.
+        sweepStaleVoiceCaptures(prefix: "agentdeck-voice-")
         state = .listening
         onStateChanged?(.listening, nil, nil)
 

--- a/apple/AgentDeck/Daemon/Voice/DaemonVoiceAssistant.swift
+++ b/apple/AgentDeck/Daemon/Voice/DaemonVoiceAssistant.swift
@@ -229,7 +229,7 @@ final class DaemonVoiceAssistant {
         }
         return await VoiceSpeechTranscriber.transcribe(
             url: url,
-            preferredLocales: [Locale.current, Locale(identifier: "en_US")]
+            preferredLocales: VoiceSpeechTranscriber.dictationLocales()
         )
     }
 
@@ -293,6 +293,16 @@ enum VoiceSpeechTranscriber {
             DaemonLogger.shared.debug("Voice", "Speech recognizer unavailable — on-device model may still be downloading")
             return nil
         }
+        // Which recognizer actually got the audio. Worth a line permanently: a
+        // wrong-locale recognizer and audio the service could not read both fail
+        // as kAFAssistantErrorDomain 1110 "No speech detected", so without this
+        // the two are indistinguishable from the log.
+        DaemonLogger.shared.debug(
+            "Voice",
+            "SFSpeech recognizer locale=\(recognizer.locale.identifier)"
+                + " onDevice=\(recognizer.supportsOnDeviceRecognition)"
+                + " asked=\(preferredLocales.map(\.identifier).joined(separator: ","))"
+                + " file=\(url.path)")
 
         let request = SFSpeechURLRecognitionRequest(url: url)
         request.shouldReportPartialResults = false
@@ -327,11 +337,82 @@ enum VoiceSpeechTranscriber {
 
     private static func makeSpeechRecognizer(preferredLocales: [Locale]) -> SFSpeechRecognizer? {
         for locale in preferredLocales {
-            if let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable {
+            guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+                continue
+            }
+            // `SFSpeechRecognizer(locale:)` accepts an unsupported tag and quietly
+            // resolves to something else, so taking whatever comes back makes the
+            // fallback order meaningless — and mis-transcribes in silence rather
+            // than failing. Only accept a recognizer that speaks the language we
+            // asked for; a region swap (ko-KR → ko) is fine.
+            if languageMatches(requested: locale.identifier, resolved: recognizer.locale.identifier) {
                 return recognizer
             }
         }
         return SFSpeechRecognizer()
+    }
+
+    /// Locales to try for dictation, best first.
+    ///
+    /// Deliberately NOT `Locale.current`: for an *app* that is the intersection of
+    /// the user's preferred languages with the **bundle's** localizations, so a
+    /// Korean user of an English-only app resolves to `en_KR` — and an `en_KR`
+    /// recognizer reports Korean speech as kAFAssistantErrorDomain 1110
+    /// "No speech detected", which is indistinguishable from a dead microphone.
+    /// Dictation has to follow what the user speaks, not what this bundle happens
+    /// to be translated into. Mirrors the Node daemon, which passes
+    /// `voice.locale` from settings.json to the bundled helper.
+    static func dictationLocales() -> [Locale] {
+        speechLocaleCandidates(
+            settingsLocale: settingsVoiceLocale(),
+            preferredLanguages: Locale.preferredLanguages,
+            currentIdentifier: Locale.current.identifier
+        ).map { Locale(identifier: $0) }
+    }
+
+    /// Pure ordering rule behind `dictationLocales()`, split out so it can be
+    /// tested without a bundle or a settings file.
+    static func speechLocaleCandidates(
+        settingsLocale: String?,
+        preferredLanguages: [String],
+        currentIdentifier: String
+    ) -> [String] {
+        var out: [String] = []
+        func add(_ raw: String?) {
+            guard let raw, !raw.isEmpty else { return }
+            // BCP-47 is what SFSpeechRecognizer speaks; Foundation hands out
+            // POSIX-style identifiers ("ko_KR").
+            let tag = raw.replacingOccurrences(of: "_", with: "-")
+            guard !out.contains(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) else { return }
+            out.append(tag)
+        }
+        add(settingsLocale)
+        for language in preferredLanguages { add(language) }
+        add(currentIdentifier)
+        add("en-US")
+        return out
+    }
+
+    /// True when a resolved recognizer speaks the language that was requested.
+    static func languageMatches(requested: String, resolved: String) -> Bool {
+        func language(_ tag: String) -> String {
+            tag.replacingOccurrences(of: "_", with: "-")
+                .split(separator: "-").first?.lowercased() ?? ""
+        }
+        return language(requested) == language(resolved)
+    }
+
+    /// `voice.locale` from settings.json (BCP-47), the explicit override shared
+    /// with the Node daemon.
+    private static func settingsVoiceLocale() -> String? {
+        guard let data = try? Data(contentsOf: AgentDeckPaths.settingsJson),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let voice = root["voice"] as? [String: Any],
+              let tag = voice["locale"] as? String,
+              !tag.isEmpty else {
+            return nil
+        }
+        return tag
     }
 }
 

--- a/apple/AgentDeckTests/SpokenDigestParityTests.swift
+++ b/apple/AgentDeckTests/SpokenDigestParityTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import AgentDeck
+
+/// Parity gate for what a spoken reply says.
+///
+/// `spokenDigest` is a hand mirror of the TypeScript SSOT in
+/// `shared/src/voice-reply-digest.ts`, and the cases below are that file's
+/// exported `SPOKEN_DIGEST_CASES` verbatim. If the two daemons speak different
+/// amounts of the same reply, the same VOICE key behaves differently depending
+/// on which daemon happens to be serving — so a case added on either side has
+/// to be added on the other.
+final class SpokenDigestParityTests: XCTestCase {
+
+    /// Mirror of SPOKEN_DIGEST_CASES in shared/src/voice-reply-digest.ts.
+    private let cases: [(name: String, input: String, expected: String)] = [
+        (
+            "first sentence only, not the whole paragraph",
+            "원인을 찾았습니다. 헬퍼 바이너리에 Info.plist가 없었습니다. 지금은 고쳤습니다.",
+            "원인을 찾았습니다."
+        ),
+        (
+            "explicit summary label wins over the opening sentence",
+            "VOICE 키가 죽어 있었습니다. 원인은 TCC입니다.\n요약: 헬퍼를 재빌드하면 동작합니다.",
+            "헬퍼를 재빌드하면 동작합니다."
+        ),
+        (
+            "bare summary label takes the line after it",
+            "TL;DR\nThe helper needed a usage description.\nDetails follow.",
+            "The helper needed a usage description."
+        ),
+        (
+            "a heading-only first line is skipped for the prose under it",
+            "## 원인\n번들 헬퍼에 Info.plist가 없었습니다. 그래서 TCC가 죽였습니다.",
+            "번들 헬퍼에 Info.plist가 없었습니다."
+        ),
+        (
+            "code fences never get recited",
+            "Fixed it.\n\n```ts\nconst x = 1;\n```\n",
+            "Fixed it."
+        ),
+        (
+            "a version number does not end the sentence",
+            "Bumped it to 1.0.2 for the release. Nothing else changed.",
+            "Bumped it to 1.0.2 for the release."
+        ),
+        (
+            "nothing speakable stays empty",
+            "```\ndiff --git a b\n```",
+            "(code)"
+        ),
+    ]
+
+    func testMatchesSharedParityCases() {
+        for c in cases {
+            XCTAssertEqual(
+                DaemonServer.spokenDigest(c.input), c.expected,
+                "parity case drifted: \(c.name)")
+        }
+    }
+
+    func testReadsOneSentenceOutOfALongAnswer() {
+        let body = "고쳤습니다. " + String(repeating: "이유는 여러 가지입니다. ", count: 40)
+        let out = DaemonServer.spokenDigest(body)
+
+        XCTAssertEqual(out, "고쳤습니다.")
+        XCTAssertLessThan(out.count, DaemonServer.spokenDigestMaxChars)
+    }
+
+    func testProseOpeningWithALabelWordIsNotASummary() {
+        // "요약" is the sentence's subject here, not a heading.
+        XCTAssertEqual(
+            DaemonServer.spokenDigest("요약 문서는 따로 없습니다. 코드를 보세요."),
+            "요약 문서는 따로 없습니다.")
+    }
+
+    func testOverLongSentenceCutsOnAWordBoundary() {
+        let sentence = String(repeating: "word ", count: 120)
+            .trimmingCharacters(in: .whitespaces) + " end"
+        let out = DaemonServer.spokenDigest(sentence)
+
+        XCTAssertLessThanOrEqual(out.count, DaemonServer.spokenDigestMaxChars)
+        XCTAssertTrue(out.hasSuffix("word"), "cut mid-word: \(out.suffix(20))")
+    }
+
+    func testFullOptsBackIntoTheWholeReadableAnswer() {
+        let body = "First. Second. Third."
+
+        XCTAssertEqual(DaemonServer.spokenDigest(body, full: true), body)
+        XCTAssertEqual(DaemonServer.spokenDigest(body), "First.")
+    }
+
+    func testEmptyStaysEmpty() {
+        XCTAssertEqual(DaemonServer.spokenDigest(""), "")
+        XCTAssertEqual(DaemonServer.spokenDigest("   \n \n"), "")
+    }
+}

--- a/bridge/fm-helper/Info.plist
+++ b/bridge/fm-helper/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Embedded (via `-sectcreate __TEXT __info_plist`) into the single-file
+  agentdeck-fm-helper binary, because TCC refuses to *prompt* for a
+  privacy-sensitive service unless the requesting code carries a usage
+  description — and "refuses" means SIGABRT, not an error return. Without this
+  the helper dies the first time it touches speech recognition or the mic on any
+  machine whose grant is not already on record, which is exactly what happened
+  once a rebuild changed the binary's cdhash and invalidated the old grant.
+
+  The identifier must match the `codesign --identifier` in
+  scripts/build-fm-helper.mjs: TCC keys an ad-hoc signed binary's grant on that
+  identifier, and a mismatch reads as a different app.
+-->
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>bound.serendipity.agentdeck.fm-helper</string>
+  <key>CFBundleName</key>
+  <string>AgentDeck Voice Helper</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>AgentDeck records a short push-to-talk clip so your spoken instruction can be transcribed on this Mac and sent to your coding agent.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>AgentDeck transcribes your push-to-talk clip with Apple's on-device recognizer so your spoken instruction can be sent to your coding agent. The audio never leaves this Mac.</string>
+</dict>
+</plist>

--- a/bridge/scripts/build-fm-helper.mjs
+++ b/bridge/scripts/build-fm-helper.mjs
@@ -1,14 +1,27 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const source = join(root, 'fm-helper', 'AgentDeckFMHelper.swift');
-const out = join(root, 'assets', 'fm-helper', 'agentdeck-fm-helper');
+const plist = join(root, 'fm-helper', 'Info.plist');
+const defaultOut = join(root, 'assets', 'fm-helper', 'agentdeck-fm-helper');
 const arch = process.arch === 'arm64' ? 'arm64' : 'x86_64';
 const target = `${arch}-apple-macos26.0`;
+/** Must match CFBundleIdentifier in fm-helper/Info.plist — see the note there. */
+const signingIdentifier = 'bound.serendipity.agentdeck.fm-helper';
+
+// The daemon's source-compiled fallback (foundation-models-helper.ts) runs this
+// same script with --out so the plist embedding and the signature can't drift
+// between the packaged binary and a locally rebuilt one.
+const outFlag = process.argv.indexOf('--out');
+const out = outFlag >= 0 ? process.argv[outFlag + 1] : defaultOut;
+if (outFlag >= 0 && !out) {
+  console.error('[fm-helper] --out requires a path');
+  process.exit(1);
+}
 
 if (process.platform !== 'darwin') {
   console.log('[fm-helper] skipped: darwin only');
@@ -21,6 +34,25 @@ const swiftc = execFileSync('/usr/bin/xcrun', ['--find', 'swiftc'], { encoding: 
 // stdlib can't be found ("unable to load standard library for target ..."). Pass
 // the SDK path explicitly so the build is reproducible from the npm lifecycle.
 const sdk = execFileSync('/usr/bin/xcrun', ['--sdk', 'macosx', '--show-sdk-path'], { encoding: 'utf8' }).trim();
-execFileSync(swiftc, ['-parse-as-library', '-sdk', sdk, '-target', target, source, '-o', out], { stdio: 'inherit' });
+const args = ['-parse-as-library', '-sdk', sdk, '-target', target, source, '-o', out];
+// A single-file tool has no bundle, so its usage descriptions have to live in an
+// __info_plist section: TCC aborts (SIGABRT, not an error return) the moment it
+// needs to prompt for the mic or speech recognition without one.
+if (existsSync(plist)) {
+  args.push('-Xlinker', '-sectcreate', '-Xlinker', '__TEXT', '-Xlinker', '__info_plist', '-Xlinker', plist);
+} else {
+  console.warn(`[fm-helper] WARNING: ${plist} missing — voice capture will crash under TCC`);
+}
+execFileSync(swiftc, args, { stdio: 'inherit' });
 chmodSync(out, 0o755);
+// Ad-hoc signing gives TCC a stable identity to hang the grant on. It is not
+// about trust: an unsigned binary's grant is keyed on the raw cdhash alone, so
+// the prompt cannot name the helper and the user sees a nameless request.
+try {
+  execFileSync('/usr/bin/codesign', [
+    '--force', '--sign', '-', '--identifier', signingIdentifier, out,
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+} catch (err) {
+  console.warn(`[fm-helper] WARNING: ad-hoc codesign failed: ${String(err).slice(0, 160)}`);
+}
 console.log(`[fm-helper] built ${out}`);

--- a/bridge/src/__tests__/fm-helper-build.test.ts
+++ b/bridge/src/__tests__/fm-helper-build.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * The voice helper is a single Mach-O file with no app bundle, so the usage
+ * descriptions TCC requires before it will *prompt* have to be linked into an
+ * `__info_plist` section. Getting this wrong does not degrade gracefully: TCC
+ * aborts the helper (SIGABRT) the moment it touches the mic or the recognizer,
+ * which reads on the deck as "the VOICE key does nothing" and in the daemon log
+ * as a request timeout. These assertions guard the three pieces that have to
+ * agree — the plist keys, the linker flags, and the signing identity the grant
+ * is pinned to.
+ */
+const bridgeRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const plistPath = join(bridgeRoot, 'fm-helper', 'Info.plist');
+const scriptPath = join(bridgeRoot, 'scripts', 'build-fm-helper.mjs');
+const binaryPath = join(bridgeRoot, 'assets', 'fm-helper', 'agentdeck-fm-helper');
+
+const REQUIRED_KEYS = [
+  'NSMicrophoneUsageDescription',
+  'NSSpeechRecognitionUsageDescription',
+];
+
+function plistValue(plist: string, key: string): string | null {
+  const match = plist.match(
+    new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`),
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * Comments in this build script *explain* the linker flags and the signing
+ * identifier, so a plain `toContain` matches the prose after the code that
+ * matters is gone. Strip comments before asserting — the first cut of this test
+ * stayed green with `__info_plist` renamed in the actual argument list.
+ */
+function codeOnly(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n');
+}
+
+/** `codesign -dv` reports on stderr even when it succeeds. */
+function codesignReport(path: string): string {
+  const result = spawnSync('/usr/bin/codesign', ['-dv', path], { encoding: 'utf8' });
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+function toolchainAvailable(): boolean {
+  if (process.platform !== 'darwin') return false;
+  try {
+    execFileSync('/usr/bin/xcrun', ['--find', 'swiftc'], { stdio: 'ignore', timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('fm-helper build invariants', () => {
+  const plist = readFileSync(plistPath, 'utf8');
+  const script = codeOnly(readFileSync(scriptPath, 'utf8'));
+
+  it.each(REQUIRED_KEYS)('declares a non-empty %s', (key) => {
+    const value = plistValue(plist, key);
+    expect(value, `${key} missing from fm-helper/Info.plist`).toBeTruthy();
+    expect((value ?? '').length).toBeGreaterThan(20);
+  });
+
+  it('embeds the plist into the __TEXT segment at link time', () => {
+    expect(script).toContain('-sectcreate');
+    expect(script).toContain('__info_plist');
+    expect(script).toMatch(/join\(root, 'fm-helper', 'Info\.plist'\)/);
+  });
+
+  it('ad-hoc signs with the identifier the plist declares', () => {
+    // TCC keys an ad-hoc grant on the signing identifier; a mismatch between
+    // these two reads as a different app and re-prompts forever.
+    const bundleId = plistValue(plist, 'CFBundleIdentifier');
+    expect(bundleId).toBeTruthy();
+    expect(script).toContain('codesign');
+    expect(script).toContain(`'${bundleId}'`);
+  });
+
+  // Only meaningful where a build has run (darwin dev machines, post-prepack);
+  // the binary is not tracked, so its absence is not a failure.
+  it.skipIf(!existsSync(binaryPath))('ships a binary carrying the usage strings', () => {
+    const bytes = readFileSync(binaryPath);
+    for (const key of REQUIRED_KEYS) {
+      expect(bytes.includes(key), `${key} not embedded in the built helper`).toBe(true);
+    }
+  });
+
+  // The assertions above read intent off the script; this one reads the outcome
+  // off a real build, which is what TCC actually inspects.
+  it.skipIf(!toolchainAvailable())('produces a signed binary macOS can prompt for', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fm-helper-build-'));
+    const out = join(dir, 'agentdeck-fm-helper');
+    try {
+      execFileSync(process.execPath, [scriptPath, '--out', out], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: 180_000,
+      });
+      const bytes = readFileSync(out);
+      for (const key of REQUIRED_KEYS) {
+        expect(bytes.includes(key), `${key} not linked into the built helper`).toBe(true);
+      }
+      const signature = codesignReport(out);
+      expect(signature).toContain(`Identifier=${plistValue(plist, 'CFBundleIdentifier')}`);
+      expect(signature).toMatch(/Info\.plist entries=[1-9]/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 200_000);
+});

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -116,9 +116,9 @@ import {
   lastAssistantTextForSession,
 } from './session-transcript-timeline.js';
 import {
-  DeviceVoiceReplyRouter, speakableReply, pcmFromWav, type ReplySink,
+  DeviceVoiceReplyRouter, speakableReply, spokenDigest, pcmFromWav, type ReplySink,
 } from './device-voice-reply.js';
-import { rawSessionId } from '@agentdeck/shared';
+import { rawSessionId, type StateSnapshot } from '@agentdeck/shared';
 import { lastAgentMessageFromCodexRollout } from './codex-rollout-response.js';
 import { callFoundationModelsHelper } from './foundation-models-helper.js';
 import {
@@ -134,7 +134,7 @@ import { getConnectedAdbDevices, hasAdb, getAdbDeviceCount } from './adb-reverse
 import { getPixooDeviceDetails, pixooDeviceCount } from './pixoo/pixoo-bridge.js';
 import { loadTimeboxDevices } from './timebox/timebox-settings.js';
 import { getLanIp, stripUnsafeText, cleanRawText, prepareMarkdownDetail, normalizeCommandPrompt, formatDurationSec, type TimelineEntry, PluginCommand } from '@agentdeck/shared';
-import { injectOpenClawSession } from './openclaw-session.js';
+import { injectOpenClawSession, OPENCLAW_SESSION_ID } from './openclaw-session.js';
 import {
   buildCardFeed, buildGlance, applyOutboxDecisions, FeedPullTracker, formatFeedPull,
   normalizeClientIp, parsePullTelemetry,
@@ -1142,6 +1142,23 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   // `gatewaySessionState` / `gatewayModelName` dedicated fields.
   let gatewaySessionState = 'idle';
   let gatewayModelName: string | undefined;
+
+  /**
+   * Snapshot for an `openclaw` state event: the global machine with the
+   * Gateway-local model pinned back on.
+   *
+   * The Gateway's `model_info` no longer writes `core.stateMachine` (see the
+   * parser branch): that machine is fed by every observed Claude/Codex/OpenCode
+   * hook, and the hub stamps its broadcasts with the user's focused session —
+   * so a model written there by a *different* agent is read as the focused
+   * session's own. That is how `GLM-5.2 (1M)` appeared as the model of a Claude
+   * session on both decks. Keeping the model out of the shared slot means the
+   * Gateway's own events have to carry it explicitly, which is what this does.
+   */
+  const gatewaySnapshot = (base?: StateSnapshot): StateSnapshot => ({
+    ...(base ?? core.stateMachine.getSnapshot()),
+    modelName: gatewayModelName ?? null,
+  });
 
   // Wi-Fi WebSocket e-ink panels (XTeink X3/X4 CrossPoint fork) self-register
   // their device roster via `client_register{clientType:"eink-device"}` — the
@@ -2593,11 +2610,51 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   core.wireDisplayMonitor();
   let lastStateEvent: BridgeEvent | null = null;
   let userFocusedSessionId: string | null = null;
+  /**
+   * Stamp the focused session onto a hub `state_update`.
+   *
+   * This field carries two jobs, and both are load-bearing, which is why it
+   * cannot simply be narrowed:
+   *  - attribution: `buildStateEvent` sets no `sessionId` at all, so a
+   *    hook-observed session's AWAITING_PERMISSION options reach the decks
+   *    attributed only by this field (see session-deck-awaiting tests).
+   *  - focus ack: the Apple app toggles creature focus against it and needs it
+   *    even for a session that emits nothing of its own.
+   *
+   * The consequence is a standing invariant on the payload: whatever rides along
+   * here is read as the focused session's own. So nothing may write a *different*
+   * agent's per-session field into `core.stateMachine` — the Gateway's model went
+   * in and came out as a Claude session's model. Gateway-specific state lives in
+   * `gatewaySessionState` / `gatewayModelName` and is re-attached by
+   * `gatewaySnapshot()`.
+   */
   const attachFocusedSessionId = <T extends BridgeEvent>(event: T): T => {
     if ((event as any).type !== 'state_update') return event;
     return {
       ...(event as any),
       focusedSessionId: userFocusedSessionId ?? '',
+    } as T;
+  };
+
+  /**
+   * Stamp a *Gateway-specific* state event — one whose payload really is the
+   * Gateway's (its parser events, its connection transitions), as opposed to the
+   * hub broadcasts above that merely get labelled `openclaw` while the Gateway is
+   * alive.
+   *
+   * These name their own row (`sessionId`), which is the honest attribution and
+   * the reason a client never has to guess: an event carrying the Gateway's model
+   * now says so. The focus ack rides only when the Gateway IS the focused row —
+   * otherwise this event would claim to describe a Claude session, which is
+   * precisely how `GLM-5.2 (1M)` became that session's model on both decks. The
+   * ack still reaches the Apple app through every hub broadcast.
+   */
+  const attachGatewayEvent = <T extends BridgeEvent>(event: T): T => {
+    if ((event as any).type !== 'state_update') return event;
+    return {
+      ...(event as any),
+      sessionId: OPENCLAW_SESSION_ID,
+      focusedSessionId: userFocusedSessionId === OPENCLAW_SESSION_ID ? OPENCLAW_SESSION_ID : '',
     } as T;
   };
   const broadcastFocusedState = () => {
@@ -3062,7 +3119,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           else if (evt.event === 'SessionEnd') core.stateMachine.handleHookEvent('SessionEnd', {});
           break;
         case 'parser':
-          core.stateMachine.handleParserEvent(evt.event, evt.data);
+          // `model_info` is deliberately NOT forwarded: the global machine holds
+          // one modelName for the whole hub, fed by every observed hook session,
+          // and its broadcasts are stamped with the user's focused session — so a
+          // model written here by the Gateway is read as that session's own
+          // (GLM on a Claude row). It lives in `gatewayModelName` instead, and
+          // `gatewaySnapshot()` puts it back on the Gateway's own events.
+          if (evt.event !== 'model_info') core.stateMachine.handleParserEvent(evt.event, evt.data);
           // Gateway-local activity state for the virtual session row (mirror of
           // Swift `gatewaySessionState`). Kept separate from the global
           // `core.stateMachine` above so the OpenClaw row reflects only the
@@ -3087,10 +3150,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             if (models) {
               core.cachedModelCatalog = models;
               const snap = core.stateMachine.getSnapshot();
-              const stateEvent = attachFocusedSessionId(core.buildStateEvent({
+              const stateEvent = attachGatewayEvent(core.buildStateEvent({
                 agentType: 'openclaw',
                 agentCapabilities: OPENCLAW_CAPABILITIES,
-                snapshot: snap,
+                snapshot: gatewaySnapshot(snap),
               }));
               lastStateEvent = stateEvent;
               core.broadcast(stateEvent);
@@ -3139,10 +3202,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             }
             // Force full state broadcast
             const snap = core.stateMachine.getSnapshot();
-            const gwStateEvent = attachFocusedSessionId(core.buildStateEvent({
+            const gwStateEvent = attachGatewayEvent(core.buildStateEvent({
               agentType: 'openclaw',
               agentCapabilities: OPENCLAW_CAPABILITIES,
-              snapshot: snap,
+              snapshot: gatewaySnapshot(snap),
             }));
             lastStateEvent = gwStateEvent;
             core.wsServer.broadcast(gwStateEvent);
@@ -3546,10 +3609,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       if (target === 'openclaw' && gatewayAdapter?.isAlive()) {
         // Force broadcast OpenClaw state to all clients
         const snap = core.stateMachine.getSnapshot();
-        const gwStateEvent = attachFocusedSessionId(core.buildStateEvent({
+        const gwStateEvent = attachGatewayEvent(core.buildStateEvent({
           agentType: 'openclaw',
           agentCapabilities: OPENCLAW_CAPABILITIES,
-          snapshot: snap,
+          snapshot: gatewaySnapshot(snap),
         }));
         lastStateEvent = gwStateEvent;
         core.wsServer.broadcast(gwStateEvent);
@@ -3895,9 +3958,20 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     log(`[agentdeck] voice: reply ready for ${sessionId.slice(0, 32)}`
       + ` -> ${targets.length} board(s)`);
     const voiceCfg = loadDaemonSettings().voice as
-      { locale?: unknown; speakReplies?: unknown } | undefined;
+      { locale?: unknown; speakReplies?: unknown; speakFullReply?: unknown } | undefined;
     if (voiceCfg?.speakReplies === false) return;  // opt-out, default on
-    const spoken = speakableReply(text);
+    // Speech gets the lead, not the transcript: an explicit summary line if the
+    // answer has one, else its first sentence. The full answer is already on the
+    // screen the user is sitting at, where it can be skimmed — read aloud it is
+    // a minute of monologue nobody can skip. `voice.speakFullReply` opts back in.
+    const full = voiceCfg?.speakFullReply === true;
+    const spoken = spokenDigest(text, { full });
+    if (!full) {
+      const readable = speakableReply(text, Number.MAX_SAFE_INTEGER);
+      if (spoken && readable.length > spoken.length) {
+        log(`[agentdeck] voice: reply digested ${readable.length} -> ${spoken.length} chars`);
+      }
+    }
     if (!spoken) {
       // A code-only answer has nothing worth reading aloud; say that instead of
       // spelling out punctuation, so the user still knows the turn finished.

--- a/bridge/src/device-voice-reply.ts
+++ b/bridge/src/device-voice-reply.ts
@@ -20,6 +20,13 @@
 
 import { rawSessionId } from '@agentdeck/shared';
 
+// What to read aloud is a two-daemon rule, so it lives in shared/ with the
+// Swift mirror pinned to the same parity cases. Re-exported here because every
+// existing caller reaches for it through this module.
+export {
+  MAX_SPOKEN_CHARS, SPOKEN_DIGEST_MAX_CHARS, speakableReply, spokenDigest,
+} from '@agentdeck/shared';
+
 export interface ReplySink {
   /** Send a JSON control frame. */
   send(data: string): void;
@@ -50,9 +57,6 @@ export interface ArmedReply {
  *  frame is inaudible, large enough that framing overhead stays negligible. */
 export const PCM_FRAME_BYTES = 1024;
 
-/** A spoken reply past this is a monologue, not an answer. Truncated at a
- *  sentence boundary when one is near the cap. */
-export const MAX_SPOKEN_CHARS = 700;
 
 /**
  * How long an arming survives *without the session making progress*. Measured
@@ -61,38 +65,6 @@ export const MAX_SPOKEN_CHARS = 700;
  * that went quiet has moved on and speaking then is worse than silence.
  */
 export const REPLY_ARM_TTL_MS = 10 * 60 * 1000;
-
-/**
- * Strip the parts of an assistant reply that make no sense read aloud (code
- * fences, markdown scaffolding, bare URLs) and cap the length. Returns an empty
- * string when nothing speakable is left — a reply that was only a diff should
- * play nothing rather than spell out punctuation.
- */
-export function speakableReply(raw: string, maxChars = MAX_SPOKEN_CHARS): string {
-  if (!raw) return '';
-  let text = raw
-    // Fenced blocks read as noise; say so once instead of reciting them.
-    .replace(/```[\s\S]*?```/g, ' (code) ')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/https?:\/\/\S+/g, ' link ')
-    .replace(/^\s*(?:#{1,6}|>|[*\-+])\s+/gm, '')
-    .replace(/\*\*|__|~~/g, '')
-    .replace(/[ \t]+/g, ' ')
-    .replace(/\n{2,}/g, '\n')
-    .trim();
-  if (!text) return '';
-  if (text.length > maxChars) {
-    const head = text.slice(0, maxChars);
-    // Prefer ending on a sentence so the cut doesn't sound like a dropout.
-    const lastStop = Math.max(
-      head.lastIndexOf('. '), head.lastIndexOf('。'),
-      head.lastIndexOf('! '), head.lastIndexOf('? '), head.lastIndexOf('다.'),
-    );
-    text = lastStop > maxChars * 0.5 ? head.slice(0, lastStop + 1) : head;
-  }
-  return text.trim();
-}
 
 /**
  * Extract PCM samples from a canonical RIFF/WAVE file by walking the chunk

--- a/bridge/src/foundation-models-helper.ts
+++ b/bridge/src/foundation-models-helper.ts
@@ -1,5 +1,5 @@
 import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from 'child_process';
-import { chmodSync, existsSync, mkdirSync, statSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from 'fs';
 import { dirname, join } from 'path';
 import { homedir, release } from 'os';
 import { fileURLToPath } from 'url';
@@ -74,30 +74,49 @@ function sourceIsNewer(source: string, output: string): boolean {
   }
 }
 
-function compileHelper(source: string, output: string): FoundationModelsHelperStatus {
+function buildScriptPath(): string {
+  return join(packageRoot(), 'scripts', 'build-fm-helper.mjs');
+}
+
+/**
+ * Compile the helper through the packaged build script rather than invoking
+ * swiftc here: the script owns the `__info_plist` embedding and the ad-hoc
+ * signature, and a second copy of those flags would drift into a binary that
+ * TCC kills on the first mic or speech request.
+ */
+function compileHelper(output: string): FoundationModelsHelperStatus {
   try {
     mkdirSync(dirname(output), { recursive: true });
-    const swiftc = execFileSync('/usr/bin/xcrun', ['--find', 'swiftc'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 5_000,
-    }).trim();
-    const arch = process.arch === 'arm64' ? 'arm64' : 'x86_64';
-    execFileSync(swiftc, [
-      '-parse-as-library',
-      '-target',
-      `${arch}-apple-macos26.0`,
-      source,
-      '-o',
-      output,
-    ], {
+    const script = buildScriptPath();
+    if (!existsSync(script)) {
+      return { available: false, reason: `Foundation Models helper build script missing: ${script}` };
+    }
+    execFileSync(process.execPath, [script, '--out', output], {
       stdio: ['ignore', 'ignore', 'pipe'],
-      timeout: 30_000,
+      timeout: 60_000,
     });
+    if (!isExecutable(output)) {
+      return { available: false, reason: 'Foundation Models helper build produced no binary' };
+    }
     chmodSync(output, 0o755);
     return { available: true, path: output };
   } catch (err) {
     return { available: false, reason: `failed to build Foundation Models helper: ${String(err).slice(0, 160)}` };
+  }
+}
+
+/**
+ * True when the binary carries the usage descriptions TCC demands before it will
+ * prompt for the microphone or speech recognition. A binary built by an older
+ * build script has none, and the failure mode is not a denied request but a
+ * SIGABRT the moment voice is used — so a plist-less bundled binary is worth
+ * rebuilding from source even though it serves the judge path perfectly well.
+ */
+function hasVoiceUsageDescriptions(path: string): boolean {
+  try {
+    return readFileSync(path).includes('NSSpeechRecognitionUsageDescription');
+  } catch {
+    return false;
   }
 }
 
@@ -122,24 +141,33 @@ export function resolveFoundationModelsHelper(): FoundationModelsHelperStatus {
   }
 
   const bundled = bundledHelperPath();
-  if (isExecutable(bundled)) {
+  const bundledUsable = isExecutable(bundled);
+  if (bundledUsable && hasVoiceUsageDescriptions(bundled)) {
     helperPathCache = { available: true, path: bundled };
     return helperPathCache;
   }
 
   const source = sourcePath();
   if (!existsSync(source)) {
-    helperPathCache = { available: false, reason: 'Foundation Models helper source not packaged' };
+    helperPathCache = bundledUsable
+      ? { available: true, path: bundled }
+      : { available: false, reason: 'Foundation Models helper source not packaged' };
     return helperPathCache;
   }
 
   const cached = cachedHelperPath();
-  if (isExecutable(cached) && !sourceIsNewer(source, cached)) {
+  if (isExecutable(cached) && hasVoiceUsageDescriptions(cached) && !sourceIsNewer(source, cached)) {
     helperPathCache = { available: true, path: cached };
     return helperPathCache;
   }
 
-  helperPathCache = compileHelper(source, cached);
+  const compiled = compileHelper(cached);
+  // A bundled binary that predates the plist still runs the judge; keep it as
+  // the degraded fallback rather than losing the helper entirely when this
+  // machine has no Swift toolchain to rebuild with.
+  helperPathCache = compiled.available || !bundledUsable
+    ? compiled
+    : { available: true, path: bundled };
   return helperPathCache;
 }
 
@@ -302,10 +330,16 @@ export async function recordWithHelper(
   opts: { maxMs?: number } = {},
 ): Promise<{ wav: string; durationMs: number; stopReason: string }> {
   const maxMs = Math.min(opts.maxMs ?? RECORD_MAX_MS, 120_000);
-  const response = await requestHelper(
-    { type: 'record', wav: outPath, maxMs },
-    maxMs + 15_000,
-  );
+  let response: Record<string, unknown>;
+  try {
+    response = await requestHelper({ type: 'record', wav: outPath, maxMs }, maxMs + 15_000);
+  } catch (err) {
+    // Peer silence is the signal, not the end of it: the helper allows one
+    // capture at a time, so a timed-out record leaves its slot armed and every
+    // later press answers `busy`. Release it before surfacing the failure.
+    await stopHelperRecording({ cancel: true }).catch(() => false);
+    throw err;
+  }
   if (response.cancelled === true) {
     throw new Error('record_cancelled');
   }

--- a/bridge/src/openclaw-session.ts
+++ b/bridge/src/openclaw-session.ts
@@ -7,6 +7,13 @@
 import { isOpenClawSessionActive, hasOpenClawSession } from '@agentdeck/shared';
 import type { EnrichedSession } from './session-aggregator.js';
 
+/**
+ * Id of the virtual Gateway session row. Defined here because this injector is
+ * what creates it; import it instead of retyping the literal, which is how a
+ * comparison against it silently stops matching.
+ */
+export const OPENCLAW_SESSION_ID = 'openclaw-gateway';
+
 export interface InjectOpenClawOptions {
   /** SSOT gate — inject only when the Gateway is authenticated. */
   gatewayConnected: boolean;
@@ -30,7 +37,7 @@ export function injectOpenClawSession(
   if (!isOpenClawSessionActive({ gatewayConnected: opts.gatewayConnected })) return sessions;
   if (hasOpenClawSession(sessions)) return sessions;
   const injected: EnrichedSession = {
-    id: 'openclaw-gateway',
+    id: OPENCLAW_SESSION_ID,
     port: 18789,
     projectName: opts.projectName ?? 'OpenClaw',
     agentType: 'openclaw',

--- a/docs/voice-setup.md
+++ b/docs/voice-setup.md
@@ -2,7 +2,7 @@
 
 AgentDeck's voice assistant uses Apple's **on-device `SFSpeechRecognizer`** (the Speech framework). **Nothing to install** — no whisper.cpp, no model download. macOS and iOS manage the dictation model themselves; AgentDeck piggybacks on whatever the user already granted for system dictation.
 
-**Both daemons use the same engine.** The Swift daemon calls the framework directly; the Node (CLI) daemon reaches it through the bundled Swift helper (`bridge/fm-helper/AgentDeckFMHelper.swift`) that already serves Foundation Models for the APME judge — `{"type":"transcribe","wav":…}` in, `{"text":…}` out, plus `{"type":"speak"}` for replies. The helper ships prebuilt in the npm package and self-compiles with `xcrun swiftc` if it is missing, so there is still nothing for a user to install. Host-microphone capture (not transcription) is the one thing that still wants `sox`; device-sourced audio from an ESP32 board does not.
+**Both daemons use the same engine.** The Swift daemon calls the framework directly; the Node (CLI) daemon reaches it through the bundled Swift helper (`bridge/fm-helper/AgentDeckFMHelper.swift`) that already serves Foundation Models for the APME judge — `{"type":"transcribe","wav":…}` in, `{"text":…}` out, plus `{"type":"record"}` for host push-to-talk capture and `{"type":"speak"}` for replies. The helper ships prebuilt in the npm package and self-compiles with `xcrun swiftc` if it is missing, so there is still nothing for a user to install. Host-microphone capture goes through the same helper (the old `sox` + borrowed-terminal-grant path is gone); device-sourced audio from an ESP32 board needs no capture at all.
 
 The flow:
 
@@ -26,6 +26,10 @@ Two TCC prompts fire the first time you use voice. Both are backed by Info.plist
 | **Speech Recognition access** | "AgentDeck transcribes your voice commands locally using Apple's on-device speech recognition so your audio never leaves this device." | `SFSpeechRecognizer` transcription |
 
 Grant both on first use. You can change the decision later under **System Settings → Privacy & Security → Microphone** and **→ Speech Recognition** (macOS 13+).
+
+**The CLI daemon prompts as its own helper, not as a terminal.** The Node daemon's capture and transcription happen inside `agentdeck-fm-helper`, a single-file binary with no app bundle — so its usage strings are linked into an `__info_plist` section (`bridge/fm-helper/Info.plist`) and the binary is ad-hoc signed with a fixed identifier by `bridge/scripts/build-fm-helper.mjs`. Both are load-bearing: **TCC aborts the process (SIGABRT) instead of returning an error when it needs to prompt for a service the requesting code has no usage description for**, so a plist-less helper does not degrade — it dies, mid-turn, and the deck's VOICE key reports a timeout. The prompts read **AgentDeck Voice Helper**; grant them there.
+
+Because an ad-hoc signature pins the grant to that identifier plus the binary's cdhash, **rebuilding the helper re-prompts** (the same TCC pinning that makes a rebuilt app re-ask for Bluetooth). If a rebuilt helper starts failing instead of asking, clear the stale entries: `tccutil reset Microphone` and `tccutil reset SpeechRecognition`, then press VOICE again.
 
 ---
 
@@ -76,6 +80,7 @@ The wake word system is **independent of the SFSpeech transcription path** — w
 | Wrong language detected | Current locale not supported / model missing | Set current Mac locale to a supported Speech language, or rely on en_US fallback (auto) |
 | Voice cut off at 15 seconds | Hit `maxRecordingDuration` | Press the voice button again for a new turn. Voice commands are designed to be short |
 | Transcript correct but agent doesn't receive | Daemon/bridge not connected | Check the menu bar dashboard — Connection status must be "Connected" before voice sends work |
+| Deck VOICE key does nothing; daemon logs `voice: host PTT failed: … request timed out` or `helper exited (SIGABRT)` | The CLI daemon's `agentdeck-fm-helper` was built without the embedded usage descriptions, so TCC killed it instead of prompting | Rebuild it: `cd bridge && node scripts/build-fm-helper.mjs` (verify with `codesign -dv assets/fm-helper/agentdeck-fm-helper` → `Info.plist entries=4`), restart the daemon, then grant the two **AgentDeck Voice Helper** prompts |
 
 **Logs**: `DaemonVoiceAssistant` writes to the standard AgentDeck log. Search for `[Voice]` entries:
 

--- a/plugin/src/__tests__/session-slot-manager.test.ts
+++ b/plugin/src/__tests__/session-slot-manager.test.ts
@@ -700,3 +700,61 @@ describe('VOICE hold-to-talk key', () => {
     expect(configs.some(c => c.type === 'status' && c.label === 'OBSERVED')).toBe(true);
   });
 });
+
+describe('SessionSlotManager detail cache ownership', () => {
+  // The 2026-07-17 guards stop a *foreign* event from being applied to the
+  // focused session. They cannot help when the field was cached while another
+  // session was focused and no event ever arrives for the new one — an idle or
+  // mid-turn session emits nothing. That combination is what put OpenClaw's
+  // GLM model on a Claude session's detail.
+  const OPENCLAW = makeSession({
+    id: 'openclaw-gateway', agentType: 'openclaw',
+    projectName: 'OpenClaw', modelName: 'GLM-5.2 (1M)', effortLevel: undefined,
+  });
+  const CLAUDE = makeSession({
+    id: 'claude-1', agentType: 'claude-code',
+    projectName: 'AgentDeck', modelName: 'claude-opus-5', state: State.PROCESSING,
+  });
+
+  function managerWithBothSessions(): SessionSlotManager {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([CLAUDE, OPENCLAW]);
+    return manager;
+  }
+
+  it('does not carry the previous session model into the next detail view', () => {
+    const manager = managerWithBothSessions();
+    manager.enterDetailView('openclaw-gateway');
+    manager.updateDetailState(State.IDLE, [], undefined, undefined, undefined, 'GLM-5.2 (1M)');
+    expect(manager.detailModelName).toBe('GLM-5.2 (1M)');
+
+    // Straight to another session's detail, with no state_update in between.
+    manager.exitDetailView();
+    manager.enterDetailView('claude-1');
+
+    expect(manager.detailModelName).toBe('claude-opus-5');
+  });
+
+  it('seeds the detail readout from the session row rather than blanking it', () => {
+    const manager = managerWithBothSessions();
+    manager.enterDetailView('claude-1');
+
+    // INFO renders manager.detailState directly, so a cleared cache would show
+    // DISCONNECTED for a live session.
+    expect(manager.detailState).toBe(State.PROCESSING);
+    expect(manager.detailEffortLevel).toBe('high');
+  });
+
+  it('drops the cached model when re-entering a session that has none', () => {
+    const manager = new SessionSlotManager();
+    manager.updateSessions([
+      OPENCLAW,
+      makeSession({ id: 'unknown-1', modelName: undefined, effortLevel: undefined }),
+    ]);
+    manager.enterDetailView('openclaw-gateway');
+    manager.updateDetailState(State.IDLE, [], undefined, undefined, undefined, 'GLM-5.2 (1M)');
+    manager.enterDetailView('unknown-1');
+
+    expect(manager.detailModelName).toBeUndefined();
+  });
+});

--- a/plugin/src/focused-detail-state.ts
+++ b/plugin/src/focused-detail-state.ts
@@ -20,7 +20,8 @@ export interface FocusedDetailSnapshot {
   suggestedPrompt?: string;
 }
 
-function stateFromSession(session: SessionInfo): State {
+/** Exported so the slot manager seeds its own detail cache identically. */
+export function stateFromSession(session: SessionInfo): State {
   const state = session.state;
   if (
     state === State.IDLE
@@ -35,7 +36,14 @@ function stateFromSession(session: SessionInfo): State {
   return session.alive ? State.IDLE : State.DISCONNECTED;
 }
 
-/** Prefer an explicit user focus, then the event's source session. */
+/**
+ * Prefer an explicit user focus, then the event's source session.
+ *
+ * `focusedSessionId` is load-bearing, not a hint: `buildStateEvent` sets no
+ * `sessionId` at all, so a hook-observed session's AWAITING_PERMISSION options
+ * reach the deck attributed only by this field. Narrowing it to `sessionId`
+ * silently drops Allow/Deny routing (bridge/src/__tests__/session-deck-awaiting).
+ */
 function eventSessionId(ev: { sessionId?: string; focusedSessionId?: string }): string | undefined {
   return ev.focusedSessionId || ev.sessionId || undefined;
 }

--- a/plugin/src/session-slot-manager.ts
+++ b/plugin/src/session-slot-manager.ts
@@ -9,6 +9,7 @@ import type { SessionInfo, StatusCardTone, StatusIconKind, CodexRateLimits } fro
 import { State, sortSessions, assignDisplayNames, foldCodexSessionsForDisplay, aliasModelName, Brand, usageWindowKind, usageWindowLabel, codexUsageFootnote, UI } from '@agentdeck/shared';
 import type { PromptOption } from '@agentdeck/shared';
 import { dlog } from './log.js';
+import { stateFromSession } from './focused-detail-state.js';
 
 export type SlotView = 'list' | 'detail';
 
@@ -499,6 +500,13 @@ export class SessionSlotManager {
     this._focusedSessionId = sessionId;
     this._view = 'detail';
     this._detailPage = 0;
+    // The `_detail*` fields describe ONE session, so they must not survive a
+    // focus change: some readouts (INFO) render them with no session fallback,
+    // and a state_update for the newly focused session may never arrive — an
+    // idle or mid-turn session emits nothing. That is how the previously
+    // focused row's model kept showing on the next one. Seed from the
+    // sessions_list row, which is per-session by construction.
+    this.seedDetailState(this._sessions.find((s) => s.id === sessionId));
     dlog('SlotMgr', `enterDetailView: ${sessionId}`);
   }
 
@@ -506,10 +514,31 @@ export class SessionSlotManager {
     this._focusedSessionId = null;
     this._view = 'list';
     this._detailPage = 0;
+    this.seedDetailState(undefined);
+    dlog('SlotMgr', `exitDetailView → list`);
+  }
+
+  /**
+   * Reset the session-owned detail cache to what `sessions_list` says about
+   * `session` (or to nothing on the way back to the list). Never carries a field
+   * over from the session that was focused before.
+   */
+  private seedDetailState(session: SessionInfo | undefined): void {
+    this._detailState = session ? stateFromSession(session) : State.DISCONNECTED;
+    this._detailOptions = session?.options ?? [];
+    this._detailTool = session?.currentTool ?? session?.currentTask;
+    this._detailToolInput = undefined;
+    this._detailQuestion = session?.question;
+    this._detailModelName = session?.modelName;
+    this._detailEffortLevel = session?.effortLevel;
+    // sessions_list carries no permission mode, and the previous session's is
+    // worse than none — the MODE card renders its own fallback.
+    this._detailMode = undefined;
+    // A suggestion belongs to a turn, not to a session row — never seed one.
+    this._detailSuggestedPrompt = undefined;
     this._modelSwitching = false;
     this._prevModelName = undefined;
     this._modelSwitchStartedAt = 0;
-    dlog('SlotMgr', `exitDetailView → list`);
   }
 
   nextPage(layout?: DeckLayout): void {

--- a/shared/src/__tests__/voice-reply-digest.test.ts
+++ b/shared/src/__tests__/voice-reply-digest.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_SPOKEN_CHARS, SPOKEN_DIGEST_MAX_CHARS, SPOKEN_DIGEST_CASES,
+  speakableReply, spokenDigest,
+} from '../voice-reply-digest.js';
+
+describe('spokenDigest parity cases', () => {
+  // The same table drives SpokenDigestParityTests on the Swift side; a case
+  // added here must be added there, which is the point of keeping it exported.
+  it.each(SPOKEN_DIGEST_CASES.map((c) => [c.name, c] as const))('%s', (_name, c) => {
+    expect(spokenDigest(c.input)).toBe(c.expected);
+  });
+});
+
+describe('spokenDigest', () => {
+  it('reads one sentence out of a long answer, not the whole thing', () => {
+    const body = '고쳤습니다. ' + '이유는 여러 가지입니다. '.repeat(40);
+    const out = spokenDigest(body);
+    expect(out).toBe('고쳤습니다.');
+    expect(out.length).toBeLessThan(SPOKEN_DIGEST_MAX_CHARS);
+  });
+
+  it('keeps a summary line even when it is the last thing in the reply', () => {
+    const out = spokenDigest('앞 문장입니다.\n중간 문장입니다.\n결론 — 다시 빌드하면 됩니다.');
+    expect(out).toBe('다시 빌드하면 됩니다.');
+  });
+
+  it('does not treat prose that merely opens with a label word as a summary', () => {
+    // "요약" here is the subject of the sentence, not a heading.
+    const out = spokenDigest('요약 문서는 따로 없습니다. 코드를 보세요.');
+    expect(out).toBe('요약 문서는 따로 없습니다.');
+  });
+
+  it('cuts an over-long single sentence on a word boundary', () => {
+    const sentence = `${'word '.repeat(120).trim()} end`;
+    const out = spokenDigest(sentence);
+    expect(out.length).toBeLessThanOrEqual(SPOKEN_DIGEST_MAX_CHARS);
+    expect(out.endsWith('word')).toBe(true);   // never mid-word
+  });
+
+  it('honours full: true for callers that opted back in', () => {
+    const body = 'First. Second. Third.';
+    expect(spokenDigest(body, { full: true })).toBe(body);
+    expect(spokenDigest(body)).toBe('First.');
+  });
+
+  it('stays empty when there is nothing to say', () => {
+    expect(spokenDigest('')).toBe('');
+    expect(spokenDigest('   \n \n')).toBe('');
+  });
+});
+
+describe('speakableReply', () => {
+  // Unchanged contract — the digest is layered on top rather than replacing it,
+  // so the board/bench paths that want the whole readable answer still can.
+  it('keeps the whole readable answer', () => {
+    const out = speakableReply('Fixed it.\n\n```ts\nconst x = 1;\n```\n\nRun the tests.');
+    expect(out).toContain('Fixed it.');
+    expect(out).toContain('(code)');
+    expect(out).toContain('Run the tests.');
+    expect(out).not.toContain('const x');
+  });
+
+  it('caps at the monologue ceiling', () => {
+    expect(speakableReply('y'.repeat(MAX_SPOKEN_CHARS + 500)).length)
+      .toBeLessThanOrEqual(MAX_SPOKEN_CHARS);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './gateway-protocol.js';
 export * from './command-builders.js';
 export * from './adapter.js';
 export * from './voice-paths.js';
+export * from './voice-reply-digest.js';
 export * from './net-utils.js';
 export * from './timeline.js';
 export * from './subagent-activity.js';

--- a/shared/src/voice-reply-digest.ts
+++ b/shared/src/voice-reply-digest.ts
@@ -1,0 +1,205 @@
+/**
+ * What a spoken reply should actually say.
+ *
+ * SSOT for both daemons: the Node daemon imports these, and
+ * `DaemonServer.speakableReply` / `.spokenDigest` in the Swift daemon mirror
+ * them (parity cases in `SPOKEN_DIGEST_CASES` below are asserted on both sides).
+ *
+ * The distinction that matters: `speakableReply` decides *what is readable*
+ * (strip code fences, markdown scaffolding, URLs), while `spokenDigest` decides
+ * *how much to read*. A written answer and a spoken one are different artifacts
+ * — a 700-character reply is a fine thing to read on screen and a monologue
+ * through a speaker, and the listener cannot skim it. So speech gets the lead:
+ * an explicit summary line when the answer has one, otherwise its first
+ * sentence. The full text stays on the deck and in the terminal, where skimming
+ * works.
+ */
+
+/** A spoken reply past this is a monologue, not an answer. Truncated at a
+ *  sentence boundary when one is near the cap. */
+export const MAX_SPOKEN_CHARS = 700;
+
+/** Ceiling for the digest. Reached only by a single very long sentence — the
+ *  first-sentence rule normally lands far below it. */
+export const SPOKEN_DIGEST_MAX_CHARS = 240;
+
+/**
+ * Openers that mark an author-written summary. Matched at the start of a line,
+ * with or without a separator, in both languages the replies come in.
+ */
+const SUMMARY_LABELS = [
+  '요약', '한 줄 요약', '한줄 요약', '결론', '정리',
+  'TL;DR', 'TLDR', 'Summary', 'In short', 'In summary', 'Bottom line',
+];
+
+/** Sentence enders, including the CJK forms. */
+const TERMINATORS = new Set(['.', '!', '?', '。', '！', '？', '…']);
+
+/**
+ * Strip what makes no sense read aloud and cap at a sentence boundary.
+ * Kept separate from the digest so callers that genuinely want the whole answer
+ * (a board with a screen, a test) can still get it.
+ */
+export function speakableReply(raw: string, maxChars = MAX_SPOKEN_CHARS): string {
+  if (!raw) return '';
+  let text = raw
+    // Fenced blocks read as noise; say so once instead of reciting them.
+    .replace(/```[\s\S]*?```/g, ' (code) ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/https?:\/\/\S+/g, ' link ')
+    .replace(/^\s*(?:#{1,6}|>|[*\-+])\s+/gm, '')
+    .replace(/\*\*|__|~~/g, '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+  if (!text) return '';
+  if (text.length > maxChars) {
+    const head = text.slice(0, maxChars);
+    // Prefer ending on a sentence so the cut doesn't sound like a dropout.
+    const lastStop = Math.max(
+      head.lastIndexOf('. '), head.lastIndexOf('。'),
+      head.lastIndexOf('! '), head.lastIndexOf('? '), head.lastIndexOf('다.'),
+    );
+    text = lastStop > maxChars * 0.5 ? head.slice(0, lastStop + 1) : head;
+  }
+  return text.trim();
+}
+
+/** True when a line ends a sentence — the cheap test for "prose, not a heading". */
+function hasTerminator(line: string): boolean {
+  for (const ch of line) if (TERMINATORS.has(ch)) return true;
+  return false;
+}
+
+/**
+ * The summary a line declares, or null. `요약: 고쳤습니다` yields the remainder;
+ * a bare `요약` line yields '' so the caller can take the line after it.
+ */
+function summaryOnLine(line: string): string | null {
+  for (const label of SUMMARY_LABELS) {
+    if (!line.toLowerCase().startsWith(label.toLowerCase())) continue;
+    const afterLabel = line.slice(label.length);
+    const rest = afterLabel.replace(/^\s*[:：\-—–.]\s*/, '').trim();
+    // "Summarywise …" and "요약 대신 …" are prose, not labels; require a
+    // separator (or end of line) before treating the remainder as the summary.
+    if (rest === afterLabel.trim() && rest !== '' && /^[\p{L}\p{N}_]/u.test(rest)) {
+      continue;
+    }
+    return rest;
+  }
+  return null;
+}
+
+/**
+ * The first sentence of `text`, or all of it when it has no terminator.
+ * Returns the substring rather than an index so the Swift mirror (which counts
+ * Characters, not UTF-16 units) cannot cut a surrogate pair differently.
+ */
+function firstSentence(text: string): string {
+  const chars = Array.from(text);
+  for (let i = 0; i < chars.length; i += 1) {
+    if (!TERMINATORS.has(chars[i])) continue;
+    const next = chars[i + 1];
+    // "1.0" and "v1.2.3" are not sentence ends; a terminator only counts when
+    // what follows is nothing, whitespace, or a closing mark.
+    if (chars[i] === '.' && /\d/.test(chars[i - 1] ?? '') && /\d/.test(next ?? '')) continue;
+    if (next === undefined || /[\s"'”’)\]]/.test(next)) {
+      // Run out any repeated terminators ("!?", "...") so they stay together.
+      let end = i + 1;
+      while (end < chars.length && TERMINATORS.has(chars[end])) end += 1;
+      return chars.slice(0, end).join('');
+    }
+  }
+  return text;
+}
+
+/**
+ * The one thing worth reading aloud out of a full reply: an explicit summary
+ * line if the answer has one, otherwise its first sentence.
+ *
+ * `full: true` restores the whole readable answer for callers that opted out
+ * (daemon setting `voice.speakFullReply`).
+ */
+export function spokenDigest(
+  raw: string,
+  opts: { maxChars?: number; full?: boolean } = {},
+): string {
+  const readable = speakableReply(raw, opts.full ? MAX_SPOKEN_CHARS : Number.MAX_SAFE_INTEGER);
+  if (!readable) return '';
+  if (opts.full) return readable;
+
+  const cap = opts.maxChars ?? SPOKEN_DIGEST_MAX_CHARS;
+  const lines = readable.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+
+  let unit = '';
+  for (let i = 0; i < lines.length; i += 1) {
+    const summary = summaryOnLine(lines[i]);
+    if (summary === null) continue;
+    unit = summary || lines[i + 1] || '';
+    if (unit) break;
+  }
+
+  if (!unit) {
+    // Skip a leading section label ("원인", "Result") when prose follows it:
+    // reading a heading alone tells the listener nothing.
+    let start = 0;
+    while (start < lines.length - 1 && !hasTerminator(lines[start]) && lines[start].length <= 24) {
+      start += 1;
+    }
+    unit = firstSentence(lines[start] ?? '');
+  }
+
+  unit = unit.trim();
+  if (!unit) return '';
+  if (unit.length <= cap) return unit;
+  // A single sentence over the cap: cut on a word boundary, not mid-word.
+  const head = unit.slice(0, cap);
+  const lastSpace = head.lastIndexOf(' ');
+  return (lastSpace > cap * 0.6 ? head.slice(0, lastSpace) : head).trim();
+}
+
+/**
+ * Cross-surface parity table. Asserted by vitest against `spokenDigest` and by
+ * XCTest against the Swift mirror, so the two daemons cannot drift into
+ * speaking different amounts of the same reply.
+ */
+export const SPOKEN_DIGEST_CASES: ReadonlyArray<{
+  name: string; input: string; expected: string;
+}> = [
+  {
+    name: 'first sentence only, not the whole paragraph',
+    input: '원인을 찾았습니다. 헬퍼 바이너리에 Info.plist가 없었습니다. 지금은 고쳤습니다.',
+    expected: '원인을 찾았습니다.',
+  },
+  {
+    name: 'explicit summary label wins over the opening sentence',
+    input: 'VOICE 키가 죽어 있었습니다. 원인은 TCC입니다.\n요약: 헬퍼를 재빌드하면 동작합니다.',
+    expected: '헬퍼를 재빌드하면 동작합니다.',
+  },
+  {
+    name: 'bare summary label takes the line after it',
+    input: 'TL;DR\nThe helper needed a usage description.\nDetails follow.',
+    expected: 'The helper needed a usage description.',
+  },
+  {
+    name: 'a heading-only first line is skipped for the prose under it',
+    input: '## 원인\n번들 헬퍼에 Info.plist가 없었습니다. 그래서 TCC가 죽였습니다.',
+    expected: '번들 헬퍼에 Info.plist가 없었습니다.',
+  },
+  {
+    name: 'code fences never get recited',
+    input: 'Fixed it.\n\n```ts\nconst x = 1;\n```\n',
+    expected: 'Fixed it.',
+  },
+  {
+    name: 'a version number does not end the sentence',
+    input: 'Bumped it to 1.0.2 for the release. Nothing else changed.',
+    expected: 'Bumped it to 1.0.2 for the release.',
+  },
+  {
+    name: 'nothing speakable stays empty',
+    input: '```\ndiff --git a b\n```',
+    expected: '(code)',
+  },
+];


### PR DESCRIPTION
The Stream Deck VOICE key did nothing, and chasing that turned up four
distinct defects — two of which made the feature impossible rather than
degraded. Every claim below was verified against a running daemon on
macOS 26.5.2, not inferred from code.

## What was broken

**1. TCC aborted the CLI daemon's helper instead of prompting it.**
`agentdeck-fm-helper` is a single Mach-O with no app bundle, so it carried no
usage descriptions — and TCC does not deny such a request, it kills the process.
A rebuild on 2026-08-01 changed the helper's cdhash and invalidated the grant
that had been hiding this, so the next press died mid-turn. The crash report
says it outright: `termination.namespace: TCC`,
`NSSpeechRecognitionUsageDescription`. Now the usage strings are linked into an
`__info_plist` section and the binary is ad-hoc signed with a fixed identifier,
so TCC has an identity to hang the grant on and can name the helper in its
prompt. The daemon's source-compiled fallback runs the same build script, and a
bundled binary that predates the plist no longer wins resolution in silence.

**2. Host push-to-talk crashed the app-only (Swift) daemon on every press.**
The `installTap` block inherited `@MainActor` isolation statically; AVFAudio
calls it on its own realtime queue, so the executor assertion the compiler
plants at the block's entry trapped immediately — `SIGTRAP` in
`dispatch_assert_queue` on `RealtimeMessenger.mServiceQueue`. Hopping to the
actor *inside* the block cannot help: the check runs before the first
statement. Same family as the `@convention(c)` rule in CLAUDE.md, so the tap now
lives at file scope over a locked sink.

**3. Dictation followed the bundle's languages, not the user's.**
With the crash fixed, every utterance came back
`kAFAssistantErrorDomain 1110 "No speech detected"`. The audio was fine — the
app's own capture transcribes outside the sandbox — but `Locale.current` for an
app is the intersection of the user's preferred languages with the *bundle's*
localizations, so a Korean user of an English-only app resolves to `en_KR` and
gets an en-US recognizer. **Every non-English user's voice input was dead in
app-only mode.** Preference order is now `voice.locale` →
`Locale.preferredLanguages` → `Locale.current` → en-US, normalized to BCP-47,
and a recognizer whose language differs from the one asked for is refused
(`SFSpeechRecognizer(locale:)` silently resolves elsewhere, which makes a
fallback chain meaningless).

**4. OpenClaw's model was read as a Claude session's model.**
Pressing a Claude session showed `GLM-5.2 (1M)`. Two independent causes: the
Gateway's `model_info` was writing the *global* state machine — one modelName
slot fed by every observed hook, and the hub stamps those broadcasts with the
focused session — and separately the deck's detail cache survived a focus
change, so the previously focused row's model kept rendering when no event
arrived for the new one (an idle or mid-turn session emits nothing). The
Gateway's model now stays in `gatewayModelName`, its own events name their own
row, and `enterDetailView` seeds the cache from the sessions_list row.

Plus: dictation audio no longer survives a crash or force-quit in the sandbox
container — the crash in (2) left two `agentdeck-ptt-*.caf` files behind.

## Also here

A spoken reply is no longer the whole transcript. A 700-character answer is fine
on screen and a minute of monologue through a speaker, and the listener cannot
skim, so `spokenDigest` reads an explicit summary line when the answer has one,
else its first sentence (`voice.speakFullReply` opts back in). The rule is a
shared SSOT with the Swift mirror pinned to an exported parity table.

The diagnostics that made all of this findable are kept: capture
level/format/duration, and which recognizer locale actually got the audio. A
quiet microphone and a wrong-locale recognizer both fail as 1110 — without that
line they are indistinguishable, which is what cost the most time here.

## Verification

- Full vitest suite green on this branch after rebase: 2519 passed, 1 skipped
- Swift parity XCTest green; Apple target compiles against upstream's Codex
  freshness changes in the same file
- Regression tests were confirmed to fail with each fix reverted; the
  build-invariant gate was deliberately broken twice (its first version passed
  with the linker flag renamed, because the string also appears in a comment)
- Live, app-only daemon (no Node): `locale=ko-KR` chosen,
  `PTT: "안녕하세요" -> <session>`
- App Store invariants re-checked on a Release build: no embedded executables,
  no subprocess or companion-install strings, sandbox + audio-input entitlements
  only, no iOS-only plist keys

## Known gap, unchanged by this PR

In app-only mode the transcript is delivered by blocking the target session's
Stop hook, so it lands when that session ends a turn. Dictating to an **idle**
session leaves it queued (`queuedDirectives` badge, TTL 1h) until that session
next completes a turn. The CLI daemon types into the terminal instead and is
immediate. Worth deciding separately whether Tier 1 should say so in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)