### PR TITLE
fix(ulanzi): keep the Marketplace archive to its declared platforms

### DIFF
--- a/scripts/package-ulanzi-plugin.sh
+++ b/scripts/package-ulanzi-plugin.sh
@@ -83,6 +83,22 @@ mkdir -p "$OUT/node_modules"
 cp -R "$TMP/node_modules/." "$OUT/node_modules/"
 rm -rf "$TMP"
 
+# npm also installs the *host* platform's optional binary on top of the five
+# requested above, so a Linux CI runner silently adds resvg-js-linux-x64-gnu —
+# 4.4 MB for a platform manifest.json does not declare. That made the released
+# archive 11.5 MB while a local build was 9.1 MB: same version, different bytes,
+# and the bigger one is the one users would have downloaded. Prune to the
+# declared set so the artifact does not depend on where it was built.
+KEEP="darwin-arm64 darwin-x64 win32-x64-msvc win32-arm64-msvc win32-ia32-msvc"
+for dir in "$OUT"/node_modules/@resvg/resvg-js-*; do
+  [ -d "$dir" ] || continue
+  target="$(basename "$dir" | sed 's/^resvg-js-//')"
+  case " $KEEP " in
+    *" $target "*) ;;
+    *) echo "    prune @resvg/resvg-js-$target (not a declared platform)"; rm -rf "$dir" ;;
+  esac
+done
+
 echo "==> verify"
 node -e "const fs=require('fs');const p='$OUT';
   for (const f of ['manifest.json','plugin/app.js','plugin/package.json']) if(!fs.existsSync(p+'/'+f)) throw new Error('missing '+f);
@@ -95,6 +111,11 @@ node -e "const fs=require('fs');const p='$OUT';
     if(!fs.existsSync(dir)) throw new Error('missing resvg target '+target);
     if(!require('child_process').execSync('find '+dir+' -name *.node').toString().trim()) throw new Error('missing native binary '+target);
   }
+  // The prune above must leave EXACTLY the declared set: an extra host-platform
+  // binary is what made a CI archive differ from a local one by 4.4 MB.
+  const present=fs.readdirSync(nm+'/@resvg').filter(d=>d.startsWith('resvg-js-')).map(d=>d.slice('resvg-js-'.length)).sort();
+  const extra=present.filter(t=>!targets.includes(t));
+  if(extra.length) throw new Error('undeclared platform binary in package: '+extra.join(', '));
   console.log('OK — bundle '+(fs.statSync(p+'/plugin/app.js').size/1024|0)+'KB, resvg targets: '+targets.join(', '));
 "
 echo "==> packaged at: $OUT"


### PR DESCRIPTION
The `ulanzi-v1.0.2` release asset came out **11.5 MB**; the same commit packaged locally produced **9.1 MB**. The difference is a 4.4 MB `@resvg/resvg-js-linux-x64-gnu` binary.

The script asks npm for five explicit mac/windows targets, and npm installs the **host platform's** optional binary on top of them — so a Linux CI runner ships a platform `manifest.json` does not declare (`OS: mac, windows`).

That is two problems:

1. **The artifact depends on where it was built.** Same commit, different bytes.
2. **The wrong one is the one users get.** The local build is never what anyone downloads; the CI archive is.

It also pushed the archive over the 10 MB limit of the tooling used to upload it, which is how it was noticed.

## Fix

- Prune `node_modules/@resvg/resvg-js-*` to the declared set after install.
- `verify` now fails on **any undeclared target**, not just on a missing expected one — the previous check could only catch absence, never surplus.

Verified by neutering the prune and planting a linux binary: verify exits 1 and names the offender.

`ulanzi-v1.0.2` will be re-cut from this commit so the released archive matches what the manifest promises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)