### PR TITLE
fix(devices): let the BLE panels say whether they are actually connected

### DIFF
--- a/apple/AgentDeck/UI/MenuBar/ControlTowerPanel.swift
+++ b/apple/AgentDeck/UI/MenuBar/ControlTowerPanel.swift
@@ -47,6 +47,11 @@ struct ControlTowerPanel: View {
     /// maxHeight, which surfaces a scrollbar even when content fits.
     @State private var measuredContentHeight: CGFloat = 0
 
+    /// Room the popup window actually has, measured from its own top edge down
+    /// to the bottom of *its* screen's usable area. 0 until the hosting window
+    /// exists, which falls `availablePanelHeight` back to the screen estimate.
+    @State private var measuredAvailableHeight: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0) {
             // Header: Attention Theater when any session awaits input,
@@ -107,6 +112,11 @@ struct ControlTowerPanel: View {
                 .measureChromeHeight()
         }
         .frame(minWidth: 380, idealWidth: 420, maxWidth: 460)
+        .background(PanelAvailableHeightReader { height in
+            // Ignore sub-point jitter: this feeds the ScrollView cap, which
+            // resizes the window, and a 0.5pt oscillation would relayout forever.
+            if abs(height - measuredAvailableHeight) > 1 { measuredAvailableHeight = height }
+        })
         // Dark ocean theme matching Dashboard / Monitor HUD.
         // `deepSea` → `midWater` gives the popup a subtle gradient so the
         // top edge reads as shallower water and the bottom reads as the
@@ -233,20 +243,36 @@ struct ControlTowerPanel: View {
     /// the cap, the ScrollView reports its content's natural height (via
     /// `fixedSize(vertical: true)`) so the panel shrinks to fit when
     /// devices are sparse.
+    /// Vertical room the popup has to lay itself out in.
+    ///
+    /// Measured from the hosting window's own top edge, NOT from a screen
+    /// height. `NSScreen.main` is the screen holding the *key window*, which on
+    /// a multi-display desk is routinely not the screen the menubar popup opened
+    /// on — sizing the body against a taller neighbouring display is what pushed
+    /// the footer's "Start at Login / Quit" row off the bottom edge. Measuring
+    /// the window also folds in the menu-bar gap and the popup's own top inset,
+    /// neither of which a screen height accounts for.
+    ///
+    /// Falls back to the screen estimate only for the first frame, before the
+    /// hosting window exists.
+    private var availablePanelHeight: CGFloat {
+        if measuredAvailableHeight > 0 { return measuredAvailableHeight }
+        return NSScreen.main?.visibleFrame.height ?? 900
+    }
+
     private var scrollContentMaxHeight: CGFloat {
-        let screenHeight = NSScreen.main?.visibleFrame.height ?? 900
         // First frame may render before PreferenceKey lands — fall back to
         // the legacy 140pt reserve so the popup never starts overflowing.
         let chrome = max(140, measuredChromeHeight)
-        // Visual cushion against the visibleFrame edge (Dock auto-hide,
-        // multi-display chrome).
+        // Visual cushion against the bottom edge (popup corner radius/shadow
+        // inset, Dock auto-hide reveal strip).
         let safety: CGFloat = 24
         // Low floor (80pt ≈ one session row visible). When chrome is huge
         // — AttentionTheater with many options + DaemonOfflineBanner —
         // the body shrinks and scrolls internally instead of pushing the
         // popup past the screen edge. The previous 360pt floor stacked
         // with the AttentionTheater options cap to exceed visibleFrame.
-        return max(80, screenHeight - chrome - safety)
+        return max(80, availablePanelHeight - chrome - safety)
     }
 
     // MARK: - Session Classification
@@ -1146,6 +1172,35 @@ private struct ContentHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+/// Reports how much vertical room the hosting popup window actually has:
+/// from its own top edge down to the bottom of its screen's usable area.
+///
+/// The menubar popup is anchored under the menu bar, so `frame.maxY` is stable
+/// as the content resizes — no feedback loop with the height it feeds. Reading
+/// `window.screen` (rather than `NSScreen.main`) is the point: it is the screen
+/// the popup actually opened on.
+private struct PanelAvailableHeightReader: NSViewRepresentable {
+    let onChange: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        // The window is not attached yet during makeNSView.
+        DispatchQueue.main.async { report(from: view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { report(from: nsView) }
+    }
+
+    private func report(from view: NSView) {
+        guard let window = view.window, let screen = window.screen else { return }
+        let available = window.frame.maxY - screen.visibleFrame.minY
+        guard available > 0 else { return }
+        onChange(available)
     }
 }
 

--- a/bridge/src/__tests__/ble-sync-status.test.ts
+++ b/bridge/src/__tests__/ble-sync-status.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createBleLinkTracker, mergeBleLinkSnapshots } from '../ble-sync-status.js';
+import { parseStatusLine, BLE_STATUS_LINE_PREFIX } from '../ble-sync-spawn.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('parseStatusLine', () => {
+  it('parses an AGENTDECK_STATUS line', () => {
+    const line = `${BLE_STATUS_LINE_PREFIX}{"connected":true,"phase":"streaming","hasFrame":true,"dimmed":false,"error":null}`;
+    expect(parseStatusLine(line)).toEqual({
+      connected: true,
+      phase: 'streaming',
+      hasFrame: true,
+      dimmed: false,
+      error: null,
+    });
+  });
+
+  it('rejects a non-status line and malformed JSON', () => {
+    expect(parseStatusLine('Frame sent (abc @ 100%)')).toBeNull();
+    expect(parseStatusLine(`${BLE_STATUS_LINE_PREFIX}{not json`)).toBeNull();
+    // An array is valid JSON but not a status payload.
+    expect(parseStatusLine(`${BLE_STATUS_LINE_PREFIX}[1,2]`)).toBeNull();
+  });
+});
+
+describe('createBleLinkTracker', () => {
+  it('reports "sync not started" before anything is spawned', () => {
+    const t = createBleLinkTracker();
+    const s = t.snapshot(1);
+    expect(s.connected).toBe(false);
+    expect(s.statusReason).toBe('sync not started');
+  });
+
+  it('reports no device when nothing is configured', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    expect(t.snapshot(0).statusReason).toBe('no device configured');
+  });
+
+  it('goes connected on a streaming status line — the regression this fixes', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    // Before the status-line contract existed the supervisor had nothing to fold
+    // in here, so a happily streaming panel reported connected:false forever and
+    // every dashboard drew it as disconnected.
+    t.applyStatusLine({ connected: true, phase: 'streaming', hasFrame: true, dimmed: false, error: null });
+    const s = t.snapshot(1);
+    expect(s.connected).toBe(true);
+    expect(s.hasFrame).toBe(true);
+    expect(s.statusReason).toBe('connected');
+    expect(s.lastPushAtMs).not.toBeNull();
+  });
+
+  it('distinguishes host-display pause from a dead link', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    t.applyStatusLine({ connected: true, phase: 'streaming', hasFrame: true, dimmed: true, error: null });
+    const s = t.snapshot(1);
+    expect(s.connected).toBe(true);
+    expect(s.displayDimmed).toBe(true);
+    expect(s.statusReason).toBe('paused: host display asleep');
+  });
+
+  it('keeps hasFrame sticky across a disconnect and surfaces the error', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    t.applyStatusLine({ connected: true, phase: 'streaming', hasFrame: true, dimmed: false, error: null });
+    t.applyStatusLine({ connected: false, phase: 'disconnected', hasFrame: true, dimmed: false, error: 'BLE link lost' });
+    const s = t.snapshot(1);
+    expect(s.connected).toBe(false);
+    expect(s.hasFrame).toBe(true);
+    expect(s.lastError).toBe('BLE link lost');
+    expect(s.statusReason).toBe('BLE link lost');
+  });
+
+  it('clears a stale error once the client recovers', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    t.applyStatusLine({ connected: false, phase: 'error', hasFrame: false, dimmed: false, error: 'BLE connection error: timeout' });
+    t.applyStatusLine({ connected: true, phase: 'connected', hasFrame: false, dimmed: false, error: null });
+    const s = t.snapshot(1);
+    expect(s.lastError).toBeNull();
+    expect(s.statusReason).toBe('connected');
+  });
+
+  it('reports the backoff window after an exit, then falls back to connecting', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-05T00:00:00Z'));
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    // A bare exit with no captured output must still explain itself.
+    t.noteExit(null, Date.now() + 5_000);
+    expect(t.snapshot(1).statusReason).toBe('retrying (backed off)');
+    vi.advanceTimersByTime(6_000);
+    expect(t.snapshot(1).statusReason).toBe('connecting…');
+  });
+
+  it('surfaces a missing BLE runtime instead of an unexplained disconnect', () => {
+    const t = createBleLinkTracker();
+    t.noteUnavailable('BLE sync unavailable: venv missing');
+    expect(t.snapshot(1).statusReason).toBe('BLE sync unavailable: venv missing');
+  });
+
+  it('a respawn clears the connected flag until the child reports again', () => {
+    const t = createBleLinkTracker();
+    t.noteSpawn();
+    t.applyStatusLine({ connected: true, phase: 'streaming', hasFrame: true, dimmed: true, error: null });
+    t.noteSpawn();
+    const s = t.snapshot(1);
+    expect(s.connected).toBe(false);
+    expect(s.displayDimmed).toBe(false);
+  });
+});
+
+describe('mergeBleLinkSnapshots', () => {
+  const snap = (over: Partial<ReturnType<ReturnType<typeof createBleLinkTracker>['snapshot']>>) => ({
+    connected: true,
+    hasFrame: true,
+    displayDimmed: false,
+    statusReason: 'connected',
+    lastError: null,
+    lastPushAtMs: 1000,
+    ...over,
+  });
+
+  it('is connected only when every panel is', () => {
+    expect(mergeBleLinkSnapshots([snap({}), snap({})], 2).connected).toBe(true);
+    const mixed = mergeBleLinkSnapshots(
+      [snap({}), snap({ connected: false, statusReason: 'BLE link lost', lastError: 'BLE link lost' })],
+      2,
+    );
+    expect(mixed.connected).toBe(false);
+    expect(mixed.statusReason).toBe('BLE link lost');
+  });
+
+  it('reports no-device state when there are no trackers yet', () => {
+    const merged = mergeBleLinkSnapshots([], 0);
+    expect(merged.connected).toBe(false);
+    expect(merged.statusReason).toBe('no device configured');
+  });
+
+  it('takes the newest push time across panels', () => {
+    const merged = mergeBleLinkSnapshots([snap({ lastPushAtMs: 10 }), snap({ lastPushAtMs: 99 })], 2);
+    expect(merged.lastPushAtMs).toBe(99);
+  });
+});

