### PR TITLE
docs(release): record that Elgato 1.0.4 is published, not awaiting upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 |---|---|---|
 | **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.6](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.6) |
 | **Apple App Store** — macOS | `apple-v*` | [1.0.2 live](https://apps.apple.com/app/id6784822497) (released 2026-07-24); 1.0.3 submitted for macOS and iPhone/iPad, superseding the 1.0.2 companion rejected on 2026-08-04 under Guideline 2.1(a) |
-| **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.3 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-07-31); 1.0.4 packaged and awaiting Maker-portal upload |
+| **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.4 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-05) |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.2 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.2); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.4](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.4) |
 | **GitHub Release** — ESP32 firmware | `esp32-v*` | [1.0.2](https://github.com/puritysb/AgentDeck/releases/tag/esp32-v1.0.2) — one binary per Shipping board |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: required
 owner: Release maintainers
-reviewed: 2026-08-05
-revision: 2026-08-05
+reviewed: 2026-08-06
+revision: 2026-08-06
 source_of_truth: RELEASING.md
 validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-version]
 ---
@@ -106,7 +106,9 @@ Assets are named by the board's **canonical id** (`agentdeck-<board>.bin`) — t
 
 ### Stream Deck plugin
 
-`1.0.2` was approved and published on 2026-07-28, and `1.0.3` — the Windows compatibility correction — has been published since 2026-07-31: [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Now that builds are published, the Marketplace's **monotonic-version rule applies** — every subsequent submission needs a version above `1.0.3`, and same-version resubmission (which pre-publication review revisions allowed) is no longer available.
+`1.0.2` was approved and published on 2026-07-28, `1.0.3` — the Windows compatibility correction — on 2026-07-31, and **`1.0.4` has been published since 2026-08-05**: [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Now that builds are published, the Marketplace's **monotonic-version rule applies** — every subsequent submission needs a version above `1.0.4`, and same-version resubmission (which pre-publication review revisions allowed) is no longer available.
+
+The live version is verifiable without signing in to the Maker Console: the product page is a client-rendered SPA, but its Next.js payload carries the version array verbatim, so `curl -s <product-url> | grep -oE '\\"versions\\":\[.{0,1200}'` reports `version_number`, `status`, and `publish_date` for every submission. Check it there before writing a release-status claim into this file — a portal upload that succeeds leaves no trace in the repository, which is exactly how these paragraphs fell a version behind between 2026-07-31 and 2026-08-06.
 
 1. Confirm the main manifest and embedded profile snapshots match the Stream Deck package version as `X.Y.Z.0`.
 2. Follow `.agents/workflows/build-plugin.md`, then run `pnpm package` — this validates with Elgato's official CLI (pinned as the `@elgato/cli` devDependency) before packing, so a local failure is a submission the Marketplace would have rejected.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,7 +60,7 @@ Eval results broadcast to every device simultaneously (Stream Deck/Apple/Android
 
 - [x] **Windows daemon autostart** — `agentdeck daemon install` registers a per-user Scheduled Task (`AgentDeckDaemon`, logon trigger) so the daemon auto-starts in the interactive session, the Windows analog of the macOS LaunchAgent. See [daemon.md → Autostart](daemon.md#autostart-loginlogon).
 - [ ] Play Store distribution (Android app)
-- [x] **Stream Deck Marketplace registration** — first approved 2026-07-28 (1.0.2); **1.0.3 published 2026-07-31** at [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Listing assets and packages remain under `marketplace/elgato/`.
+- [x] **Stream Deck Marketplace registration** — first approved 2026-07-28 (1.0.2), Windows correction 1.0.3 on 2026-07-31, and **1.0.4 published 2026-08-05** at [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Listing assets and packages remain under `marketplace/elgato/`.
 
 ---
 

--- a/marketplace/elgato/LISTING.md
+++ b/marketplace/elgato/LISTING.md
@@ -1,7 +1,9 @@
 # AgentDeck — Elgato Marketplace listing
 
-> **Published 2026-07-28.** Version `1.0.2` was approved and is live at
-> <https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464>.
+> **Live since 2026-07-28.** The product page is at
+> <https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464>,
+> and the current published version is `1.0.4` (2026-08-05), after `1.0.2` (2026-07-28)
+> and `1.0.3` (2026-07-31).
 > This file stays the source of the listing copy and asset inventory for future revisions.
 
 Submission target: **https://maker.elgato.com** (Maker Console → Publish).
@@ -29,12 +31,15 @@ Plugin package: `dist/bound.serendipity.agentdeck.streamDeckPlugin` — rebuild 
 
 ## Version
 
-`1.0.3.0` (product version `1.0.3`) — **published 2026-07-31**. It corrects
-Windows compatibility after the 1.0.2 manifest (public since 2026-07-28)
-incorrectly restricted installation to macOS. Stream Deck requires the 4-part
-form; `scripts/verify-version-sync.mjs` pins it to `<plugin package version>.0`.
-Marketplace versions are monotonic once published, so the next submission must
-carry a version above 1.0.3.
+`1.0.4.0` (product version `1.0.4`) — **published 2026-08-05**. It adds
+Stream Deck XL and Stream Deck + XL as their own device models, brings the
+Windows host controls to parity with macOS, and adapts the Codex usage encoder
+to a single live rate-limit window. It follows `1.0.3` (published 2026-07-31),
+which corrected Windows compatibility after the 1.0.2 manifest (public since
+2026-07-28) incorrectly restricted installation to macOS. Stream Deck requires
+the 4-part form; `scripts/verify-version-sync.mjs` pins it to
+`<plugin package version>.0`. Marketplace versions are monotonic once
+published, so the next submission must carry a version above 1.0.4.
 
 ## Platform
 
@@ -67,15 +72,22 @@ AgentDeck is an independent project and is not affiliated with or endorsed by El
 
 ## Release notes
 
-```
-Windows compatibility update.
+As submitted and published for `1.0.4`:
 
-• Session keys for Claude Code, Codex, OpenCode, and OpenClaw with distinct running / waiting states
-• Prompt steering, mode toggle, and stop from the key
-• Stream Deck + dials: Claude usage, Codex usage, volume, launcher
-• Bundled profiles for Stream Deck, Stream Deck Mini, and Stream Deck +
-• Automatic reconnect with an explicit OFFLINE state when no daemon is running
-• Restores Marketplace installation on Windows; Volume and Launcher now use native Windows host controls
+```
+Stream Deck XL and Stream Deck + XL are now first-class: both are recognized as their own device models, and the bundled profiles install for them the way they already did for Stream Deck, Mini, and Stream Deck +.
+
+Windows now reaches parity with macOS for the host controls: the volume encoder uses the system media keys, and the launcher opens Start-menu apps with a browser fallback.
+
+The Codex usage encoder adapts when only one rate-limit window is live: the remaining window keeps a proper slot with its own countdown instead of a dead placeholder.
+
+Fixed: a session's detail view could show the model name belonging to the previously focused session, and the hold-to-talk VOICE key now completes the round trip to the host microphone.
+```
+
+The `1.0.3` notes, for reference:
+
+```
+Restores Windows Marketplace support, including Windows volume/mute controls and Launcher app/URL handling. macOS behavior is unchanged.
 ```
 
 ## Links
@@ -84,9 +96,9 @@ Windows compatibility update.
 - Support: https://github.com/puritysb/AgentDeck/issues
 - Privacy: https://puritysb.github.io/AgentDeck/#privacy
 
-## Submission files (Windows compatibility revision — 2026-07-30)
+## Submission files (XL + Windows parity revision — 2026-08-05)
 
-- Plugin: `dist/bound.serendipity.agentdeck.streamDeckPlugin` (v1.0.3.0, macOS + Windows)
+- Plugin: `dist/bound.serendipity.agentdeck.streamDeckPlugin` (v1.0.4.0, macOS + Windows)
 - App icon: `marketplace/elgato/1.0.2/app-icon-288.png`
 - Thumbnail: `marketplace/elgato/1.0.2/thumbnail-1920x960.png`
 - Gallery: the three `marketplace/elgato/1.0.2/gallery-*.png` files


### PR DESCRIPTION
The Elgato Marketplace published Stream Deck `1.0.4` on **2026-08-05T13:39:21Z**, but four repository surfaces still described `1.0.3` as live and `1.0.4` as a package "awaiting Maker-portal upload". A portal upload leaves no trace in git, so nothing failed — the docs simply fell a version behind, exactly as they did between 07-31 and 08-05 for `1.0.3`.

That matters beyond accuracy: the Marketplace's monotonic-version floor is now `1.0.4`, so the next submission must clear a bar the docs understated as `1.0.3`.

**Verified against the store, not the tag** — the product page is a client-rendered SPA, but its Next.js payload carries the version array verbatim:

```
version_number 1.0.4  status published  publish_date 2026-08-05T13:39:21.921899Z
version_number 1.0.3  status published  publish_date 2026-07-31T15:03:27.703683Z
version_number 1.0.2  status published  publish_date 2026-07-27T14:49:00.960472Z
```

Changes:
- `README.md` release table → `1.0.4 live (published 2026-08-05)`
- `RELEASING.md` § Stream Deck → 1.0.4 published, monotonic floor above `1.0.4`, plus the login-free verification command as the step before writing any status claim
- `docs/roadmap.md` → the full 1.0.2 → 1.0.3 → 1.0.4 publication line
- `marketplace/elgato/LISTING.md` → header, Version section, submission-files heading, and the release notes **as actually published** for 1.0.4 (1.0.3 text kept for reference)

Gates: `check-docs.mjs`, `build-design-system-viewer.mjs --check`, and `verify-version-sync.mjs` all pass. No code or version-number changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)