--- a/bridge/src/ble-sync-spawn.ts
+++ b/bridge/src/ble-sync-spawn.ts
@@ -12,6 +12,7 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
+import type { BleStatusLine } from './ble-sync-status.js';
 
 export interface ManagedSyncChild {
   proc: ChildProcess;
@@ -22,14 +23,40 @@ export interface ManagedSyncChild {
 }
 
 /**
+ * Machine-readable status lines the sync clients print on every BLE link state
+ * change. Emitted by `StatusReporter` in `pysync/matrix_sync_common.py` — the
+ * two must agree on this prefix.
+ */
+export const BLE_STATUS_LINE_PREFIX = 'AGENTDECK_STATUS ';
+
+export interface SpawnPythonSyncOptions {
+  /** Ring size for the diagnostic stdout/stderr tails. */
+  maxTailLines?: number;
+  /**
+   * Called for each `AGENTDECK_STATUS` line the child prints. These lines are
+   * the *only* window Node has into the BLE link (the clients reconnect inside
+   * their own loop, so the child staying alive proves nothing).
+   */
+  onStatus?: (payload: BleStatusLine) => void;
+}
+
+/**
  * Spawn a Python sync child with stdout/stderr captured into bounded tail
- * buffers. Output is not streamed live; callers read it only if the child exits.
+ * buffers. Output is not streamed live; callers read it only if the child exits
+ * — except `AGENTDECK_STATUS` lines, which are parsed and dispatched live to
+ * `onStatus` and kept *out* of the tails (they are state, not diagnostics, and
+ * letting them into the tail would make every reconnect look like a new exit
+ * cycle to `createSyncCycleSquelch`).
  */
 export function spawnPythonSync(
   venvPython: string,
   args: string[],
-  maxTailLines = 8,
+  options: SpawnPythonSyncOptions | number = {},
 ): ManagedSyncChild {
+  const opts: SpawnPythonSyncOptions =
+    typeof options === 'number' ? { maxTailLines: options } : options;
+  const maxTailLines = opts.maxTailLines ?? 8;
+  const onStatus = opts.onStatus;
   // [stdin ignored, stdout/stderr piped into small rings for diagnostics]
   const proc = spawn(venvPython, args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
 
@@ -46,6 +73,15 @@ export function spawnPythonSync(
     for (const line of lines) {
       const trimmed = line.trimEnd();
       if (!trimmed) continue;
+      if (onStatus && trimmed.startsWith(BLE_STATUS_LINE_PREFIX)) {
+        const parsed = parseStatusLine(trimmed);
+        // A malformed line is a client bug, not link state — drop it into the
+        // diagnostic tail rather than silently swallowing it.
+        if (parsed) {
+          onStatus(parsed);
+          continue;
+        }
+      }
       const tagged = `${label}: ${trimmed}`;
       outputTail.push(tagged);
       if (outputTail.length > maxTailLines) outputTail.shift();
@@ -74,6 +110,18 @@ export function spawnPythonSync(
       return lines.slice(-maxTailLines).join(' | ');
     },
   };
+}
+
+/** Parse one `AGENTDECK_STATUS {...}` line; null when it isn't valid JSON. */
+export function parseStatusLine(line: string): BleStatusLine | null {
+  if (!line.startsWith(BLE_STATUS_LINE_PREFIX)) return null;
+  try {
+    const value: unknown = JSON.parse(line.slice(BLE_STATUS_LINE_PREFIX.length));
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    return value as BleStatusLine;
+  } catch {
+    return null;
+  }
 }
 
 /** Emit a repeated-cycle summary at most this often while suppressing. */

--- a/bridge/src/ble-sync-status.ts
+++ b/bridge/src/ble-sync-status.ts
@@ -1,0 +1,198 @@
+/**
+ * Live link state for the daemon-managed Python BLE sync clients
+ * (iDotMatrix `sync.py`, Timebox `sync_ble.py`).
+ *
+ * The Node daemon spawns these clients but cannot see the BLE link: both
+ * scripts reconnect *inside* their own loop, so the child process stays alive
+ * across a powered-off panel and "process running" says nothing about whether
+ * anything is being driven. Node therefore reported only the configured device
+ * list in `/health`, and every consumer that renders `BLEMatrixHealth.connected`
+ * — the macOS menubar topology list, the Dashboard TopologyRail, the TUI —
+ * drew both panels as disconnected forever while they were streaming happily.
+ *
+ * The clients now print one `AGENTDECK_STATUS {...}` line per state *change*
+ * (see `pysync/matrix_sync_common.py`); this module folds those into the same
+ * `{connected, statusReason, displayDimmed, hasFrame, lastError}` shape the
+ * Swift daemon's `TimeboxModule.refreshShadow()` / `IDotMatrixModule` emit, so
+ * the two daemons can't disagree about why a panel isn't streaming.
+ *
+ * `statusReason` wording is mirrored from `TimeboxModule.currentStatusReason()`
+ * (Swift) — keep the two in step, `MenuBarTopologyList.bleMatrixStatus()`
+ * keys its LED colour off the words "paused" / "connecting" / "retry".
+ */
+
+/** One BLE panel's live link state, in the `BLEMatrixHealth` wire shape. */
+export interface BleLinkSnapshot {
+  connected: boolean;
+  hasFrame: boolean;
+  displayDimmed: boolean;
+  statusReason: string;
+  lastError: string | null;
+  lastPushAtMs: number | null;
+}
+
+/** Parsed `AGENTDECK_STATUS` payload from a sync client. */
+export interface BleStatusLine {
+  connected?: unknown;
+  phase?: unknown;
+  hasFrame?: unknown;
+  dimmed?: unknown;
+  error?: unknown;
+}
+
+export interface BleLinkTracker {
+  /** Fold one parsed `AGENTDECK_STATUS` line from the child into the state. */
+  applyStatusLine(payload: BleStatusLine): void;
+  /** The supervisor is (re)spawning the child — link state is unknown again. */
+  noteSpawn(): void;
+  /** The child exited; `retryAtMs` is when the supervisor will respawn it. */
+  noteExit(reason: string | null, retryAtMs: number | null): void;
+  /** No child at all (BLE runtime missing, sync never started). */
+  noteUnavailable(reason: string): void;
+  /** Current state, given how many devices are configured right now. */
+  snapshot(configuredDeviceCount: number): BleLinkSnapshot;
+}
+
+function asBool(value: unknown): boolean {
+  return value === true;
+}
+
+function asText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function createBleLinkTracker(): BleLinkTracker {
+  let connected = false;
+  // Sticky: a panel that has been painted once still has our frame on it while
+  // the link is down, which is exactly what `hasFrame` means to the renderers.
+  let hasFrame = false;
+  let displayDimmed = false;
+  let lastError: string | null = null;
+  let lastPushAtMs: number | null = null;
+  let retryAtMs: number | null = null;
+  /** Set while no child is running at all — distinct from "child up, link down". */
+  let unavailableReason: string | null = null;
+  let everSpawned = false;
+
+  return {
+    applyStatusLine(payload: BleStatusLine): void {
+      unavailableReason = null;
+      connected = asBool(payload.connected);
+      if (asBool(payload.hasFrame)) {
+        hasFrame = true;
+        lastPushAtMs = Date.now();
+      }
+      displayDimmed = asBool(payload.dimmed);
+      // Explicit null clears a stale error once the client recovers — the
+      // client always sends the key, so absence here only means a legacy
+      // client, and retaining is the safer read for that case.
+      if ('error' in payload) lastError = asText(payload.error);
+      if (connected) retryAtMs = null;
+    },
+    noteSpawn(): void {
+      everSpawned = true;
+      unavailableReason = null;
+      retryAtMs = null;
+      connected = false;
+      displayDimmed = false;
+    },
+    noteExit(reason: string | null, nextRetryAtMs: number | null): void {
+      connected = false;
+      displayDimmed = false;
+      lastError = asText(reason);
+      retryAtMs = nextRetryAtMs;
+    },
+    noteUnavailable(reason: string): void {
+      connected = false;
+      displayDimmed = false;
+      unavailableReason = reason;
+      retryAtMs = null;
+    },
+    snapshot(configuredDeviceCount: number): BleLinkSnapshot {
+      return {
+        connected,
+        hasFrame,
+        displayDimmed,
+        lastError,
+        lastPushAtMs,
+        statusReason: reasonFor({
+          configuredDeviceCount,
+          connected,
+          displayDimmed,
+          lastError,
+          retryAtMs,
+          unavailableReason,
+          everSpawned,
+        }),
+      };
+    },
+  };
+}
+
+interface ReasonInput {
+  configuredDeviceCount: number;
+  connected: boolean;
+  displayDimmed: boolean;
+  lastError: string | null;
+  retryAtMs: number | null;
+  unavailableReason: string | null;
+  everSpawned: boolean;
+}
+
+/**
+ * Human-readable reason the panel isn't streaming, so `/health` can tell
+ * "device off", "paused while the host display sleeps" and "never attempted"
+ * apart instead of an ambiguous `connected:false, lastError:null`.
+ * Mirrors `TimeboxModule.currentStatusReason()` in the Swift daemon.
+ */
+export function reasonFor(input: ReasonInput): string {
+  if (input.configuredDeviceCount === 0) return 'no device configured';
+  if (input.connected) return input.displayDimmed ? 'paused: host display asleep' : 'connected';
+  if (input.unavailableReason) return input.unavailableReason;
+  if (input.lastError) return input.lastError;
+  if (input.retryAtMs !== null && Date.now() < input.retryAtMs) return 'retrying (backed off)';
+  if (!input.everSpawned) return 'sync not started';
+  return 'connecting…';
+}
+
+/**
+ * Fold several per-device trackers into the single module-level
+ * `BLEMatrixHealth` the wire carries. `connected` is all-or-nothing so a
+ * two-panel setup with one dead panel doesn't read as fully healthy, and the
+ * surfaced reason is the first unhappy panel's.
+ */
+export function mergeBleLinkSnapshots(
+  snapshots: BleLinkSnapshot[],
+  configuredDeviceCount: number,
+): BleLinkSnapshot {
+  if (snapshots.length === 0) {
+    return {
+      connected: false,
+      hasFrame: false,
+      displayDimmed: false,
+      lastError: null,
+      lastPushAtMs: null,
+      statusReason: reasonFor({
+        configuredDeviceCount,
+        connected: false,
+        displayDimmed: false,
+        lastError: null,
+        retryAtMs: null,
+        unavailableReason: null,
+        everSpawned: false,
+      }),
+    };
+  }
+  const unhappy = snapshots.find((s) => !s.connected);
+  const pushes = snapshots.map((s) => s.lastPushAtMs).filter((v): v is number => v !== null);
+  return {
+    connected: unhappy === undefined,
+    hasFrame: snapshots.some((s) => s.hasFrame),
+    displayDimmed: snapshots.every((s) => s.displayDimmed),
+    lastError: snapshots.find((s) => s.lastError !== null)?.lastError ?? null,
+    lastPushAtMs: pushes.length > 0 ? Math.max(...pushes) : null,
+    statusReason: (unhappy ?? snapshots[0]).statusReason,
+  };
+}

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -938,8 +938,16 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
   if (timebox?.statusSnapshot) {
     modules.timebox = timebox.statusSnapshot();
   } else if (configuredTimebox.length > 0) {
+    // Configured but the module never started — say so explicitly. An omitted
+    // `connected` reads as "no information" to retain-on-absent clients, and a
+    // panel nobody is driving must not inherit a stale connected:true.
     modules.timebox = {
       configuredDeviceCount: configuredTimebox.length,
+      connected: false,
+      statusReason: 'sync module not started',
+      displayDimmed: false,
+      hasFrame: false,
+      lastError: null,
       devices: configuredTimebox.map((d) => ({
         address: d.address,
         name: d.name ?? 'Timebox Mini',
@@ -955,8 +963,14 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
   if (idotmatrix?.statusSnapshot) {
     modules.idotmatrix = idotmatrix.statusSnapshot();
   } else if (configuredIDotMatrix.length > 0) {
+    // Configured but the module never started — see the Timebox note above.
     modules.idotmatrix = {
       configuredDeviceCount: configuredIDotMatrix.length,
+      connected: false,
+      statusReason: 'sync module not started',
+      displayDimmed: false,
+      hasFrame: false,
+      lastError: null,
       devices: configuredIDotMatrix.map((d) => ({
         address: d.address,
         name: d.name ?? 'iDotMatrix',

--- a/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
+++ b/bridge/src/idotmatrix/idotmatrix-daemon-sync.ts
@@ -19,6 +19,7 @@
 import { type ChildProcess } from 'child_process';
 import { loadIDotMatrixDevices, type IDotMatrixDevice } from './idotmatrix-settings.js';
 import { createSyncCycleSquelch, spawnPythonSync, terminateSyncChild } from '../ble-sync-spawn.js';
+import { createBleLinkTracker, type BleLinkSnapshot } from '../ble-sync-status.js';
 import { getBleRuntimeStatus } from '../python-ble-runtime.js';
 
 let child: ChildProcess | null = null;
@@ -26,6 +27,8 @@ let stopping = false;
 let respawnTimer: ReturnType<typeof setTimeout> | null = null;
 let consecutiveFailures = 0;
 let startedAt = 0;
+/** Live BLE link state, fed by the child's `AGENTDECK_STATUS` lines. */
+const link = createBleLinkTracker();
 /** Address+brightness of the device the running child is driving (for reload-on-change). */
 let runningKey: string | null = null;
 
@@ -75,6 +78,9 @@ export function startIDotMatrixSync(httpPort: number): void {
   const runtime = getBleRuntimeStatus();
   if (!runtime.ready || !runtime.python) {
     log(`BLE sync unavailable (${runtime.reason}); run \`agentdeck ble setup\``);
+    // Record *why* nothing is driving the panel so /health can say so instead
+    // of reporting an unexplained `connected:false`.
+    link.noteUnavailable(`BLE sync unavailable: ${runtime.reason}`);
     return;
   }
 
@@ -93,13 +99,16 @@ function spawnSync(venvPython: string, syncScript: string, httpPort: number): vo
   squelch.logStart(`Starting BLE sync for ${device.name ?? addr} (bridge ${url}, brightness ${brightness}%)`);
   startedAt = Date.now();
   runningKey = deviceKey(device);
+  link.noteSpawn();
   // iDotMatrix software brightness boost canonical = 1.22 — keep in sync:
   // sync.py (run_sync boost default), IDotMatrixModule.swift (boostBrightnessContrast).
   // stdout/stderr are captured into small rings so clean exits and crashes both
   // leave enough context without flooding the daemon log while running.
-  const { proc, stderrTail, outputTail } = spawnPythonSync(venvPython, [
-    syncScript, '-a', addr, '-u', url, '-b', String(brightness), '--boost', '1.22',
-  ]);
+  const { proc, stderrTail, outputTail } = spawnPythonSync(
+    venvPython,
+    [syncScript, '-a', addr, '-u', url, '-b', String(brightness), '--boost', '1.22'],
+    { onStatus: (payload) => link.applyStatusLine(payload) },
+  );
   child = proc;
 
   proc.on('error', (err: Error) => {
@@ -119,6 +128,7 @@ function spawnSync(venvPython: string, syncScript: string, httpPort: number): vo
     const delay = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * consecutiveFailures);
     const tail = stderrTail() || outputTail();
     const why = tail ? `; output: ${tail}` : '';
+    link.noteExit(tail || `BLE sync exited (code=${code} signal=${signal})`, Date.now() + delay);
     squelch.logExit(
       code,
       signal,
@@ -149,6 +159,7 @@ export async function stopIDotMatrixSync(awaitFarewell = false): Promise<void> {
   const proc = child;
   child = null;
   runningKey = null;
+  link.noteUnavailable('BLE sync stopped');
   if (!proc) return;
   if (awaitFarewell) {
     await terminateSyncChild(proc);
@@ -159,4 +170,14 @@ export async function stopIDotMatrixSync(awaitFarewell = false): Promise<void> {
       /* already gone */
     }
   }
+}
+
+/**
+ * Live link state for the configured iDotMatrix panel, in the `BLEMatrixHealth`
+ * wire shape. Called by `IDotMatrixModule.statusSnapshot()` so `/health` reports
+ * whether the panel is actually being driven — the configured-device list alone
+ * left every dashboard drawing a streaming panel as disconnected.
+ */
+export function idotMatrixLinkSnapshot(configuredDeviceCount: number): BleLinkSnapshot {
+  return link.snapshot(configuredDeviceCount);
 }

--- a/bridge/src/idotmatrix/sync.py
+++ b/bridge/src/idotmatrix/sync.py
@@ -21,6 +21,7 @@ from matrix_sync_common import (  # noqa: E402
     DEFAULT_URL,
     POLL_INTERVAL,
     BRIDGE_GONE_EXIT_SEC,
+    StatusReporter,
     fetch_display_state as _fetch_display_state_sync,
     bridge_reachable as _bridge_reachable_sync,
     resolve_display_brightness as _resolve_display_brightness_common,
@@ -124,7 +125,13 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
     print(f"AgentDeck Bridge API URL: {url}")
     print(f"Initial Hardware Brightness: {brightness}%")
     print(f"Software Brightness Boost: {boost}x")
-    
+
+    # Machine-readable link state for the daemon supervisor — it spawns us but
+    # cannot see the BLE link, and we reconnect inside this loop rather than
+    # exiting, so process liveness tells it nothing about whether the panel is
+    # actually being driven.
+    status = StatusReporter()
+
     manager = ConnectionManager()
     
     idm_image = IdmImage()
@@ -187,8 +194,10 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
             # 1. Ensure bluetooth connection
             if not connected:
                 print(f"Connecting to iDotMatrix ({address})...")
+                status.connecting()
                 await manager.connectByAddress(address)
                 print("Connected to Bluetooth device!")
+                status.connected()
 
                 # Settle: the panel drops commands sent too soon after the GATT
                 # link comes up. Without this the first setBrightness is lost on a
@@ -227,6 +236,7 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
             # bleak's is_connected reflects the real OS-level link state.
             if manager.client is None or not manager.client.is_connected:
                 print("BLE link lost — reconnecting...")
+                status.disconnected("BLE link lost")
                 connected = False
                 last_hash = ""
                 await _interruptible_sleep(stop_event, 1.0)
@@ -274,6 +284,7 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
                 last_brightness_assert = time.monotonic()
 
             if display_dimmed:
+                status.streaming(dimmed=True)
                 await _interruptible_sleep(stop_event, POLL_INTERVAL)
                 continue
 
@@ -302,6 +313,7 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
             current_hash = hashlib.sha256(frame_data).hexdigest()
             if current_hash == last_hash:
                 # Frame didn't change, skip BLE transmission to save battery and bandwidth
+                status.streaming()
                 await _interruptible_sleep(stop_event, POLL_INTERVAL)
                 continue
                 
@@ -332,8 +344,10 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
             if res:
                 last_hash = current_hash
                 print("Frame uploaded successfully.")
+                status.frame_sent()
             else:
                 print("Failed to upload frame (uploadUnprocessed returned False).")
+                status.disconnected("frame upload failed")
 
             await _interruptible_sleep(stop_event, POLL_INTERVAL)
 
@@ -343,6 +357,7 @@ async def run_sync(address: str, url: str, brightness: int = 100, boost: float =
         except Exception as e:
             print(f"Error during loop: {e}")
             print("Resetting bluetooth connection...")
+            status.failed(e)
             connected = False
             try:
                 await manager.disconnect()

--- a/bridge/src/modules/idotmatrix-module.ts
+++ b/bridge/src/modules/idotmatrix-module.ts
@@ -3,7 +3,11 @@ import {
   loadIDotMatrixDevices,
   isIDotMatrixAutoDiscoverEnabled,
 } from '../idotmatrix/idotmatrix-settings.js';
-import { startIDotMatrixSync, stopIDotMatrixSync } from '../idotmatrix/idotmatrix-daemon-sync.js';
+import {
+  idotMatrixLinkSnapshot,
+  startIDotMatrixSync,
+  stopIDotMatrixSync,
+} from '../idotmatrix/idotmatrix-daemon-sync.js';
 import { autoDiscoverIDotMatrix } from '../idotmatrix/idotmatrix-discover.js';
 
 export class IDotMatrixModule implements DeviceModule {
@@ -37,8 +41,19 @@ export class IDotMatrixModule implements DeviceModule {
 
   statusSnapshot(): Record<string, unknown> {
     const devices = loadIDotMatrixDevices();
+    // The live link fields come from the spawned sync client's status lines;
+    // without them every consumer of `BLEMatrixHealth.connected` drew a
+    // streaming panel as disconnected. Same shape the Swift daemon emits.
+    const link = idotMatrixLinkSnapshot(devices.length);
     return {
       configuredDeviceCount: devices.length,
+      connected: link.connected,
+      deviceName: devices[0]?.name ?? devices[0]?.address ?? null,
+      statusReason: link.statusReason,
+      displayDimmed: link.displayDimmed,
+      hasFrame: link.hasFrame,
+      lastError: link.lastError,
+      lastPushAtMs: link.lastPushAtMs,
       devices: devices.map((d) => ({
         id: d.address,
         transport: 'ble',

--- a/bridge/src/modules/timebox-module.ts
+++ b/bridge/src/modules/timebox-module.ts
@@ -4,7 +4,7 @@ import {
   deviceId,
   isTimeboxAutoDiscoverEnabled,
 } from '../timebox/timebox-settings.js';
-import { startTimeboxSync, stopTimeboxSync } from '../timebox/timebox-daemon-sync.js';
+import { startTimeboxSync, stopTimeboxSync, timeboxLinkSnapshot } from '../timebox/timebox-daemon-sync.js';
 import { autoDiscoverTimebox } from '../timebox/timebox-discover.js';
 
 export class TimeboxModule implements DeviceModule {
@@ -38,8 +38,19 @@ export class TimeboxModule implements DeviceModule {
 
   statusSnapshot(): Record<string, unknown> {
     const devices = loadTimeboxDevices();
+    // The live link fields come from the spawned sync clients' status lines;
+    // without them every consumer of `BLEMatrixHealth.connected` drew a
+    // streaming panel as disconnected. Same shape the Swift daemon emits.
+    const link = timeboxLinkSnapshot(devices.length);
     return {
       configuredDeviceCount: devices.length,
+      connected: link.connected,
+      deviceName: devices[0]?.name ?? devices[0]?.address ?? null,
+      statusReason: link.statusReason,
+      displayDimmed: link.displayDimmed,
+      hasFrame: link.hasFrame,
+      lastError: link.lastError,
+      lastPushAtMs: link.lastPushAtMs,
       devices: devices.map((d) => ({
         id: deviceId(d),
         transport: 'ble',

--- a/bridge/src/pysync/matrix_sync_common.py
+++ b/bridge/src/pysync/matrix_sync_common.py
@@ -10,6 +10,7 @@ so this module must stay dependency-free beyond the stdlib.
 """
 
 import json
+import sys
 import urllib.request
 
 DEFAULT_URL = "http://127.0.0.1:9120"
@@ -87,3 +88,85 @@ def resolve_display_brightness(display_state, normal_brightness, *, off_floor, l
     if display_on or not dim_enabled:
         return normal_brightness, False, signature, dim_mode
     return (dim_level if dim_mode == "min" else off_floor), True, signature, dim_mode
+
+
+# ---------------------------------------------------------------------------
+# Link status reporting
+# ---------------------------------------------------------------------------
+
+# Prefix of the machine-readable status lines the daemon supervisor parses.
+# Mirrored in bridge/src/ble-sync-spawn.ts (`BLE_STATUS_LINE_PREFIX`).
+STATUS_LINE_PREFIX = "AGENTDECK_STATUS "
+
+
+class StatusReporter:
+    """Report BLE link state to the daemon that spawned us, one line per change.
+
+    The Node daemon has no BLE of its own: it spawns this client and can only
+    watch the process. But both clients reconnect *inside* their own loop, so a
+    powered-off panel leaves the child running indefinitely and "process alive"
+    says nothing about whether the panel is being driven. Without this signal
+    the daemon's /health could only report the configured device list, and every
+    consumer that renders `connected` — macOS menubar, Dashboard rail, TUI —
+    drew both BLE panels as disconnected while they were streaming.
+
+    Emitting only on *change* keeps the frame loop from flooding the daemon log,
+    and the supervisor keeps these lines out of its diagnostic output ring so a
+    reconnect never looks like a new crash cycle.
+    """
+
+    def __init__(self, emit=None):
+        self._emit = emit if emit is not None else _write_status_line
+        self._last = None
+        # Sticky: once we have painted the panel, our frame is on it even while
+        # the link is down. Matches `hasFrame` in the daemon's health shape.
+        self._has_frame = False
+
+    def _update(self, connected, phase, dimmed=False, error=None):
+        payload = {
+            "connected": bool(connected),
+            "phase": phase,
+            "hasFrame": self._has_frame,
+            "dimmed": bool(dimmed),
+            "error": error,
+        }
+        if payload == self._last:
+            return
+        self._last = payload
+        self._emit(payload)
+
+    def connecting(self):
+        self._update(False, "connecting")
+
+    def connected(self):
+        self._update(True, "connected")
+
+    def streaming(self, dimmed=False):
+        """Link up and the frame loop is running — does not claim a painted frame.
+
+        Used on the dim/pause path, where a reconnect while the host display is
+        already asleep runs the loop without pushing anything.
+        """
+        self._update(True, "streaming", dimmed=dimmed)
+
+    def frame_sent(self, dimmed=False):
+        self._has_frame = True
+        self.streaming(dimmed=dimmed)
+
+    def disconnected(self, error=None):
+        self._update(False, "disconnected", error=error)
+
+    def failed(self, error):
+        self._update(False, "error", error=str(error) if error is not None else None)
+
+
+def _write_status_line(payload):
+    """Write one status line to stdout. Never raises — a closed pipe during
+    shutdown must not take the farewell frame down with it."""
+    try:
+        sys.stdout.write(
+            STATUS_LINE_PREFIX + json.dumps(payload, separators=(",", ":")) + "\n"
+        )
+        sys.stdout.flush()
+    except Exception:
+        pass

--- a/bridge/src/timebox/sync_ble.py
+++ b/bridge/src/timebox/sync_ble.py
@@ -31,6 +31,7 @@ from matrix_sync_common import (  # noqa: E402
     DEFAULT_URL,
     POLL_INTERVAL,
     BRIDGE_GONE_EXIT_SEC,
+    StatusReporter,
     fetch_display_state,
     bridge_reachable,
     resolve_display_brightness as _resolve_display_brightness_common,
@@ -182,6 +183,11 @@ async def push_micro_frame(client, url, brightness, gamma, sat, contrast, last_k
 
 async def run(address: str, url: str, brightness: int, gamma: float, sat: float, contrast: float, once: bool = False) -> None:
     print(f"Starting Timebox Mini BLE sync: {address} <- {url} brightness={brightness}% gamma={gamma}")
+    # Machine-readable link state for the daemon supervisor — it spawns us but
+    # cannot see the BLE link, and we reconnect inside this loop rather than
+    # exiting, so process liveness tells it nothing about whether the panel is
+    # actually being driven.
+    status = StatusReporter()
     stop = asyncio.Event()
     # Why we're stopping — decides the farewell. 'signal' = clean daemon shutdown
     # (no successor → blank the panel). 'orphan' = parent died (a successor daemon
@@ -238,12 +244,15 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
             # the inner loop would spin forever on a dead link and the outer reconnect
             # path (below) would never run.
             print("BLE peripheral disconnected — will reconnect.", file=sys.stderr)
+            status.disconnected("BLE peripheral disconnected")
             loop.call_soon_threadsafe(link_lost.set)
 
         try:
             print(f"Connecting BLE {address}...")
+            status.connecting()
             async with BleakClient(address, timeout=15.0, disconnected_callback=on_disconnect) as client:
                 print(f"BLE connected (MTU={client.mtu_size})")
+                status.connected()
 
                 last_key = ""
                 last_sent_at = time.monotonic()
@@ -270,6 +279,7 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                     #    on a dead link — only this flag / is_connected reveals it.
                     if link_lost.is_set() or not client.is_connected:
                         print("BLE link lost — reconnecting.", file=sys.stderr)
+                        status.disconnected("BLE link lost")
                         break
                     # 1. Apply host display sleep/wake. The daemon exposes the same
                     #    display_state Pixoo/iDotMatrix/ESP32 receive; older session-
@@ -289,6 +299,7 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                     #    brightness on the transition (0 => blank sleep frame), then
                     #    pause polling to save BLE bandwidth (mirrors iDotMatrix).
                     if display_dimmed:
+                        status.streaming(dimmed=True)
                         if transitioned or once:
                             try:
                                 last_key, sent = await push_micro_frame(
@@ -297,9 +308,11 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                                 if sent:
                                     last_sent_at = time.monotonic()
                                 last_bridge_ok = time.monotonic()
+                                status.frame_sent(dimmed=True)
                             except Exception as e:
                                 print(f"Dim-frame send error: {e}", file=sys.stderr)
                                 if link_lost.is_set() or not client.is_connected:
+                                    status.disconnected(f"dim-frame send error: {e}")
                                     break
                         if once:
                             return
@@ -321,6 +334,7 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                         if sent:
                             last_sent_at = time.monotonic()
                         last_bridge_ok = time.monotonic()
+                        status.frame_sent()
                     except Exception as e:
                         print(f"Frame fetch/send error: {e}", file=sys.stderr)
                         # A write error after the link dropped must escalate to a
@@ -328,6 +342,7 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                         # not — keep streaming and let should_exit() handle a truly
                         # gone bridge.
                         if link_lost.is_set() or not client.is_connected:
+                            status.disconnected(f"frame send error: {e}")
                             break
                     if once:
                         return
@@ -364,6 +379,7 @@ async def run(address: str, url: str, brightness: int, gamma: float, sat: float,
                         print(f"Farewell blank failed: {e}", file=sys.stderr)
         except Exception as e:
             print(f"BLE connection error: {e}", file=sys.stderr)
+            status.failed(f"BLE connection error: {e}")
             if once:
                 raise
             try:

--- a/bridge/src/timebox/timebox-daemon-sync.ts
+++ b/bridge/src/timebox/timebox-daemon-sync.ts
@@ -9,6 +9,12 @@
 import { type ChildProcess } from 'child_process';
 import { deviceId, loadTimeboxDevices, type TimeboxDevice } from './timebox-settings.js';
 import { createSyncCycleSquelch, spawnPythonSync, terminateSyncChild, type SyncCycleSquelch } from '../ble-sync-spawn.js';
+import {
+  createBleLinkTracker,
+  mergeBleLinkSnapshots,
+  type BleLinkSnapshot,
+  type BleLinkTracker,
+} from '../ble-sync-status.js';
 import { getBleRuntimeStatus } from '../python-ble-runtime.js';
 
 interface SyncEntry {
@@ -20,9 +26,14 @@ interface SyncEntry {
   startedAt: number;
   /** Collapses repeated identical respawn cycles into an hourly summary. */
   squelch: SyncCycleSquelch;
+  /** Live BLE link state, fed by the child's `AGENTDECK_STATUS` lines. */
+  link: BleLinkTracker;
 }
 
 const entries = new Map<string, SyncEntry>();
+
+/** Set when no child could be spawned at all (missing BLE runtime). */
+let unavailableReason: string | null = null;
 
 const BASE_BACKOFF_MS = 5_000;
 const MAX_BACKOFF_MS = 60_000;
@@ -39,8 +50,12 @@ export function startTimeboxSync(httpPort: number): void {
   const runtime = getBleRuntimeStatus();
   if (!runtime.ready || !runtime.python) {
     log(`sync unavailable (${runtime.reason}); run \`agentdeck ble setup\``);
+    // Register the reason so /health can say *why* the panel is dark instead of
+    // reporting a bare `connected:false` with no explanation.
+    unavailableReason = `BLE sync unavailable: ${runtime.reason}`;
     return;
   }
+  unavailableReason = null;
 
   for (const device of devices) {
     const id = deviceId(device);
@@ -53,6 +68,7 @@ export function startTimeboxSync(httpPort: number): void {
       consecutiveFailures: 0,
       startedAt: 0,
       squelch: createSyncCycleSquelch(log),
+      link: createBleLinkTracker(),
     };
     entries.set(id, entry);
     spawnSync(entry, runtime.python, runtime.paths.scripts.timeboxSync, httpPort);
@@ -71,10 +87,13 @@ function spawnSync(entry: SyncEntry, venvPython: string, syncScript: string, htt
     `Starting BLE sync for ${device.name ?? 'Timebox Mini'} (${id}, bridge ${url}, brightness ${brightness}%)`,
   );
   entry.startedAt = Date.now();
+  entry.link.noteSpawn();
 
   // stdout/stderr are captured into small rings so clean exits and crashes both
   // leave enough context without flooding the daemon log while running.
-  const { proc, stderrTail, outputTail } = spawnPythonSync(venvPython, args);
+  const { proc, stderrTail, outputTail } = spawnPythonSync(venvPython, args, {
+    onStatus: (payload) => entry.link.applyStatusLine(payload),
+  });
   entry.child = proc;
 
   proc.on('error', (err: Error) => {
@@ -94,6 +113,7 @@ function spawnSync(entry: SyncEntry, venvPython: string, syncScript: string, htt
     const delay = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * entry.consecutiveFailures);
     const tail = stderrTail() || outputTail();
     const why = tail ? `; output: ${tail}` : '';
+    entry.link.noteExit(tail || `sync exited (code=${code} signal=${signal})`, Date.now() + delay);
     entry.squelch.logExit(
       code,
       signal,
@@ -138,5 +158,25 @@ export async function stopTimeboxSync(awaitFarewell = false): Promise<void> {
     }
   }
   entries.clear();
+  unavailableReason = null;
   if (procs.length) await Promise.all(procs.map((p) => terminateSyncChild(p)));
+}
+
+/**
+ * Live link state for the configured Timebox panels, in the `BLEMatrixHealth`
+ * wire shape. Called by `TimeboxModule.statusSnapshot()` so `/health` reports
+ * whether the panel is actually being driven — the configured-device list alone
+ * left every dashboard drawing a streaming panel as disconnected.
+ */
+export function timeboxLinkSnapshot(configuredDeviceCount: number): BleLinkSnapshot {
+  const merged = mergeBleLinkSnapshots(
+    [...entries.values()].map((e) => e.link.snapshot(configuredDeviceCount)),
+    configuredDeviceCount,
+  );
+  // A configured device with no entry at all means the supervisor never got to
+  // spawn anything — surface that instead of an unexplained `connected:false`.
+  if (unavailableReason && configuredDeviceCount > 0 && !merged.connected) {
+    return { ...merged, statusReason: unavailableReason };
+  }
+  return merged;
 }


### PR DESCRIPTION
## Timebox Mini / iDotMatrix rendered as disconnected while streaming

The Node daemon has no BLE of its own — both panels are driven by Python clients it spawns. **Both clients reconnect inside their own loop**, so a powered-off panel leaves the child running indefinitely and process liveness says nothing about the link.

`/health` could therefore only report the configured device list:

```
timebox {"configuredDeviceCount":1, "devices":[…]}    ← no connected/statusReason
```

Every consumer of `BLEMatrixHealth.connected` — macOS menubar `MenuBarTopologyList`, Dashboard `TopologyRail`, TUI `renderer.ts` — read that as `false` and drew a hollow dot on a panel that was streaming fine. The Swift daemon holds the CoreBluetooth link itself and always emitted the full shape, so the symptom only showed on the Node daemon.

**Fix:** the clients report their own link state.

- `pysync/matrix_sync_common.py` — `StatusReporter` prints one `AGENTDECK_STATUS {json}` line per state *change* (shared by both clients).
- `ble-sync-spawn.ts` — parses those lines and dispatches them live, and keeps them **out of the diagnostic tail ring**; letting them in would make every reconnect read as a fresh crash cycle to `createSyncCycleSquelch`.
- `ble-sync-status.ts` — folds them into the `{connected, statusReason, displayDimmed, hasFrame, lastError}` shape the Swift daemon emits. `statusReason` wording mirrors `TimeboxModule.currentStatusReason()`, since `bleMatrixStatus()` keys its LED colour off the words "paused" / "connecting" / "retry".
- The module-not-started fallback in `daemon-server.ts` now sends an explicit `connected: false` instead of omitting the key — an omitted key reads as "no information" to retain-on-absent clients.

Verified live against a restarted daemon: both modules report `connected:true, statusReason:"connected", hasFrame:true`, and both rows turned into filled green dots in the Dashboard rail.

## MenuBarExtra footer clipped at the bottom

The popup's inner ScrollView cap was computed from `NSScreen.main?.visibleFrame.height`. `NSScreen.main` is the screen holding the **key window**, which on a multi-display desk is routinely not the screen the popup opened on — and `visibleFrame` only subtracts the Dock on the screen that actually has it. Sizing against the taller, Dock-less screen overruns the room available on the other one, and the bottom of the "Start at Login / Quit" footer gets cut.

`PanelAvailableHeightReader` now measures `window.frame.maxY - window.screen.visibleFrame.minY` from the popup's own hosting window. That is exact, folds in the menu-bar gap and the popup's top inset, and cannot feed back into itself because the popup is anchored at the top. The screen estimate remains only as the first-frame fallback.

Not visually confirmed — the macOS menu bar strip is owned by Control Center, which the automation tooling cannot be granted, so the popup could not be opened programmatically. Needs a relaunch + a look.

## Tests

- New `bridge/src/__tests__/ble-sync-status.test.ts` (14 cases): status-line parsing, the streaming→`connected` regression, host-display pause vs dead link, sticky `hasFrame`, error clearing on recovery, backoff window, missing BLE runtime, multi-panel merge.
- `pnpm vitest run` — 2555 passed / 155 files.
- macOS XCTest — 518 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)