### PR TITLE
fix(apme): archive the half of every conversation that was going missing

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,81 @@
 
 ---
 
+## 2026-08-06 — 타임라인이 다 보여주는 대화를 APME 는 절반만 저장하고 있었다
+
+### 문제
+
+"TIMELINE 에서 보는 대화 세션이 APME 에 어떻게 아카이빙됐는지 최근 이벤트 기준으로 비교
+검증하라" 에서 출발했다. 같은 세션을 두 저장소에서 나란히 놓으니 답이 바로 나왔다 —
+프롬프트·타임스탬프·툴 호출은 1:1 로 맞는데 **응답만 통째로 없었다**.
+
+```
+TIMELINE                                   APME
+chat_start 23:30 → chat_response (811B)    turn0 23:30→23:32 tools=8  response=NULL
+chat_start 23:32 → chat_response (610B)    turn1 23:32→23:52 tools=5  response=NULL
+chat_start 23:57 → chat_response (1917B)   turn3 23:57→00:03 tools=9  response=NULL
+```
+
+범위는 국지적이지 않았다. claude-code turn 1589개 중 response 219개, 그마저 마지막이
+2026-07-11. 정본 trajectory 는 6종(user/assistant/model/tool/state/info)인데 최근 24시간에
+적재된 건 2종뿐이고, `assistant_message` 는 전 기간 15개 — 그중 12개가 OpenClaw 였다.
+`model` 이벤트가 0건이라 최근 108 run 의 cost/token 도 전부 비어 있었다.
+
+### 해결
+
+**응답 유실 — 데몬마다 원인이 달랐다.**
+
+- Node: `setTurnResponse()` 의 유일한 호출부가 PTY 세션 브리지(`index.ts`)였다. 직접 실행한
+  `claude`/`codex`/`opencode` 는 hook 으로만 데몬에 닿으므로 그 경로를 타지 않는다.
+  `daemon-server.ts` 의 stop 핸들러는 transcript tail 로 텍스트를 **이미 만들어놓고**
+  타임라인에만 썼다. 타임라인 행을 결정하는 같은 분기에서 collector 로 넘기도록 배선.
+- Swift: `setTurnResponse` 는 부르는데 소스가 `getLastEntry(type:"chat_end")` 였다.
+  `chat_end` 는 응답이 **없을 때만** 나오는 행이고 raw 가 `"Completed · 2m 19s"` —
+  구조적으로 응답을 볼 수 없었다. hook 핸들러로 옮겼다.
+
+**평가 굶주림.** 데몬이 재시작하면 in-memory `sessionToRun` 맵이 사라져 진행 중이던 run 이
+영영 `ended_at IS NULL` 로 남는다. eval 은 task close 에서만 발화하므로 최근 3일 기준
+open task 65 vs closed 9. 기존 `listOrphanedRuns` 는 `task_prompt IS NULL AND NOT
+EXISTS(turns)` — 빈 껍데기 전용 술어라 실제 작업을 담은 run 을 전부 건너뛰었다.
+
+**그래프 적합성.** `runs→tasks→turns→sample_events` 는 FK 가 실재해 그대로 투영되지만,
+작업 단위끼리 잇는 간선이 없었다. 스키마로 두 개를 복구하고(`sample_events.turn_id`,
+`runs.parent_run_id`), 나머지 허브는 투영 시점에 유도한다.
+
+### 핵심 설계 결정
+
+- **아카이빙 호출은 타임라인 행을 결정하는 바로 그 분기에 둔다.** 별도 경로에서 "마지막 행을
+  찾아 읽는" 방식은 어떤 행 타입이 응답을 담는지에 대한 가정이 화석화돼 조용히 고장난다.
+  Swift 가 정확히 그렇게 죽어 있었다.
+- **reaper 는 `started_at` 이 아니라 마지막 *활동* 시각으로 판정하고, 그 시각으로 닫는다.**
+  장수 세션을 주인 밑에서 닫으면 안 되고, 어젯밤 버려진 run 이 12시간짜리 턴으로 보고돼도
+  안 된다. run 은 **마지막에** 닫는다 — 부분 실패 시 `ended_at` 이 NULL 로 남아 다음 sweep
+  이 재시도한다. 반대 순서였다면 닫힌 run 뒤에 열린 task 가 갇혀 아무도 못 찾는다.
+- **better-sqlite3 는 단일 커넥션 동기 실행 — 느린 쿼리 하나가 데몬 HTTP 전체를 멈춘다.**
+  이 sweep 의 `MAX(steps.ts)` 가 `idx_steps_run`(run_id only)만으로 돌면서 `payload`(훅
+  본문 전체)가 든 행을 전부 읽어 **22초**가 걸렸다. `(run_id, ts)` 커버링 인덱스로
+  22359ms → 6.9ms. APME 에 per-run/per-task 롤업을 추가할 땐 커버링 인덱스를 같이 넣는다.
+- **백로그는 채점하지 않는다.** reaper 가 마감한 과거 task 대부분은 응답이 없다. 그대로
+  judge 에 넣으면 "침묵 채점" 점수가 scorecard 에 쌓인다 — `response_kind` 가 애초에 막으려던
+  노이즈다. 응답이 있는 task 만 enqueue.
+- **file 노드는 run 의 `project_path` 기준 상대경로로 키잉한다.** 처음엔 "경로 뒤 3세그먼트"
+  로 잡았는데, 두 체크아웃이 repo-relative 깊이가 **정확히 3일 때만** 우연히 합쳐지고 아니면
+  조용히 갈라진다. worktree 를 상시 쓰는 레포라 그 실패가 일상이 된다. 테스트가 잡아냈다.
+- **잘린 그래프는 잘렸다고 말한다.** `stats.truncatedTasks` / `stats.fileCoverage`(경로를
+  받지 않는 Bash·WebFetch 때문에 커버리지는 본질적으로 부분적)를 항상 실어 보낸다. 부분
+  슬라이스가 전체 히스토리처럼 읽히면 없는 것만 못하다.
+- **투영은 저장하지 않는다.** session/project/model/agent/tool/file 은 테이블로 승격하지 않고
+  `graph.ts` 가 요청 시 materialize 한다 — 마이그레이션 없이 형태를 바꿀 수 있다.
+
+### 검증
+
+유닛 테스트만으로 끝내지 않고 실기 데몬에 합성 hook 턴을 흘려 `turns.response` +
+`assistant_message` 적재를 확인한 뒤, 실제 세션에서 2404/1380/1052자 응답이 아카이빙되는 걸
+확인했다(검증용 합성 row 는 사후 삭제). reaper 는 백로그 783 task 를 마감하고 열린 task 를
+5개까지 배수했고, `turn_id` 는 20735/20736 backfill 됐다.
+
+---
+
 ## 2026-08-06 — 로컬 추론 지도를 그리다 나온 다섯 건: 문서가 코드보다 오래 살아남는 방식
 
 ### 문제

--- a/apple/AgentDeck/Daemon/Apme/ApmeCollector.swift
+++ b/apple/AgentDeck/Daemon/Apme/ApmeCollector.swift
@@ -944,6 +944,16 @@ final class ApmeCollector {
         return sessionToTask[sid]?.id
     }
 
+    /// True while this collector still owns `runId` — some session maps to it
+    /// and will close it normally. The abandoned-run reaper consults this before
+    /// finalizing anything: an inactivity window alone would reap a live session
+    /// whose user simply stepped away mid-turn, and the row would then be closed
+    /// underneath the collector still writing to it.
+    /// Mirrors bridge/src/apme/collector.ts isLiveRun.
+    func isLiveRun(_ runId: String) -> Bool {
+        sessionToRun.values.contains(runId)
+    }
+
     /// (runId, taskId) for a session's currently-open task — used to record a
     /// manual_review eval (REVIEW deck button) into the same store as the
     /// automatic pipeline. Returns nil when no run/task is open for the id.

--- a/apple/AgentDeck/Daemon/Apme/ApmeStore.swift
+++ b/apple/AgentDeck/Daemon/Apme/ApmeStore.swift
@@ -230,6 +230,114 @@ final class ApmeStore: @unchecked Sendable {
         return result
     }
 
+    /// Abandoned runs: real work that was never closed. The daemon restarted
+    /// (or crashed) mid-session, so the in-memory session→run map `closeRun`
+    /// depends on is gone and nothing will ever finalize these rows.
+    ///
+    /// Distinct from `listOrphanedRuns`, which by design matches only empty
+    /// shells (`task_prompt IS NULL` + no turns) and therefore steps over the
+    /// case that actually costs data: a run carrying prompts, turns and a whole
+    /// tool trajectory stays open forever, its task never closes, and a task
+    /// that never closes is never evaluated.
+    ///
+    /// Staleness is measured from the LAST recorded activity, never
+    /// `started_at` — a live multi-hour session must not be reaped out from
+    /// under the process that owns it. `lastActivity` is returned so the caller
+    /// closes the rows AT that instant rather than `now`, keeping durations
+    /// honest. Mirrors bridge/src/apme/store.ts listAbandonedRuns.
+    func listAbandonedRuns(staleSec: Int = 7200, limit: Int = 20) -> [(id: String, lastActivity: Int)] {
+        guard let db else { return [] }
+        let cutoff = Int(Date().timeIntervalSince1970 * 1000) - staleSec * 1000
+        let sql = """
+        SELECT id, last_activity FROM (
+          SELECT r.id AS id,
+            MAX(
+              r.started_at,
+              COALESCE((SELECT MAX(MAX(t.started_at, COALESCE(t.ended_at, 0))) FROM turns t WHERE t.run_id = r.id), 0),
+              COALESCE((SELECT MAX(s.ts) FROM steps s WHERE s.run_id = r.id), 0),
+              COALESCE((SELECT MAX(se.ts) FROM sample_events se WHERE se.run_id = r.id), 0)
+            ) AS last_activity
+          FROM runs r
+          WHERE r.ended_at IS NULL
+            AND EXISTS (SELECT 1 FROM turns t WHERE t.run_id = r.id)
+        )
+        WHERE last_activity < ?
+        ORDER BY last_activity ASC
+        LIMIT ?
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_int64(stmt, 1, Int64(cutoff))
+        sqlite3_bind_int64(stmt, 2, Int64(limit))
+        var result: [(id: String, lastActivity: Int)] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            result.append((String(cString: sqlite3_column_text(stmt, 0)),
+                           Int(sqlite3_column_int64(stmt, 1))))
+        }
+        return result
+    }
+
+    /// Finalize an abandoned run: close its dangling turns, close its tasks with
+    /// `boundary_signal='orphaned'`, then close the run — all stamped at
+    /// `endedAt` (the run's last activity), so a run abandoned last night does
+    /// not report a twelve-hour turn. The run is closed LAST: any partial
+    /// failure leaves `ended_at` NULL so the next sweep retries, instead of
+    /// stranding an open task behind a closed run where nothing would find it.
+    ///
+    /// Returns the closed task ids so the caller can enqueue task-level evals —
+    /// the reason for closing them. Mirrors bridge/src/apme/store.ts.
+    @discardableResult
+    func reapAbandonedRun(runId: String, endedAt: Int) -> [(id: String, category: String?)] {
+        guard let db else { return [] }
+        var bounds: (lo: Int, hi: Int)?
+        var bstmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT MIN(turn_index), MAX(turn_index) FROM turns WHERE run_id = ?", -1, &bstmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(bstmt, 1, (runId as NSString).utf8String, -1, nil)
+            if sqlite3_step(bstmt) == SQLITE_ROW, sqlite3_column_type(bstmt, 0) != SQLITE_NULL {
+                bounds = (Int(sqlite3_column_int64(bstmt, 0)), Int(sqlite3_column_int64(bstmt, 1)))
+            }
+        }
+        sqlite3_finalize(bstmt)
+
+        var tasks: [(id: String, category: String?)] = []
+        var tstmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT id, task_category FROM tasks WHERE run_id = ? AND ended_at IS NULL", -1, &tstmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(tstmt, 1, (runId as NSString).utf8String, -1, nil)
+            while sqlite3_step(tstmt) == SQLITE_ROW {
+                let id = String(cString: sqlite3_column_text(tstmt, 0))
+                let cat = sqlite3_column_type(tstmt, 1) == SQLITE_NULL
+                    ? nil : String(cString: sqlite3_column_text(tstmt, 1))
+                tasks.append((id, cat))
+            }
+        }
+        sqlite3_finalize(tstmt)
+
+        func exec(_ sql: String, _ binds: [Any?]) {
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+            defer { sqlite3_finalize(stmt) }
+            for (i, b) in binds.enumerated() {
+                let idx = Int32(i + 1)
+                switch b {
+                case let v as Int: sqlite3_bind_int64(stmt, idx, Int64(v))
+                case let v as String: sqlite3_bind_text(stmt, idx, (v as NSString).utf8String, -1, nil)
+                default: sqlite3_bind_null(stmt, idx)
+                }
+            }
+            _ = sqlite3_step(stmt)
+        }
+        exec("UPDATE turns SET ended_at = ? WHERE run_id = ? AND ended_at IS NULL", [endedAt, runId])
+        exec("""
+        UPDATE tasks SET ended_at = ?, boundary_signal = 'orphaned',
+          first_turn_index = COALESCE(first_turn_index, ?),
+          last_turn_index  = COALESCE(last_turn_index, ?)
+        WHERE run_id = ? AND ended_at IS NULL
+        """, [endedAt, bounds?.lo, bounds?.hi, runId])
+        exec("UPDATE runs SET ended_at = ? WHERE id = ? AND ended_at IS NULL", [endedAt, runId])
+        return tasks
+    }
+
     /// Orphaned runs: started long ago, never closed, no turns.
     /// Typically from session bridges that crashed without cleanup.
     func listOrphanedRuns(staleSec: Int = 1800) -> [String] {
@@ -1035,6 +1143,43 @@ final class ApmeStore: @unchecked Sendable {
             ("latency_ms",    "ALTER TABLE tasks ADD COLUMN latency_ms INTEGER"),
         ]
         for (col, sql) in tasksMigrations where !tasksCols.contains(col) { exec(sql) }
+
+        // ── Graph-integrity columns (mirrors bridge/src/apme/store.ts) ──
+        // Both daemons write the same sqlite layout, so a DB created by either
+        // must carry these or the other's graph projection silently loses edges.
+        //  1. sample_events addressed its turn by `turn_index`, unique only
+        //     within a run — there was no event→turn edge at all.
+        //  2. `/clear` opens a fresh run with no pointer to the one it
+        //     continues, so one conversation appeared as N disconnected runs.
+        let sevCols = query("PRAGMA table_info(sample_events)").compactMap { $0["name"] as? String }
+        if !sevCols.contains("turn_id") {
+            exec("ALTER TABLE sample_events ADD COLUMN turn_id TEXT")
+            exec("CREATE INDEX IF NOT EXISTS idx_sevents_turn ON sample_events(turn_id)")
+            // One-shot backfill from the compound key the column replaces.
+            exec("""
+            UPDATE sample_events SET turn_id = (
+              SELECT t.id FROM turns t
+              WHERE t.run_id = sample_events.run_id AND t.turn_index = sample_events.turn_index
+            ) WHERE turn_id IS NULL AND turn_index IS NOT NULL
+            """)
+        }
+        if !runsCols.contains("parent_run_id") {
+            exec("ALTER TABLE runs ADD COLUMN parent_run_id TEXT")
+            exec("CREATE INDEX IF NOT EXISTS idx_runs_parent ON runs(parent_run_id)")
+        }
+
+        // ── Covering indexes for the per-run/per-task rollups ──
+        // `MAX(ts)` over a run's steps was reading full rows to reach one
+        // integer, and `steps.payload` holds entire hook bodies — the
+        // abandoned-run sweep touched hundreds of megabytes and took 22s on a
+        // real store. (run_id, ts) answers it from the index alone.
+        for sql in [
+            "CREATE INDEX IF NOT EXISTS idx_steps_run_ts ON steps(run_id, ts)",
+            "CREATE INDEX IF NOT EXISTS idx_sevents_run_ts ON sample_events(run_id, ts)",
+            "CREATE INDEX IF NOT EXISTS idx_turns_run_started ON turns(run_id, started_at)",
+            "CREATE INDEX IF NOT EXISTS idx_evals_task ON evals(task_id)",
+            "CREATE INDEX IF NOT EXISTS idx_tasks_started ON tasks(started_at)",
+        ] { exec(sql) }
     }
 
     private func seedDefaultRubric() {

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -5812,7 +5812,17 @@ final class DaemonServer {
         if wasProcessing && currentState == .idle {
             Task { @DaemonActor [weak self] in
                 guard let self else { return }
-                let lastEntry = await self.timelineStore.getLastEntry(type: "chat_end")
+                // Read `chat_response`, NOT `chat_end`. A turn's reply is only
+                // ever written to a chat_response row; chat_end is emitted
+                // exactly when there is no reply, and its `raw` is the literal
+                // string "Completed · 2m 19s" — so the old lookup could only
+                // ever hand the collector a duration label or nothing at all.
+                // This is now a backstop: `appendClaudeCodeChatEnd` records the
+                // response at the hook itself, where the text is already
+                // session-scoped and the turn anchor is known. Re-recording the
+                // same text is harmless (the trajectory event dedups on its
+                // content hash and the turn column is idempotent).
+                let lastEntry = await self.timelineStore.getLastEntry(type: "chat_response")
                 let responseText = (lastEntry?.detail ?? lastEntry?.raw) ?? ""
                 let chatEndTs = lastEntry?.ts
                 await DaemonActor.run {
@@ -8810,6 +8820,19 @@ final class DaemonServer {
                 assistantText = tail.text
             }
         }
+        // APME: hand the resolved text to the collector HERE, on the same
+        // branch that decides the timeline row. The only other caller sits on
+        // the global PROCESSING→IDLE edge and reads the last `chat_end` — but
+        // this handler emits `chat_end` only when there is NO response text, so
+        // that lookup structurally cannot see a reply, and every hook-observed
+        // turn archived a prompt with `response` NULL and no `assistant_message`
+        // trajectory event (90 turns / 0 responses over three days). Passing
+        // `chatEndTs: startTs` reuses the collector's late-Stop race guard: a
+        // duplicate Stop carrying the previous turn's anchor is recognised as
+        // stale and lands on the closed turn instead of clobbering a fresh one.
+        if !assistantText.isEmpty {
+            apmeCollector?.setTurnResponse(assistantText, sessionId: sessionId, chatEndTs: startTs)
+        }
         if !assistantText.isEmpty {
             let snippet = String(assistantText.prefix(200))
             let detail: String? = assistantText.count > 100
@@ -9413,7 +9436,43 @@ final class DaemonServer {
                 "taskCategory": "_empty",
             ])
         }
+
+        // 6. Reap ABANDONED runs — the ones step 5 cannot see. A daemon restart
+        //    drops the in-memory session→run map, leaving every mid-session run
+        //    with ended_at NULL forever. Those carry real prompts and turns, so
+        //    they fail step 5's empty-shell predicate, and because their TASK
+        //    also never closes they are never evaluated. Closing the run lets
+        //    the eval queue pick it up; the task eval must be enqueued here
+        //    because its normal trigger fires from the collector's in-memory
+        //    close path, which is exactly what went missing.
+        //    Mirrors bridge/src/daemon-server.ts step 5.
+        let abandoned = store.listAbandonedRuns(staleSec: Self.apmeAbandonedRunStaleSec, limit: 5)
+        for run in abandoned {
+            if apmeCollector?.isLiveRun(run.id) == true { continue } // still owned by us
+            let closedTasks = store.reapAbandonedRun(runId: run.id, endedAt: run.lastActivity)
+            for task in closedTasks {
+                // Judge only what there is something to judge. The backlog this
+                // reaper drains predates the response-capture fix, so most of
+                // those tasks hold prompts and tool calls but no reply —
+                // scoring them would push "judged against silence" rows into
+                // the scorecard, the noise `response_kind` exists to keep out.
+                let hasReply = store.listTurnsForTask(task.id).contains {
+                    guard let r = $0["response"] as? String else { return false }
+                    return !r.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }
+                guard hasReply else { continue }
+                runner.enqueueTask(runId: run.id, taskId: task.id,
+                                   category: task.category, boundarySignal: "orphaned")
+            }
+            DaemonLogger.shared.debug("APME", "reaped abandoned run \(run.id.prefix(8)) — \(closedTasks.count) task(s) closed")
+        }
     }
+
+    /// Inactivity after which an unclosed APME run is treated as abandoned and
+    /// finalized. Deliberately generous: an orphan stays reapable forever, so
+    /// closing it late costs nothing, while reaping a live run corrupts the unit
+    /// being measured. Mirrors APME_ABANDONED_RUN_STALE_SEC in the Node daemon.
+    private static let apmeAbandonedRunStaleSec = 7200
 
     /// Propagates APME outcome evaluation results directly to the task_end timeline row.
     /// Ensures real-time UI badge ("...") update synchronization right after SQLite commits.

--- a/bridge/src/__tests__/apme-abandoned-run-reaper.test.ts
+++ b/bridge/src/__tests__/apme-abandoned-run-reaper.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ApmeStore } from '../apme/store.js';
+import { ApmeCollector } from '../apme/collector.js';
+
+// A daemon restart drops the in-memory session→run map that `closeRun` depends
+// on, so every run that was mid-session is left with `ended_at` NULL forever.
+// The pre-existing `listOrphanedRuns` only matches empty shells (no prompt, no
+// turns), so those runs — which carry the actual work — were invisible to it,
+// and because their TASK never closed they were never evaluated (the live store
+// had accumulated 65 open tasks against 9 closed ones).
+
+async function makeStore(): Promise<ApmeStore> {
+  const dir = mkdtempSync(join(tmpdir(), 'apme-reaper-'));
+  const store = new ApmeStore(join(dir, 'apme.sqlite'));
+  const ok = await store.init();
+  if (!ok) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('APME store failed to initialize — is better-sqlite3 installed?');
+  }
+  (store as unknown as { _tmpDir: string })._tmpDir = dir;
+  return store;
+}
+
+function cleanup(store: ApmeStore) {
+  store.close();
+  const dir = (store as unknown as { _tmpDir?: string })._tmpDir;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+}
+
+const HOUR = 3_600_000;
+
+/** A run left open mid-work, with `lastActivity` ms ago. */
+function seedAbandoned(store: ApmeStore, id: string, agoMs: number): number {
+  const lastActivity = Date.now() - agoMs;
+  store.insertRun({ id, sessionId: `s-${id}`, agentType: 'claude-code', startedAt: lastActivity - 60_000, taskPrompt: 'do the thing' });
+  store.insertTask({ id: `task-${id}`, runId: id, taskIndex: 0, boundarySignal: 'open', startedAt: lastActivity - 60_000 });
+  store.insertTurn({ id: `turn-${id}`, runId: id, taskId: `task-${id}`, turnIndex: 3, prompt: 'do the thing', startedAt: lastActivity });
+  return lastActivity;
+}
+
+describe('abandoned APME run reaper', () => {
+  let store!: ApmeStore;
+  beforeEach(async () => { store = await makeStore(); });
+  afterEach(() => { cleanup(store); });
+
+  it('finds runs with real work that the empty-shell reaper cannot see', () => {
+    seedAbandoned(store, 'run-old', 3 * HOUR);
+    // The exact shape listOrphanedRuns targets — must stay ITS job, not ours.
+    store.insertRun({ id: 'run-shell', sessionId: 's-shell', agentType: 'claude-code', startedAt: Date.now() - 3 * HOUR });
+
+    expect(store.listOrphanedRuns(1800)).toEqual(['run-shell']);
+    expect(store.listAbandonedRuns(7200).map(r => r.id)).toEqual(['run-old']);
+  });
+
+  it('measures staleness from last activity, not started_at', () => {
+    // Started 5h ago but a turn landed a minute ago: a live long session.
+    store.insertRun({ id: 'run-live', sessionId: 's-live', agentType: 'claude-code', startedAt: Date.now() - 5 * HOUR, taskPrompt: 'p' });
+    store.insertTask({ id: 'task-live', runId: 'run-live', taskIndex: 0, boundarySignal: 'open', startedAt: Date.now() - 5 * HOUR });
+    store.insertTurn({ id: 'turn-live', runId: 'run-live', taskId: 'task-live', turnIndex: 0, prompt: 'p', startedAt: Date.now() - 60_000 });
+
+    expect(store.listAbandonedRuns(7200)).toEqual([]);
+  });
+
+  it('counts steps and sample events as activity, not just turns', () => {
+    const lastActivity = seedAbandoned(store, 'run-busy', 3 * HOUR);
+    // Tool traffic 1 minute ago on a turn that opened 3h back.
+    store.insertStep({ runId: 'run-busy', ts: Date.now() - 60_000, kind: 'PostToolUse', toolName: 'Edit', payload: '{}' });
+    expect(store.listAbandonedRuns(7200)).toEqual([]);
+
+    store.insertSampleEvent({
+      taskId: 'task-run-busy', runId: 'run-busy', turnIndex: 3, seq: 0,
+      ts: lastActivity, kind: 'tool', toolName: 'Read', toolStatus: 'success', dedupKey: 'k0',
+    });
+    // Still fresh — the newest event wins, not the oldest.
+    expect(store.listAbandonedRuns(7200)).toEqual([]);
+  });
+
+  it('closes turns, tasks and the run at the last activity, not now', () => {
+    const lastActivity = seedAbandoned(store, 'run-x', 3 * HOUR);
+
+    const closed = store.reapAbandonedRun('run-x', lastActivity);
+    expect(closed).toEqual([{ id: 'task-run-x', category: null }]);
+
+    const run = store.getRun('run-x');
+    expect(run?.endedAt).toBe(lastActivity);
+    const task = store.getTask('task-run-x');
+    expect(task?.endedAt).toBe(lastActivity);
+    expect(task?.boundarySignal).toBe('orphaned');
+    // Backfilled from the run's real turns so the task rollup has its range.
+    expect(task?.firstTurnIndex).toBe(3);
+    expect(task?.lastTurnIndex).toBe(3);
+    const turn = store.getTurn('turn-run-x');
+    expect(turn?.ended_at).toBe(lastActivity);
+  });
+
+  it('is idempotent and drops out of the candidate list once reaped', () => {
+    const lastActivity = seedAbandoned(store, 'run-y', 3 * HOUR);
+    store.reapAbandonedRun('run-y', lastActivity);
+
+    expect(store.listAbandonedRuns(7200)).toEqual([]);
+    // A second pass finds nothing left open, so it reports no tasks to judge —
+    // the eval queue must not be handed the same task twice.
+    expect(store.reapAbandonedRun('run-y', lastActivity + 999)).toEqual([]);
+    expect(store.getRun('run-y')?.endedAt).toBe(lastActivity);
+  });
+
+  it('leaves reaped runs to the normal eval queue', () => {
+    const lastActivity = seedAbandoned(store, 'run-z', 3 * HOUR);
+    expect(store.listUnevaluatedRuns(10).map(r => r.id)).not.toContain('run-z');
+    store.reapAbandonedRun('run-z', lastActivity);
+    expect(store.listUnevaluatedRuns(10).map(r => r.id)).toContain('run-z');
+  });
+
+  it('reports a run the collector still owns as live', () => {
+    const collector = new ApmeCollector(store);
+    const runId = collector.openRun({ sessionId: 'live-session', agentType: 'claude-code' });
+    expect(runId).not.toBeNull();
+    expect(collector.isLiveRun(runId!)).toBe(true);
+    expect(collector.isLiveRun('some-other-run')).toBe(false);
+    collector.closeRun('live-session');
+    expect(collector.isLiveRun(runId!)).toBe(false);
+  });
+});

--- a/bridge/src/__tests__/apme-observed-turn-response.test.ts
+++ b/bridge/src/__tests__/apme-observed-turn-response.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ApmeStore } from '../apme/store.js';
+import { ApmeCollector } from '../apme/collector.js';
+
+/**
+ * Archiving contract for a hook-observed turn: whatever the timeline shows as
+ * `chat_response`, APME must hold as BOTH `turns.response` and an
+ * `assistant_message` trajectory event.
+ *
+ * This went unenforced and silently regressed. `setTurnResponse` was reachable
+ * only from the PTY session bridge, so direct `claude` / `codex` / standalone
+ * `opencode` sessions — which reach the daemon through hooks — archived a
+ * prompt and a full tool trajectory with no reply at all: 1589 claude-code
+ * turns held 219 responses, none newer than 2026-07-11, and only 15
+ * `assistant_message` events existed store-wide (12 of them OpenClaw's).
+ * The dashboard could not replay a conversation the timeline showed in full,
+ * and the judge scored those turns against silence.
+ */
+
+async function makeStore(): Promise<ApmeStore> {
+  const dir = mkdtempSync(join(tmpdir(), 'apme-resp-'));
+  const store = new ApmeStore(join(dir, 'apme.sqlite'));
+  const ok = await store.init();
+  if (!ok) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('APME store failed to initialize — is better-sqlite3 installed?');
+  }
+  (store as unknown as { _tmpDir: string })._tmpDir = dir;
+  return store;
+}
+
+function cleanup(store: ApmeStore) {
+  store.close();
+  const dir = (store as unknown as { _tmpDir?: string })._tmpDir;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+}
+
+const SID = 'observed-session';
+
+/** The daemon's observed-hook sequence for one turn, minus the response. */
+function driveTurn(collector: ApmeCollector, prompt: string) {
+  collector.ingestHook(SID, 'user_prompt_submit', { message: { content: prompt } });
+  collector.ingestHook(SID, 'tool_start', { tool_name: 'Read', tool_input: { file_path: 'a.ts' } });
+  collector.ingestHook(SID, 'tool_end', { tool_name: 'Read', tool_response: 'contents' });
+}
+
+function kindsFor(store: ApmeStore, taskId: string): string[] {
+  return (store.getSample(taskId)?.events ?? []).map((e) => e.kind);
+}
+
+describe('observed turn response archiving', () => {
+  let store!: ApmeStore;
+  let collector!: ApmeCollector;
+  beforeEach(async () => {
+    store = await makeStore();
+    collector = new ApmeCollector(store);
+    collector.openRun({ sessionId: SID, agentType: 'claude-code', projectName: 'AgentDeck' });
+  });
+  afterEach(() => { cleanup(store); });
+
+  it('archives the reply on the turn and as an assistant_message event', () => {
+    driveTurn(collector, '커밋하고 푸시하자.');
+    const taskId = collector.getActiveTaskId(SID)!;
+    expect(kindsFor(store, taskId)).toEqual(['user_message', 'tool']);
+
+    collector.setTurnResponse(SID, '커밋·푸시 완료했습니다. PR #132.');
+
+    const turn = store.listTurns(collector.getRunId(SID)!)[0];
+    expect(turn.response).toBe('커밋·푸시 완료했습니다. PR #132.');
+    const events = store.getSample(taskId)!.events;
+    expect(events.map((e) => e.kind)).toEqual(['user_message', 'tool', 'assistant_message']);
+    const assistant = events.find((e) => e.kind === 'assistant_message')!;
+    expect(assistant).toMatchObject({ responseKind: 'text', text: '커밋·푸시 완료했습니다. PR #132.' });
+  });
+
+  it('tags a tool-only turn so the judge skips it instead of scoring silence', () => {
+    driveTurn(collector, 'run the build');
+    collector.setTurnResponse(SID, '');
+
+    const turn = store.listTurns(collector.getRunId(SID)!)[0];
+    expect(JSON.parse(String(turn.efficiency_json)).response_kind).toBe('tool_only');
+  });
+
+  it('keeps each turn\'s reply on its own turn across a multi-turn task', () => {
+    driveTurn(collector, 'first');
+    collector.setTurnResponse(SID, 'first answer');
+    driveTurn(collector, 'second');
+    collector.setTurnResponse(SID, 'second answer');
+
+    const turns = store.listTurns(collector.getRunId(SID)!);
+    expect(turns.map((t) => [t.prompt, t.response])).toEqual([
+      ['first', 'first answer'],
+      ['second', 'second answer'],
+    ]);
+    // One user/tool/assistant arc per turn — the reply must not be duplicated
+    // onto the task by landing twice or re-attributing to the newest turn.
+    expect(kindsFor(store, collector.getActiveTaskId(SID)!)).toEqual([
+      'user_message', 'tool', 'assistant_message',
+      'user_message', 'tool', 'assistant_message',
+    ]);
+  });
+
+  it('lands a late reply on the last closed turn without overwriting one', () => {
+    driveTurn(collector, 'only turn');
+    collector.setTurnResponse(SID, 'real answer');
+    collector.closeTurnForSession(SID);
+
+    // A duplicate/late Stop for the same turn must not clobber the record.
+    collector.setLastClosedTurnResponse(SID, 'stale duplicate');
+    const turns = store.listTurns(collector.getRunId(SID)!);
+    expect(turns[0].response).toBe('real answer');
+  });
+});

--- a/bridge/src/__tests__/apme-task-page-and-graph.test.ts
+++ b/bridge/src/__tests__/apme-task-page-and-graph.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ApmeStore } from '../apme/store.js';
+import { buildApmeGraph, filePathFromToolPayload, shortenPath } from '../apme/graph.js';
+
+/**
+ * The task browse surface and the graph projection.
+ *
+ * Tasks are the canonical evaluation unit, but the only way to reach one used to
+ * be drilling into its run — `listAllTasks` returns bare rows that name no
+ * agent, model or project. And the row model, while a clean containment tree,
+ * had two severed edges (event→turn, run→continued-run) plus six hub entities
+ * living as denormalized strings, so nothing could be walked as a graph.
+ */
+
+async function makeStore(): Promise<ApmeStore> {
+  const dir = mkdtempSync(join(tmpdir(), 'apme-graph-'));
+  const store = new ApmeStore(join(dir, 'apme.sqlite'));
+  const ok = await store.init();
+  if (!ok) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('APME store failed to initialize — is better-sqlite3 installed?');
+  }
+  (store as unknown as { _tmpDir: string })._tmpDir = dir;
+  return store;
+}
+
+function cleanup(store: ApmeStore) {
+  store.close();
+  const dir = (store as unknown as { _tmpDir?: string })._tmpDir;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+}
+
+/** One run holding one task, one turn, and `tools` tool events. */
+function seedTask(store: ApmeStore, o: {
+  run: string; task: string; ts: number;
+  agent?: string; project?: string; projectPath?: string; model?: string; session?: string;
+  category?: string | null; parentRun?: string | null;
+  tools?: Array<{ name: string; file?: string }>;
+  response?: string | null;
+}) {
+  store.insertRun({
+    id: o.run, sessionId: o.session ?? `sess-${o.run}`,
+    agentType: (o.agent ?? 'claude-code') as never,
+    modelId: o.model ?? 'claude-opus-5',
+    projectName: o.project ?? 'AgentDeck',
+    ...(o.projectPath ? { projectPath: o.projectPath } : {}),
+    taskPrompt: 'seed prompt', startedAt: o.ts,
+  });
+  if (o.parentRun) store.updateRun(o.run, { parentRunId: o.parentRun });
+  store.insertTask({
+    id: o.task, runId: o.run, taskIndex: 0, boundarySignal: 'session_end', startedAt: o.ts,
+  });
+  // `insertTask` writes only the opening columns — a task is always born open
+  // and closed later, so the closed state has to come through updateTask.
+  store.updateTask(o.task, {
+    endedAt: o.ts + 1000,
+    ...(o.category != null ? { taskCategory: o.category } : {}),
+  });
+  const turnId = `turn-${o.task}`;
+  store.insertTurn({ id: turnId, runId: o.run, taskId: o.task, turnIndex: 0, prompt: 'do it', startedAt: o.ts });
+  if (o.response) store.updateTurn(turnId, { response: o.response });
+  (o.tools ?? []).forEach((t, i) => {
+    store.insertSampleEvent({
+      taskId: o.task, runId: o.run, turnIndex: 0, turnId,
+      seq: i, ts: o.ts + i, kind: 'tool', toolName: t.name, toolStatus: 'success',
+      payload: JSON.stringify({ input: t.file ? { file_path: t.file } : {} }),
+      dedupKey: `t${i}`,
+    });
+  });
+}
+
+describe('task page', () => {
+  let store!: ApmeStore;
+  beforeEach(async () => { store = await makeStore(); });
+  afterEach(() => { cleanup(store); });
+
+  it('carries the run context a bare task row lacks', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 2000, project: 'apple', model: 'claude-fable-5', response: 'done', tools: [{ name: 'Read' }] });
+    const { total, tasks } = store.listTaskPage({});
+    expect(total).toBe(1);
+    expect(tasks[0]).toMatchObject({
+      id: 't1', agentType: 'claude-code', projectName: 'apple', modelId: 'claude-fable-5',
+      turnCount: 1, answeredTurns: 1, toolCount: 1, firstPrompt: 'do it',
+    });
+  });
+
+  it('counts turns whose reply was never archived', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, response: null });
+    const [t] = store.listTaskPage({}).tasks;
+    // The gap the response-capture fix closed — a unit the judge can only
+    // partly see must be distinguishable from one that was fully captured.
+    expect(t.turnCount).toBe(1);
+    expect(t.answeredTurns).toBe(0);
+  });
+
+  it('pages without losing the unfiltered total', () => {
+    for (let i = 0; i < 5; i++) seedTask(store, { run: `r${i}`, task: `t${i}`, ts: 1000 + i });
+    const p1 = store.listTaskPage({ limit: 2, offset: 0 });
+    const p2 = store.listTaskPage({ limit: 2, offset: 2 });
+    expect(p1.total).toBe(5);
+    expect(p2.total).toBe(5);
+    expect(p1.tasks.map(t => t.id)).toEqual(['t4', 't3']);   // newest first
+    expect(p2.tasks.map(t => t.id)).toEqual(['t2', 't1']);
+  });
+
+  it('filters by agent, project and open/closed state', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, agent: 'codex-cli', project: 'apple' });
+    seedTask(store, { run: 'r2', task: 't2', ts: 2000, agent: 'claude-code', project: 'AgentDeck' });
+    store.insertTask({ id: 't3', runId: 'r2', taskIndex: 1, boundarySignal: 'open', startedAt: 3000 });
+
+    expect(store.listTaskPage({ agentType: 'codex-cli' }).tasks.map(t => t.id)).toEqual(['t1']);
+    expect(store.listTaskPage({ projectName: 'AgentDeck' }).tasks.map(t => t.id).sort()).toEqual(['t2', 't3']);
+    expect(store.listTaskPage({ state: 'open' }).tasks.map(t => t.id)).toEqual(['t3']);
+    expect(store.listTaskPage({ state: 'closed' }).tasks.map(t => t.id)).toEqual(['t2', 't1']);
+  });
+
+  it('hides bookkeeping shells the collector tagged _empty', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000 });
+    store.updateRun('r1', { taskCategory: '_empty' });
+    expect(store.listTaskPage({}).total).toBe(0);
+  });
+
+  it('offers facets from the whole store, not the current page', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, agent: 'codex-cli', project: 'apple' });
+    seedTask(store, { run: 'r2', task: 't2', ts: 2000, project: 'AgentDeck' });
+    const f = store.taskFacets();
+    expect(f.agents.sort()).toEqual(['claude-code', 'codex-cli']);
+    expect(f.projects.sort()).toEqual(['AgentDeck', 'apple']);
+  });
+});
+
+describe('tool payload path extraction', () => {
+  it('reads a path from the tool input, wherever the shape puts it', () => {
+    expect(filePathFromToolPayload(JSON.stringify({ input: { file_path: '/a/b/c.ts' } }))).toBe('/a/b/c.ts');
+    expect(filePathFromToolPayload(JSON.stringify({ file_path: '/x/y.ts' }))).toBe('/x/y.ts');
+    expect(filePathFromToolPayload(JSON.stringify({ input: { notebook_path: '/n.ipynb' } }))).toBe('/n.ipynb');
+  });
+
+  it('returns null rather than inventing a path', () => {
+    // Bash, WebFetch and friends take no path — partial coverage is the honest
+    // answer, and the slice reports the ratio instead of implying otherwise.
+    expect(filePathFromToolPayload(JSON.stringify({ input: { command: 'ls' } }))).toBeNull();
+    expect(filePathFromToolPayload('not json')).toBeNull();
+    expect(filePathFromToolPayload(null)).toBeNull();
+    expect(filePathFromToolPayload(JSON.stringify({ input: { file_path: '   ' } }))).toBeNull();
+  });
+
+  it('keys a file on its path relative to the project root', () => {
+    // Two checkouts of the same repo, at different depths — the root is what
+    // makes them one node.
+    expect(shortenPath('/Users/x/github/AgentDeck/src/a.ts', '/Users/x/github/AgentDeck')).toBe('src/a.ts');
+    expect(shortenPath('/Users/x/__worktrees/wt1/src/a.ts', '/Users/x/__worktrees/wt1')).toBe('src/a.ts');
+    expect(shortenPath('/Users/x/github/AgentDeck/src/a.ts', '/Users/x/github/AgentDeck/')).toBe('src/a.ts');
+  });
+
+  it('falls back to the path tail without claiming two paths are one file', () => {
+    // No root known, or the file lives outside it — the tail is a readable
+    // label, and two genuinely different files keep different node ids.
+    expect(shortenPath('/Users/x/github/AgentDeck/bridge/src/apme/store.ts')).toBe('src/apme/store.ts');
+    expect(shortenPath('/usr/include/stdio.h', '/Users/x/github/AgentDeck')).toBe('usr/include/stdio.h');
+    expect(shortenPath('a/b')).toBe('a/b');
+  });
+});
+
+describe('graph projection', () => {
+  let store!: ApmeStore;
+  beforeEach(async () => { store = await makeStore(); });
+  afterEach(() => { cleanup(store); });
+
+  const ids = (s: { nodes: Array<{ id: string }> }) => s.nodes.map(n => n.id).sort();
+
+  it('projects the containment spine and the derived entity hubs', () => {
+    seedTask(store, {
+      run: 'r1', task: 't1', ts: 1000, session: 's1', project: 'AgentDeck', model: 'claude-opus-5',
+      tools: [{ name: 'Read', file: '/repo/src/a.ts' }],
+    });
+    const g = buildApmeGraph(store, { minHubDegree: 1 });
+    expect(ids(g)).toContain('run:r1');
+    expect(ids(g)).toContain('task:t1');
+    // Session / project / model / agent are string columns, not rows — the
+    // projection is what makes them addressable.
+    expect(ids(g)).toContain('session:s1');
+    expect(ids(g)).toContain('project:AgentDeck');
+    expect(ids(g)).toContain('model:claude-opus-5');
+    expect(ids(g)).toContain('agent:claude-code');
+    expect(ids(g)).toContain('tool:Read');
+    expect(ids(g)).toContain('file:repo/src/a.ts');
+    expect(g.edges).toContainEqual(expect.objectContaining({ from: 'run:r1', to: 'task:t1', kind: 'contains' }));
+  });
+
+  it('connects two tasks that share only a file — the cross-link no ancestor gives', () => {
+    // Same repo file, two checkouts at different depths — only the project root
+    // makes them the same node; a fixed path-tail rule would split them.
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, session: 's1',
+      projectPath: '/Users/me/github/AgentDeck',
+      tools: [{ name: 'Edit', file: '/Users/me/github/AgentDeck/src/shared.ts' }] });
+    seedTask(store, { run: 'r2', task: 't2', ts: 2000, session: 's2',
+      projectPath: '/Users/me/__worktrees/wt1',
+      tools: [{ name: 'Edit', file: '/Users/me/__worktrees/wt1/src/shared.ts' }] });
+    const g = buildApmeGraph(store, { minHubDegree: 1, includeTurns: false });
+    const fileNode = g.nodes.find(n => n.kind === 'file');
+    expect(fileNode).toBeDefined();
+    const touching = g.edges.filter(e => e.to === fileNode!.id && e.kind === 'touched').map(e => e.from).sort();
+    expect(touching).toEqual(['task:t1', 'task:t2']);
+  });
+
+  it('collapses repeated calls into one weighted edge', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, tools: [{ name: 'Read' }, { name: 'Read' }, { name: 'Read' }] });
+    const g = buildApmeGraph(store, { minHubDegree: 1, includeTurns: false });
+    const used = g.edges.filter(e => e.kind === 'used');
+    // Three Read calls is one relationship of strength 3, not three edges.
+    expect(used).toHaveLength(1);
+    expect(used[0].weight).toBe(3);
+  });
+
+  it('draws the /clear continuation edge only when both runs are in the slice', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, session: 's1' });
+    seedTask(store, { run: 'r2', task: 't2', ts: 2000, session: 's1', parentRun: 'r1' });
+    const both = buildApmeGraph(store, { minHubDegree: 1, includeTurns: false });
+    expect(both.edges).toContainEqual(expect.objectContaining({ from: 'run:r1', to: 'run:r2', kind: 'continues' }));
+
+    // With only the child in view, a stub parent node would read as real work.
+    const child = buildApmeGraph(store, { limit: 1, minHubDegree: 1, includeTurns: false });
+    expect(child.edges.some(e => e.kind === 'continues')).toBe(false);
+    expect(child.nodes.some(n => n.id === 'run:r1')).toBe(false);
+  });
+
+  it('prunes one-off hubs but never containment nodes', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, tools: [{ name: 'Read' }, { name: 'Glob' }] });
+    seedTask(store, { run: 'r2', task: 't2', ts: 2000, tools: [{ name: 'Read' }] });
+    const g = buildApmeGraph(store, { minHubDegree: 2, includeTurns: false });
+    expect(g.nodes.some(n => n.id === 'tool:Read')).toBe(true);   // degree 2
+    expect(g.nodes.some(n => n.id === 'tool:Glob')).toBe(false);  // degree 1
+    expect(g.nodes.some(n => n.id === 'task:t1')).toBe(true);
+    // Pruning must not strand the edges that pointed at the removed hub.
+    const present = new Set(g.nodes.map(n => n.id));
+    for (const e of g.edges) { expect(present.has(e.from)).toBe(true); expect(present.has(e.to)).toBe(true); }
+  });
+
+  it('reports what it left out so a partial slice never reads as complete', () => {
+    for (let i = 0; i < 5; i++) {
+      seedTask(store, { run: `r${i}`, task: `t${i}`, ts: 1000 + i, tools: [{ name: 'Bash' }, { name: 'Read', file: '/r/a.ts' }] });
+    }
+    const g = buildApmeGraph(store, { limit: 2, minHubDegree: 1, includeTurns: false });
+    expect(g.stats.taskCount).toBe(2);
+    expect(g.stats.truncatedTasks).toBe(3);
+    // Bash carries no path — the ratio says so instead of the graph implying
+    // every tool event touched a file.
+    expect(g.stats.fileCoverage).toEqual({ toolEvents: 4, withPath: 2 });
+  });
+
+  it('attaches trajectory to turns when asked, and to the task when not', () => {
+    seedTask(store, { run: 'r1', task: 't1', ts: 1000, tools: [{ name: 'Read' }] });
+    const withTurns = buildApmeGraph(store, { minHubDegree: 1, includeTurns: true });
+    expect(withTurns.nodes.some(n => n.kind === 'turn')).toBe(true);
+    expect(withTurns.edges).toContainEqual(expect.objectContaining({ from: 'turn:turn-t1', to: 'tool:Read', kind: 'used' }));
+
+    const flat = buildApmeGraph(store, { minHubDegree: 1, includeTurns: false });
+    expect(flat.nodes.some(n => n.kind === 'turn')).toBe(false);
+    // The relationship survives at task altitude rather than being dropped.
+    expect(flat.edges).toContainEqual(expect.objectContaining({ from: 'task:t1', to: 'tool:Read', kind: 'used' }));
+  });
+});

--- a/bridge/src/apme/collector.ts
+++ b/bridge/src/apme/collector.ts
@@ -77,6 +77,17 @@ interface ActiveTask {
   timelineEmitted: boolean;
 }
 
+/** Where a trajectory event attaches. `turnIndex` is the run-scoped ordering key
+ *  the dedup hash is built from; `turnId` is the event→turn edge a graph
+ *  projection follows directly, and is optional only because a few late events
+ *  arrive with no turn in scope at all. */
+interface SampleCtx {
+  taskId: string;
+  runId: string;
+  turnIndex: number;
+  turnId?: string | undefined;
+}
+
 export type TaskBoundarySignal = 'todo_complete' | 'clear' | 'session_end' | 'manual' | 'idle_gap';
 
 /** Callback fired after a task is closed in DB. Used to enqueue task-level eval
@@ -292,7 +303,7 @@ export class ApmeCollector {
       // Sample trajectory: the user message opens the turn's typed event log.
       if (task) {
         this.appendSampleEvent(
-          { taskId: task.id, runId, turnIndex },
+          { taskId: task.id, runId, turnIndex, turnId },
           { kind: 'user_message', ts: turn.startedAt, dedupCore: hashCore(prompt ?? `turn${turnIndex}`), payloadObj: { text: prompt ?? '' } },
         );
       }
@@ -315,7 +326,7 @@ export class ApmeCollector {
       const task = this.sessionToTask.get(sessionId);
       if (task && toolName) {
         this.appendSampleEvent(
-          { taskId: task.id, runId, turnIndex: activeTurn.index },
+          { taskId: task.id, runId, turnIndex: activeTurn.index, turnId: activeTurn.id },
           {
             kind: 'tool', toolName, toolStatus: 'pending',
             dedupCore: `${toolName}:${activeTurn.toolCalls}`,
@@ -349,7 +360,7 @@ export class ApmeCollector {
           // No pending row (PostToolUse without a matching PreToolUse) — record
           // a resolved tool event directly.
           this.appendSampleEvent(
-            { taskId: task.id, runId, turnIndex },
+            { taskId: task.id, runId, turnIndex, turnId: this.turnIdFor(sessionId) },
             {
               kind: 'tool', toolName,
               toolStatus: isError ? 'error' : 'success',
@@ -377,7 +388,7 @@ export class ApmeCollector {
         const turnIndex = this.sessionToTurn.get(sessionId)?.index;
         if (task && turnIndex !== undefined) {
           this.appendSampleEvent(
-            { taskId: task.id, runId, turnIndex },
+            { taskId: task.id, runId, turnIndex, turnId: this.turnIdFor(sessionId) },
             { kind: 'state', dedupCore: `todos_complete:${turnIndex}:${todos.length}`, payloadObj: { state: 'todos_completed', count: todos.length } },
           );
           this.fireTaskMilestone(sessionId, task.id, runId, turnIndex, todos.length);
@@ -651,6 +662,16 @@ export class ApmeCollector {
     return this.sessionToRun.get(sessionId) ?? null;
   }
 
+  /** True while this collector still owns `runId` — some session maps to it and
+   *  will close it normally. The abandoned-run reaper consults this before
+   *  finalizing anything: an inactivity window alone would reap a live session
+   *  whose user simply stepped away mid-turn, and the row would then be closed
+   *  underneath the collector that is still writing to it. */
+  isLiveRun(runId: string): boolean {
+    for (const id of this.sessionToRun.values()) if (id === runId) return true;
+    return false;
+  }
+
   /** Agent type established for a session at `openRun` (survives closeRun so a
    *  late-attributed timeline row still resolves its brand). This is the single
    *  authoritative agentType source the timeline attributor backfills from, so
@@ -668,7 +689,7 @@ export class ApmeCollector {
   private sampleCtxForTurn(
     sessionId: string,
     turnId?: string,
-  ): { taskId: string; runId: string; turnIndex: number } | null {
+  ): SampleCtx | null {
     const active = this.sessionToTask.get(sessionId);
     if (turnId) {
       const row = this.store.getTurn(turnId);
@@ -676,13 +697,20 @@ export class ApmeCollector {
       const runId = (row?.run_id as string | undefined) ?? active?.runId;
       const turnIndex = (row?.turn_index as number | undefined)
         ?? this.sessionToTurn.get(sessionId)?.index ?? active?.lastTurnIndex ?? 0;
-      if (taskId && runId) return { taskId, runId, turnIndex };
+      if (taskId && runId) return { taskId, runId, turnIndex, turnId };
     }
     if (active) {
       const turnIndex = this.sessionToTurn.get(sessionId)?.index ?? active.lastTurnIndex ?? 0;
-      return { taskId: active.id, runId: active.runId, turnIndex };
+      return { taskId: active.id, runId: active.runId, turnIndex, turnId: this.sessionToTurn.get(sessionId)?.id };
     }
     return null;
+  }
+
+  /** The active turn's id, for stamping the event→turn edge on sample rows.
+   *  Falls back to the last closed turn so a trailing event (a PostToolUse that
+   *  lands after the turn rotated) still carries an edge instead of a null. */
+  private turnIdFor(sessionId: string): string | undefined {
+    return this.sessionToTurn.get(sessionId)?.id ?? this.sessionToLastTurnId.get(sessionId);
   }
 
   /** Append one typed trajectory event to the active sample. Storage-time dedup
@@ -690,7 +718,7 @@ export class ApmeCollector {
    *  only when a row was actually inserted (not a dup), so the timeline
    *  projection never double-emits. */
   private appendSampleEvent(
-    ctx: { taskId: string; runId: string; turnIndex: number },
+    ctx: SampleCtx,
     ev: {
       kind: TrajectoryEventKind;
       dedupCore: string;
@@ -712,6 +740,7 @@ export class ApmeCollector {
       taskId: ctx.taskId,
       runId: ctx.runId,
       turnIndex: ctx.turnIndex,
+      turnId: ctx.turnId ?? null,
       seq: this.store.nextSampleSeq(ctx.taskId),
       ts: ev.ts ?? Date.now(),
       kind: ev.kind,
@@ -882,7 +911,7 @@ export class ApmeCollector {
           const turnIndex = this.sessionToTurn.get(sessionId)?.index;
           if (task && turnIndex !== undefined) {
             this.appendSampleEvent(
-              { taskId: task.id, runId: task.runId, turnIndex },
+              { taskId: task.id, runId: task.runId, turnIndex, turnId: this.turnIdFor(sessionId) },
               { kind: 'state', dedupCore: `todos_complete:${turnIndex}`, payloadObj: { state: 'todos_completed' } },
             );
             this.fireTaskMilestone(sessionId, task.id, task.runId, turnIndex, null);
@@ -964,7 +993,7 @@ export class ApmeCollector {
     // Prefer the agent-reported marginal cost when available, else price the delta.
     const cost = priceUsd(model, dIn, dOut);
     this.appendSampleEvent(
-      { taskId: task.id, runId, turnIndex },
+      { taskId: task.id, runId, turnIndex, turnId: this.turnIdFor(sessionId) },
       {
         kind: 'model', model: model ?? undefined, inputTokens: dIn, outputTokens: dOut,
         costUsd: cost, latencyMs: 0, dedupCore: `${curIn}:${curOut}`,
@@ -993,14 +1022,22 @@ export class ApmeCollector {
     this.closeTask(sessionId, 'clear');
     // Close current run (no exitCode — session is still alive)
     this.closeRun(sessionId, undefined, projectPath);
-    // Open a new run with the same session parameters
-    return this.openRun({
+    // Open a new run with the same session parameters, pointing back at the run
+    // it continues. `/clear` resets the agent's context, not the user's work —
+    // without this edge one conversation becomes N disconnected runs (a live
+    // session here had 127), and nothing downstream can tell a genuine new
+    // session from the same session after a context reset.
+    const nextRunId = this.openRun({
       sessionId,
       agentType: run.agentType,
       modelId: run.modelId ?? undefined,
       projectName: run.projectName ?? undefined,
       projectPath: run.projectPath ?? undefined,
     });
+    if (nextRunId) {
+      try { this.store.updateRun(nextRunId, { parentRunId: runId }); } catch { /* ignore */ }
+    }
+    return nextRunId;
   }
 
   /** Update model id when the bridge resolves which model is in use. */

--- a/bridge/src/apme/dashboard-html.ts
+++ b/bridge/src/apme/dashboard-html.ts
@@ -99,6 +99,8 @@ tr.selected td{background:rgba(99,102,241,0.15);border-left:2px solid var(--acce
 .vibe-current{font-size:11px;color:var(--dim);display:flex;align-items:center;margin-left:8px}
 
 .panel{display:none}.panel.visible{display:block;height:100%}
+/* Graph needs a column flex box so the canvas can claim the leftover height. */
+.panel#panel-graph.visible{display:flex;flex-direction:column}
 .empty{color:var(--dim);font-style:italic;padding:20px;text-align:center}
 </style>
 </head>
@@ -113,6 +115,8 @@ tr.selected td{background:rgba(99,102,241,0.15);border-left:2px solid var(--acce
   <div class="left">
     <div class="tabs">
       <button class="tab active" onclick="showTab('runs')">Runs</button>
+      <button class="tab" onclick="showTab('tasks')">Tasks</button>
+      <button class="tab" onclick="showTab('graph')">Graph</button>
       <button class="tab" onclick="showTab('recommend')">Recommend</button>
       <button class="tab" onclick="showTab('scorecard')">Scorecard</button>
       <button class="tab" onclick="showTab('categories')">Categories</button>
@@ -130,6 +134,37 @@ tr.selected td{background:rgba(99,102,241,0.15);border-left:2px solid var(--acce
           <th>Agent</th><th>Model</th><th>Project</th><th>Category</th><th>Score</th><th>Outcome</th><th>Vibe</th><th>Task</th><th>Time</th>
         </tr></thead><tbody id="runs-body"></tbody></table>
       </div>
+      <!-- Tasks: every processed work unit, paged server-side. The Runs tab
+           lists sessions; this lists the units the judge actually scores. -->
+      <div class="panel" id="panel-tasks">
+        <div style="display:flex;gap:6px;padding:8px 10px;background:var(--surface);border-bottom:1px solid var(--border);flex-shrink:0;flex-wrap:wrap;align-items:center">
+          <input id="t-q" placeholder="Search prompt / summary" oninput="taskSearchDebounced()" style="background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:11px;flex:1;min-width:140px">
+          <select id="t-agent" onchange="loadTasks(0)" style="background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:11px"><option value="">All Agents</option></select>
+          <select id="t-project" onchange="loadTasks(0)" style="background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:11px"><option value="">All Projects</option></select>
+          <select id="t-cat" onchange="loadTasks(0)" style="background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:11px"><option value="">All Categories</option></select>
+          <select id="t-state" onchange="loadTasks(0)" style="background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:11px"><option value="">All</option><option value="closed">Closed</option><option value="open">Open</option></select>
+        </div>
+        <table><thead><tr>
+          <th>Task</th><th>Agent</th><th>Project</th><th>Category</th><th>Turns</th><th>Tools</th><th>Score</th><th>Outcome</th><th>Time</th>
+        </tr></thead><tbody id="tasks-body"></tbody></table>
+        <div id="tasks-pager" style="display:flex;gap:8px;align-items:center;justify-content:center;padding:10px;font-size:11px;color:var(--dim)"></div>
+      </div>
+      <!-- Graph: the row store as a property graph. Self-contained force
+           layout — the dashboard ships as one inlined HTML document. -->
+      <div class="panel" id="panel-graph">
+        <div style="display:flex;gap:6px;padding:8px 10px;background:var(--surface);border-bottom:1px solid var(--border);flex-shrink:0;flex-wrap:wrap;align-items:center">
+          <label style="font-size:11px;color:var(--dim)">Tasks <input id="g-limit" type="number" min="1" max="400" value="40" onchange="loadGraph()" style="width:56px;background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:11px"></label>
+          <label style="font-size:11px;color:var(--dim)">Min hub <input id="g-hub" type="number" min="1" max="20" value="2" onchange="loadGraph()" style="width:48px;background:var(--bg);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:11px"></label>
+          <label style="font-size:11px;color:var(--dim)"><input id="g-turns" type="checkbox" onchange="loadGraph()"> turns</label>
+          <label style="font-size:11px;color:var(--dim)"><input id="g-files" type="checkbox" checked onchange="loadGraph()"> files</label>
+          <span id="g-stats" style="font-size:11px;color:var(--dim);margin-left:auto"></span>
+        </div>
+        <div style="position:relative;flex:1;min-height:420px">
+          <canvas id="g-canvas" style="width:100%;height:100%;display:block;cursor:grab"></canvas>
+          <div id="g-legend" style="position:absolute;left:10px;bottom:10px;font-size:10px;color:var(--dim);background:rgba(0,0,0,0.35);padding:6px 8px;border-radius:4px;line-height:1.7"></div>
+          <div id="g-tip" style="position:absolute;display:none;pointer-events:none;background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;color:var(--muted);max-width:280px"></div>
+        </div>
+      </div>
       <div class="panel" id="panel-recommend"><div id="recommend-content" class="empty">Loading...</div></div>
       <div class="panel" id="panel-scorecard"><div id="scorecard-content" class="empty">Loading...</div></div>
       <div class="panel" id="panel-categories"><div id="categories-content" class="empty">Loading...</div></div>
@@ -144,6 +179,8 @@ tr.selected td{background:rgba(99,102,241,0.15);border-left:2px solid var(--acce
 
 <script>
 const B=location.origin;let selId=null;let allRuns=[];
+let selTaskId=null,taskOffset=0,taskTotal=0,tasksLoaded=false,taskSearchTimer=null;const TASK_PAGE=50;
+let graphSim=null;
 const AUTH=new URLSearchParams(location.search).get('token')||'';
 function api(path){const sep=path.includes('?')?'&':'?';return B+path+(AUTH?sep+'token='+encodeURIComponent(AUTH):'')}
 
@@ -152,6 +189,11 @@ function showTab(n){
   document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
   document.getElementById('panel-'+n).classList.add('visible');
   event.target.classList.add('active');
+  // Tasks and Graph load on first reveal, not at boot: both are server-paged
+  // queries over the whole store, and the graph canvas cannot size itself
+  // while its panel is display:none.
+  if(n==='tasks'&&!tasksLoaded){tasksLoaded=true;loadTasks(0)}
+  if(n==='graph'){requestAnimationFrame(()=>loadGraph())}
 }
 function fs(s){if(s==null)return'<span class="score score-na">—</span>';const p=Math.round(s*100),c=p>=70?'high':p>=40?'mid':'low';return'<span class="score score-'+c+'">'+p+'%</span>'}
 function fo(o){if(!o)return'';return'<span class="badge badge-'+o+'">'+o+'</span>'}
@@ -461,6 +503,108 @@ async function submitVibe(rid,v){
   catch(e){alert('Error: '+e.message)}
 }
 
+/* ── Tasks tab ──────────────────────────────────────────────────────────────
+   The task unit is what the judge scores, but it used to be reachable only by
+   drilling into a run — so there was no way to see everything processed. This
+   pages server-side (the store holds thousands of units) and keeps its filters
+   in the query rather than filtering a fetched page client-side, which would
+   silently hide matches beyond the page. */
+async function loadTasks(offset){
+  taskOffset=offset||0;
+  const body=document.getElementById('tasks-body');
+  const p=new URLSearchParams();
+  p.set('limit',String(TASK_PAGE));p.set('offset',String(taskOffset));
+  const q=document.getElementById('t-q').value.trim();if(q)p.set('q',q);
+  const ag=document.getElementById('t-agent').value;if(ag)p.set('agent',ag);
+  const pr=document.getElementById('t-project').value;if(pr)p.set('project',pr);
+  const ct=document.getElementById('t-cat').value;if(ct)p.set('category',ct);
+  const st=document.getElementById('t-state').value;if(st)p.set('state',st);
+  try{
+    const r=await fetch(api('/apme/tasks?'+p.toString()));const d=await r.json();
+    const tasks=d.tasks||[];taskTotal=d.total||0;
+    fillTaskFacets(d.facets||{});
+    if(!tasks.length){body.innerHTML='<tr><td colspan="9" class="empty">No tasks match</td></tr>';document.getElementById('tasks-pager').textContent='';return}
+    let h='';
+    for(const t of tasks){
+      const label=t.summary||t.firstPrompt||('Task '+t.taskIndex);
+      // A unit whose replies were never archived can only be partly judged —
+      // say so on the row instead of letting a blank score read as "not run".
+      const gap=t.turnCount>t.answeredTurns
+        ?' <span title="'+(t.turnCount-t.answeredTurns)+' turn(s) archived without a reply" style="color:var(--yellow)">◍</span>':'';
+      h+='<tr'+(selTaskId===t.id?' class="selected"':'')+' onclick="selectTask(\\''+t.id+'\\')">'+
+        '<td title="'+esc(label)+'">'+esc(label.slice(0,52))+gap+'</td>'+
+        '<td>'+esc(t.agentType||'')+'</td>'+
+        '<td>'+esc(t.projectName||'—')+'</td>'+
+        '<td>'+(t.taskCategory?'<span class="badge-cat">'+esc(t.taskCategory)+'</span>':'—')+'</td>'+
+        '<td>'+t.turnCount+'</td><td>'+t.toolCount+'</td>'+
+        '<td>'+fs(t.overallScore)+'</td>'+
+        '<td>'+(t.outcome?fo(t.outcome):(t.endedAt?'':'<span class="badge">open</span>'))+'</td>'+
+        '<td>'+(t.startedAt?new Date(t.startedAt).toLocaleString():'—')+'</td></tr>';
+    }
+    body.innerHTML=h;
+    const from=taskTotal?taskOffset+1:0,to=Math.min(taskOffset+tasks.length,taskTotal);
+    document.getElementById('tasks-pager').innerHTML=
+      '<button onclick="loadTasks('+Math.max(0,taskOffset-TASK_PAGE)+')" '+(taskOffset<=0?'disabled':'')+' style="background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:3px 10px;cursor:pointer">Prev</button>'+
+      '<span>'+from+'–'+to+' of '+taskTotal+'</span>'+
+      '<button onclick="loadTasks('+(taskOffset+TASK_PAGE)+')" '+(to>=taskTotal?'disabled':'')+' style="background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:3px 10px;cursor:pointer">Next</button>';
+  }catch(e){body.innerHTML='<tr><td colspan="9" class="empty">Error: '+esc(e.message)+'</td></tr>'}
+}
+function fillTaskFacets(f){
+  // Facets come from the whole store, not the current page, so a filter never
+  // offers only what happens to be visible.
+  const fill=(id,vals)=>{const s=document.getElementById(id);const cur=s.value;
+    while(s.options.length>1)s.remove(1);
+    (vals||[]).forEach(v=>{const o=document.createElement('option');o.value=v;o.textContent=v;s.add(o)});
+    s.value=cur;};
+  fill('t-agent',f.agents);fill('t-project',f.projects);fill('t-cat',f.categories);
+}
+function taskSearchDebounced(){clearTimeout(taskSearchTimer);taskSearchTimer=setTimeout(()=>loadTasks(0),250)}
+
+async function selectTask(id){
+  selTaskId=id;
+  const el=document.getElementById('detail-panel');
+  el.innerHTML='<div class="detail-empty">Loading...</div>';
+  try{
+    const r=await fetch(api('/apme/tasks/'+id));const d=await r.json();
+    const t=d.task||{},run=d.run||{},turns=d.turns||[],evals=d.evals||[],sample=d.sample;
+    let h='';
+    h+='<div class="detail-header"><h2>'+esc(t.summary||('Task '+t.taskIndex))+'</h2>';
+    h+='<div class="meta-row"><span>'+esc(run.agentType||'')+'</span><span>'+esc(run.modelId||'—')+'</span>'+
+       '<span>'+esc(run.projectName||'—')+'</span>'+
+       '<span>'+(t.startedAt?new Date(t.startedAt).toLocaleString():'—')+'</span>'+
+       '<span>'+(t.endedAt?fd(t.endedAt-t.startedAt):'<span style="color:var(--yellow)">open</span>')+'</span>'+
+       '<span>boundary '+esc(t.boundarySignal||'—')+'</span></div></div>';
+    h+='<div class="section"><div class="metric-grid">'
+       '<div class="metric-card"><div class="lbl">Score</div><div class="val">'+fs(d.overallScore??t.compositeScore)+'</div></div>'+
+       '<div class="metric-card"><div class="lbl">Turns</div><div class="val">'+turns.length+'</div></div>'+
+       '<div class="metric-card"><div class="lbl">Events</div><div class="val">'+((sample&&sample.events?sample.events.length:0))+'</div></div>'+
+       '<div class="metric-card"><div class="lbl">Cost</div><div class="val">'+(t.costUsd!=null?'$'+t.costUsd.toFixed(4):'—')+'</div></div>'+
+       '</div></div>';
+    if(evals.length){
+      h+='<div class="section"><div class="section-head"><span>Evals</span></div><table><tbody>';
+      for(const e of evals)h+='<tr><td>'+esc(e.layer)+'</td><td>'+esc(e.metric)+'</td><td>'+fs(e.score)+'</td></tr>';
+      h+='</tbody></table></div>';
+    }
+    // The conversation. This is what the response-capture gap used to make
+    // impossible to show: prompts with no replies beside them.
+    h+='<div class="section"><div class="section-head"><span>Conversation</span></div>';
+    if(!turns.length)h+='<div class="empty">No turns recorded</div>';
+    for(const tu of turns){
+      const prompt=tu.prompt||'',resp=tu.response;
+      h+='<div style="margin-bottom:12px">'+
+        '<div style="font-size:11px;color:var(--dim);margin-bottom:3px">turn '+tu.turn_index+'</div>'+
+        '<div style="white-space:pre-wrap;font-size:12px;color:var(--muted);border-left:2px solid var(--accent);padding-left:8px">'+esc(prompt.slice(0,1200))+'</div>';
+      h+= resp
+        ? '<div style="white-space:pre-wrap;font-size:12px;color:var(--dim);border-left:2px solid var(--border);padding-left:8px;margin-top:6px">'+esc(resp.slice(0,2000))+'</div>'
+        : '<div style="font-size:11px;color:var(--yellow);padding-left:10px;margin-top:6px">reply not archived</div>';
+      h+='</div>';
+    }
+    h+='</div>';
+    el.innerHTML=h;
+  }catch(e){el.innerHTML='<div class="detail-empty">Error: '+esc(e.message)+'</div>'}
+  loadTasks(taskOffset);
+}
+
 async function loadScorecard(){
   try{const r=await fetch(api('/apme/scorecard'));const d=await r.json();const c=d.scorecards||[];
   if(!c.length){document.getElementById('scorecard-content').innerHTML='<div class="empty">No scorecard data yet</div>';return}
@@ -514,8 +658,153 @@ async function loadRecommend(){
   }catch(e){document.getElementById('recommend-content').innerHTML='<div class="empty">Error: '+e.message+'</div>'}
 }
 
+/* ── Graph tab ──────────────────────────────────────────────────────────────
+   A force-directed view of /apme/graph. Hand-rolled rather than imported: the
+   dashboard is served as one self-contained HTML document with no external
+   fetches, so a CDN layout library is not an option.
+
+   Colour is by node kind; radius by degree, so the derived hubs (a file many
+   tasks touched, a tool used everywhere) are the ones that read as structural. */
+const G_COLORS={run:'#6166E0',task:'#22c55e',turn:'#64748b',session:'#eab308',project:'#06b6d4',model:'#a855f7',agent:'#C07058',tool:'#f97316',file:'#94a3b8'};
+const G_EDGE={contains:'rgba(148,163,184,0.35)',continues:'rgba(97,102,224,0.75)',produced:'rgba(234,179,8,0.30)',used:'rgba(249,115,22,0.30)',touched:'rgba(148,163,184,0.25)'};
+
+async function loadGraph(){
+  const stats=document.getElementById('g-stats');
+  const p=new URLSearchParams();
+  p.set('limit',document.getElementById('g-limit').value||'40');
+  p.set('minHubDegree',document.getElementById('g-hub').value||'2');
+  p.set('turns',document.getElementById('g-turns').checked?'1':'0');
+  p.set('files',document.getElementById('g-files').checked?'1':'0');
+  stats.textContent='Loading...';
+  try{
+    const r=await fetch(api('/apme/graph?'+p.toString()));const d=await r.json();
+    const s=d.stats||{};
+    // Say what was left out. A truncated graph that looks complete is worse
+    // than no graph — the shape would read as the whole history.
+    stats.textContent=s.nodeCount+' nodes · '+s.edgeCount+' edges · '+s.taskCount+' tasks'+
+      (s.truncatedTasks?' (+'+s.truncatedTasks+' not shown)':'')+
+      (s.fileCoverage?' · file paths on '+s.fileCoverage.withPath+'/'+s.fileCoverage.toolEvents+' tool events':'');
+    renderLegend(d.nodes||[]);
+    startGraphSim(d.nodes||[],d.edges||[]);
+  }catch(e){stats.textContent='Error: '+e.message}
+}
+
+function renderLegend(nodes){
+  const counts={};for(const n of nodes)counts[n.kind]=(counts[n.kind]||0)+1;
+  document.getElementById('g-legend').innerHTML=Object.keys(counts).sort().map(k=>
+    '<div><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:'+G_COLORS[k]+';margin-right:6px"></span>'+k+' ('+counts[k]+')</div>').join('');
+}
+
+function startGraphSim(nodes,edges){
+  const canvas=document.getElementById('g-canvas');
+  const dpr=window.devicePixelRatio||1;
+  const w=canvas.clientWidth||800,h=canvas.clientHeight||500;
+  canvas.width=w*dpr;canvas.height=h*dpr;
+  const ctx=canvas.getContext('2d');ctx.setTransform(dpr,0,0,dpr,0,0);
+  if(graphSim)cancelAnimationFrame(graphSim.raf);
+
+  const byId=new Map();
+  nodes.forEach((n,i)=>{
+    // Deterministic seeding — a golden-angle spiral, not Math.random(), so a
+    // reload of the same slice settles into the same picture and the layout is
+    // comparable between refreshes.
+    const a=i*2.399963,rad=6*Math.sqrt(i);
+    n.x=w/2+rad*Math.cos(a);n.y=h/2+rad*Math.sin(a);n.vx=0;n.vy=0;
+    n.r=Math.min(14,3+Math.sqrt(n.degree||1)*1.6);
+    byId.set(n.id,n);
+  });
+  const links=edges.map(e=>({s:byId.get(e.from),t:byId.get(e.to),kind:e.kind,w:e.weight||1}))
+                   .filter(l=>l.s&&l.t);
+
+  const view={x:0,y:0,k:1};let drag=null,hover=null;
+  canvas.onmousedown=(ev)=>{drag={x:ev.clientX,y:ev.clientY,vx:view.x,vy:view.y};canvas.style.cursor='grabbing'};
+  window.addEventListener('mouseup',()=>{drag=null;canvas.style.cursor='grab'});
+  canvas.onmousemove=(ev)=>{
+    const rect=canvas.getBoundingClientRect();
+    if(drag){view.x=drag.vx+(ev.clientX-drag.x);view.y=drag.vy+(ev.clientY-drag.y);return}
+    const mx=(ev.clientX-rect.left-view.x)/view.k,my=(ev.clientY-rect.top-view.y)/view.k;
+    hover=null;let best=1e9;
+    for(const n of nodes){const dx=n.x-mx,dy=n.y-my,d2=dx*dx+dy*dy;if(d2<Math.max(64,n.r*n.r*4)&&d2<best){best=d2;hover=n}}
+    const tip=document.getElementById('g-tip');
+    if(hover){
+      const meta=Object.entries(hover.meta||{}).filter(([,v])=>v!=null&&v!=='').map(([k,v])=>k+': '+v).join(' · ');
+      tip.style.display='block';tip.style.left=(ev.clientX-rect.left+12)+'px';tip.style.top=(ev.clientY-rect.top+12)+'px';
+      tip.innerHTML='<b style="color:'+G_COLORS[hover.kind]+'">'+esc(hover.kind)+'</b> '+esc(hover.label)+
+        '<div style="color:var(--dim);margin-top:3px">degree '+(hover.degree||0)+(meta?' · '+esc(meta):'')+'</div>';
+    } else tip.style.display='none';
+  };
+  canvas.onwheel=(ev)=>{ev.preventDefault();const f=ev.deltaY<0?1.1:0.9;view.k=Math.max(0.2,Math.min(4,view.k*f))};
+  canvas.onclick=()=>{if(hover&&hover.kind==='task'){showTabById('tasks');selectTask(hover.id.slice(5))}};
+
+  // Barnes-Hut would be overkill: the slice is capped at a few hundred nodes,
+  // so an O(n²) repulsion pass stays well inside a frame budget.
+  // Repulsion and rest length scale with node count: constants tuned on a
+  // 30-node slice collapse into an unreadable ball at 300, and the whole point
+  // of the view is that the hub structure is visible.
+  const repel=900+nodes.length*14;
+  const linkLen=50+Math.min(60,nodes.length*0.25);
+  let alpha=1;
+  function step(){
+    if(alpha>0.005){
+      for(let i=0;i<nodes.length;i++){
+        const a=nodes[i];
+        for(let j=i+1;j<nodes.length;j++){
+          const b=nodes[j];let dx=b.x-a.x,dy=b.y-a.y;let d2=dx*dx+dy*dy;
+          if(d2<0.01){dx=(i-j)*0.1;dy=0.1;d2=0.02}
+          if(d2>250000)continue;
+          const f=repel/d2,d=Math.sqrt(d2);
+          const fx=f*dx/d,fy=f*dy/d;
+          a.vx-=fx;a.vy-=fy;b.vx+=fx;b.vy+=fy;
+        }
+      }
+      for(const l of links){
+        const dx=l.t.x-l.s.x,dy=l.t.y-l.s.y,d=Math.sqrt(dx*dx+dy*dy)||0.01;
+        const f=(d-linkLen)*0.02;
+        const fx=f*dx/d,fy=f*dy/d;
+        l.s.vx+=fx;l.s.vy+=fy;l.t.vx-=fx;l.t.vy-=fy;
+      }
+      for(const n of nodes){
+        n.vx+=(w/2-n.x)*0.002;n.vy+=(h/2-n.y)*0.002;   // gravity keeps it on screen
+        n.x+=(n.vx*=0.82)*alpha;n.y+=(n.vy*=0.82)*alpha;
+      }
+      alpha*=0.985;
+    }
+    ctx.setTransform(dpr,0,0,dpr,0,0);
+    ctx.clearRect(0,0,w,h);
+    ctx.save();ctx.translate(view.x,view.y);ctx.scale(view.k,view.k);
+    for(const l of links){
+      ctx.strokeStyle=G_EDGE[l.kind]||'rgba(148,163,184,0.25)';
+      ctx.lineWidth=l.kind==='continues'?2:Math.min(3,0.6+Math.log2(l.w));
+      ctx.beginPath();ctx.moveTo(l.s.x,l.s.y);ctx.lineTo(l.t.x,l.t.y);ctx.stroke();
+    }
+    for(const n of nodes){
+      ctx.fillStyle=G_COLORS[n.kind]||'#94a3b8';
+      ctx.globalAlpha=hover&&hover!==n?0.55:1;
+      ctx.beginPath();ctx.arc(n.x,n.y,n.r,0,6.2832);ctx.fill();
+      // Label only what carries the structure, else the canvas is unreadable.
+      if(n.r>7||n===hover){
+        ctx.globalAlpha=1;ctx.fillStyle='#cbd5e1';ctx.font='10px ui-monospace,monospace';
+        ctx.fillText(String(n.label||'').slice(0,26),n.x+n.r+3,n.y+3);
+      }
+      ctx.globalAlpha=1;
+    }
+    ctx.restore();
+    graphSim.raf=requestAnimationFrame(step);
+  }
+  graphSim={raf:0};step();
+}
+/* showTab() reads the clicked element off the global event; switching tabs
+   from code needs the button, so find it rather than fake an event. */
+function showTabById(n){
+  const btn=[...document.querySelectorAll('.tab')].find(b=>b.getAttribute('onclick')==="showTab('"+n+"')");
+  if(btn)btn.click();
+}
+
 loadRuns();loadRecommend();loadScorecard();loadCategories();
 setInterval(loadRuns,15000);setInterval(loadRecommend,30000);setInterval(loadScorecard,30000);setInterval(loadCategories,30000);
+// Tasks refresh only while its tab is up — the query is server-paged and there
+// is no reason to run it against the store every 15s in the background.
+setInterval(()=>{if(document.getElementById('panel-tasks').classList.contains('visible'))loadTasks(taskOffset)},15000);
 </script>
 </body>
 </html>`;

--- a/bridge/src/apme/graph.ts
+++ b/bridge/src/apme/graph.ts
@@ -1,0 +1,245 @@
+/**
+ * Projects APME rows into a property graph (see shared/src/apme-graph.ts for
+ * the model and for what the row schema does and does not already express).
+ *
+ * Derived on demand, never persisted: the containment spine comes straight from
+ * foreign keys, while session / project / model / agent / tool / file hubs are
+ * materialized from denormalized columns and tool payloads. Those hubs are the
+ * reason this exists — they are the only edges that connect work units sharing
+ * no ancestor.
+ */
+
+import type {
+  ApmeGraphEdge, ApmeGraphEdgeKind, ApmeGraphNode, ApmeGraphSlice,
+} from '@agentdeck/shared';
+import { apmeGraphNodeId as nid } from '@agentdeck/shared';
+import type { ApmeStore } from './store.js';
+
+export interface ApmeGraphOptions {
+  /** Task units to include, newest first. The graph is anchored on tasks
+   *  because they are the canonical work unit. */
+  limit?: number;
+  agentType?: string;
+  projectName?: string;
+  category?: string;
+  /** Include turn nodes and their tool/file edges. Off keeps the slice at
+   *  run/task altitude, which is what a whole-history overview wants. */
+  includeTurns?: boolean;
+  /** Include file nodes derived from tool payloads. */
+  includeFiles?: boolean;
+  /** Drop tool/file hubs referenced fewer than this many times — the long tail
+   *  of one-off paths otherwise buries the structure. */
+  minHubDegree?: number;
+}
+
+/** Tool-input keys that name a filesystem path, in priority order. */
+const PATH_KEYS = ['file_path', 'filePath', 'path', 'notebook_path', 'file'] as const;
+
+/** Pull a file path out of a stored tool payload. Returns null for tools that
+ *  do not take one (Bash, WebFetch, …) — partial coverage is expected, and the
+ *  slice reports it rather than implying every tool touched a file. */
+export function filePathFromToolPayload(payload: string | null | undefined): string | null {
+  if (!payload) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(payload); } catch { return null; }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const input = (parsed as Record<string, unknown>).input;
+  const src = (input && typeof input === 'object' ? input : parsed) as Record<string, unknown>;
+  for (const key of PATH_KEYS) {
+    const v = src[key];
+    if (typeof v === 'string' && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+/** Identify a file by its path relative to the run's project root, so the same
+ *  file edited from a git worktree and from the main checkout lands on ONE node.
+ *
+ *  The project root is what makes this correct rather than lucky: a fixed
+ *  "last N segments" rule merges two checkouts only when their repo-relative
+ *  paths happen to be exactly N deep, and quietly splits the node otherwise
+ *  (`.../AgentDeck/src/a.ts` vs `.../__worktrees/wt1/src/a.ts` — same file,
+ *  different tails). Worktrees are routine here, so that failure would be too.
+ *
+ *  With no known root — or a path outside it, like a system header — fall back
+ *  to the last three segments: unambiguous enough to read, short enough to
+ *  render, and it never claims two paths are the same file. */
+export function shortenPath(path: string, projectPath?: string | null): string {
+  if (projectPath) {
+    const root = projectPath.endsWith('/') ? projectPath : projectPath + '/';
+    if (path.startsWith(root)) return path.slice(root.length);
+  }
+  const parts = path.split('/').filter(Boolean);
+  return parts.length <= 3 ? parts.join('/') : parts.slice(-3).join('/');
+}
+
+class GraphBuilder {
+  private readonly nodes = new Map<string, ApmeGraphNode>();
+  private readonly edges = new Map<string, ApmeGraphEdge>();
+
+  node(n: ApmeGraphNode): string {
+    const existing = this.nodes.get(n.id);
+    if (existing) {
+      // First writer wins on labels; later mentions only enrich empty fields so
+      // a hub referenced from many rows keeps one stable identity.
+      if (existing.ts == null && n.ts != null) existing.ts = n.ts;
+      if (existing.score == null && n.score != null) existing.score = n.score;
+      return n.id;
+    }
+    this.nodes.set(n.id, n);
+    return n.id;
+  }
+
+  edge(from: string, to: string, kind: ApmeGraphEdgeKind): void {
+    const key = `${from}|${to}|${kind}`;
+    const existing = this.edges.get(key);
+    // Parallel edges collapse into one weighted edge — 12 Read calls on the
+    // same file is one relationship of strength 12, not 12 relationships.
+    if (existing) { existing.weight = (existing.weight ?? 1) + 1; return; }
+    this.edges.set(key, { from, to, kind, weight: 1 });
+  }
+
+  /** Drop low-degree hubs and any edge left dangling by that removal.
+   *  Containment nodes are never pruned — they are the slice's subject. */
+  pruneHubs(minDegree: number): void {
+    if (minDegree <= 1) return;
+    const degree = new Map<string, number>();
+    for (const e of this.edges.values()) {
+      degree.set(e.from, (degree.get(e.from) ?? 0) + 1);
+      degree.set(e.to, (degree.get(e.to) ?? 0) + 1);
+    }
+    const prunable = new Set(['tool', 'file']);
+    const dropped = new Set<string>();
+    for (const n of this.nodes.values()) {
+      if (prunable.has(n.kind) && (degree.get(n.id) ?? 0) < minDegree) {
+        dropped.add(n.id);
+        this.nodes.delete(n.id);
+      }
+    }
+    if (dropped.size === 0) return;
+    for (const [key, e] of this.edges) {
+      if (dropped.has(e.from) || dropped.has(e.to)) this.edges.delete(key);
+    }
+  }
+
+  finish(): { nodes: ApmeGraphNode[]; edges: ApmeGraphEdge[] } {
+    const degree = new Map<string, number>();
+    for (const e of this.edges.values()) {
+      degree.set(e.from, (degree.get(e.from) ?? 0) + 1);
+      degree.set(e.to, (degree.get(e.to) ?? 0) + 1);
+    }
+    const nodes = [...this.nodes.values()].map((n) => ({ ...n, degree: degree.get(n.id) ?? 0 }));
+    return { nodes, edges: [...this.edges.values()] };
+  }
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+/** Build a graph slice anchored on the most recent task units. */
+export function buildApmeGraph(store: ApmeStore, opts: ApmeGraphOptions = {}): ApmeGraphSlice {
+  const limit = Math.min(Math.max(opts.limit ?? 60, 1), 400);
+  const includeTurns = opts.includeTurns ?? true;
+  const includeFiles = opts.includeFiles ?? true;
+  const minHubDegree = Math.max(opts.minHubDegree ?? 2, 1);
+
+  const page = store.listTaskPage({
+    limit,
+    ...(opts.agentType ? { agentType: opts.agentType } : {}),
+    ...(opts.projectName ? { projectName: opts.projectName } : {}),
+    ...(opts.category ? { category: opts.category } : {}),
+  });
+
+  const g = new GraphBuilder();
+  let toolEvents = 0;
+  let toolEventsWithPath = 0;
+
+  for (const t of page.tasks) {
+    const runId = t.runId;
+    const runNode = g.node({
+      id: nid.run(runId), kind: 'run', label: runId.slice(0, 8),
+      ts: t.startedAt,
+      meta: { project: t.projectName, agent: t.agentType, model: t.modelId },
+    });
+    const taskNode = g.node({
+      id: nid.task(t.id), kind: 'task',
+      label: (t.summary || t.firstPrompt || `Task ${t.taskIndex}`).slice(0, 60),
+      ts: t.startedAt,
+      score: t.overallScore,
+      meta: {
+        outcome: t.outcome ?? null,
+        category: t.taskCategory ?? null,
+        boundary: t.boundarySignal ?? null,
+        turns: t.turnCount,
+        answered: t.answeredTurns,
+        tools: t.toolCount,
+        cost: t.costUsd ?? null,
+      },
+    });
+    g.edge(runNode, taskNode, 'contains');
+
+    // ── Derived entity hubs ──
+    g.edge(g.node({ id: nid.session(t.sessionId), kind: 'session', label: t.sessionId.slice(0, 12) }), runNode, 'produced');
+    g.edge(g.node({ id: nid.agent(t.agentType), kind: 'agent', label: t.agentType }), runNode, 'produced');
+    if (t.projectName) {
+      g.edge(g.node({ id: nid.project(t.projectName), kind: 'project', label: t.projectName }), runNode, 'produced');
+    }
+    if (t.modelId) {
+      g.edge(g.node({ id: nid.model(t.modelId), kind: 'model', label: t.modelId }), runNode, 'produced');
+    }
+    // `/clear` continuation. The parent run is only drawn when it is already in
+    // the slice — a stub node for an out-of-slice run would read as real work.
+    if (t.parentRunId && page.tasks.some((o) => o.runId === t.parentRunId)) {
+      g.edge(nid.run(t.parentRunId), runNode, 'continues');
+    }
+
+    // ── Trajectory: tools and files ──
+    const events = store.listSampleEventRows(t.id);
+    for (const ev of events) {
+      if (ev.kind !== 'tool') continue;
+      toolEvents++;
+      const toolName = str(ev.toolName);
+      const turnId = str(ev.turnId);
+      // Attach to the turn when we have one and turns are shown; otherwise the
+      // task carries the relationship so the edge is never silently dropped.
+      let anchor = taskNode;
+      if (includeTurns && turnId) {
+        anchor = g.node({
+          id: nid.turn(turnId), kind: 'turn',
+          label: `turn ${ev.turnIndex ?? '?'}`,
+          ts: ev.ts,
+          meta: { index: num(ev.turnIndex) },
+        });
+        g.edge(taskNode, anchor, 'contains');
+      }
+      if (toolName) {
+        g.edge(anchor, g.node({ id: nid.tool(toolName), kind: 'tool', label: toolName }), 'used');
+      }
+      const path = filePathFromToolPayload(ev.payload);
+      if (path) toolEventsWithPath++;
+      if (path && includeFiles) {
+        const short = shortenPath(path, t.projectPath);
+        g.edge(anchor, g.node({ id: nid.file(short), kind: 'file', label: short, meta: { full: path } }), 'touched');
+      }
+    }
+  }
+
+  g.pruneHubs(minHubDegree);
+  const { nodes, edges } = g.finish();
+  return {
+    nodes,
+    edges,
+    stats: {
+      taskCount: page.tasks.length,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      truncatedTasks: Math.max(0, page.total - page.tasks.length),
+      fileCoverage: { toolEvents, withPath: toolEventsWithPath },
+    },
+  };
+}

--- a/bridge/src/apme/http.ts
+++ b/bridge/src/apme/http.ts
@@ -108,6 +108,52 @@ export async function handleApmeRequest(
       return true;
     }
 
+    // ── Tasks: the accumulating browse surface ──────────────────────────────
+    // Tasks are the canonical evaluation unit, but until this route the only
+    // way to reach one was to drill into its run — so there was no way to see
+    // "every work unit processed" at all. Paged + filtered + faceted so the
+    // list stays usable as the store grows past thousands of units.
+    if (method === 'GET' && path === '/apme/tasks') {
+      const limit = clampInt(url.searchParams.get('limit'), 1, 500, 50);
+      const offset = clampInt(url.searchParams.get('offset'), 0, 1_000_000, 0);
+      const stateParam = url.searchParams.get('state');
+      const { total, tasks } = apme.store.listTaskPage({
+        limit, offset,
+        ...(url.searchParams.get('agent') ? { agentType: url.searchParams.get('agent')! } : {}),
+        ...(url.searchParams.get('project') ? { projectName: url.searchParams.get('project')! } : {}),
+        ...(url.searchParams.get('category') ? { category: url.searchParams.get('category')! } : {}),
+        ...(url.searchParams.get('outcome') ? { outcome: url.searchParams.get('outcome')! } : {}),
+        ...(stateParam === 'closed' || stateParam === 'open' ? { state: stateParam } : {}),
+        ...(url.searchParams.get('q') ? { q: url.searchParams.get('q')! } : {}),
+      });
+      sendJson(res, 200, {
+        schema: EVAL_SCHEMA_VERSION,
+        total, limit, offset, tasks,
+        facets: apme.store.taskFacets(),
+      });
+      return true;
+    }
+
+    // ── Graph projection ────────────────────────────────────────────────────
+    // The row store viewed as a property graph: the run→task→turn containment
+    // spine plus the derived session/project/model/agent/tool/file hubs that
+    // connect work units sharing no ancestor. See shared/src/apme-graph.ts for
+    // what the schema does and does not already express.
+    if (method === 'GET' && path === '/apme/graph') {
+      const { buildApmeGraph } = await import('./graph.js');
+      const slice = buildApmeGraph(apme.store, {
+        limit: clampInt(url.searchParams.get('limit'), 1, 400, 60),
+        minHubDegree: clampInt(url.searchParams.get('minHubDegree'), 1, 50, 2),
+        includeTurns: url.searchParams.get('turns') !== '0',
+        includeFiles: url.searchParams.get('files') !== '0',
+        ...(url.searchParams.get('agent') ? { agentType: url.searchParams.get('agent')! } : {}),
+        ...(url.searchParams.get('project') ? { projectName: url.searchParams.get('project')! } : {}),
+        ...(url.searchParams.get('category') ? { category: url.searchParams.get('category')! } : {}),
+      });
+      sendJson(res, 200, { schema: EVAL_SCHEMA_VERSION, ...slice });
+      return true;
+    }
+
     if (method === 'GET' && path.startsWith('/apme/tasks/')) {
       const taskId = path.slice('/apme/tasks/'.length);
       const task = apme.store.getTask(taskId);
@@ -117,11 +163,19 @@ export async function handleApmeRequest(
       }
       const taskEvals = apme.store.listEvalsForTask(taskId);
       const turns = apme.store.listTurnsForTask(taskId);
+      const run = apme.store.getRun(task.runId);
       sendJson(res, 200, {
         schema: EVAL_SCHEMA_VERSION,
         task,
+        // Run context: the task row alone names no agent, model or project, so
+        // a task reached directly (not by drilling into a run) had no way to
+        // say whose work it was.
+        run,
         evals: taskEvals,
         turns,
+        // The canonical SessionSample — the typed trajectory the detail pane
+        // replays. Without it a task page can show scores but not the work.
+        sample: apme.store.getSample(taskId),
         overallScore: aggregateOverall(taskEvals),
       });
       return true;

--- a/bridge/src/apme/store.ts
+++ b/bridge/src/apme/store.ts
@@ -26,6 +26,7 @@ import type {
   ApmeVibeRow,
   ApmeScorecardRow,
   ApmeTaskRow,
+  ApmeTaskListRow,
 } from './types.js';
 import type {
   ApmeSampleEventRow,
@@ -462,6 +463,8 @@ type BetterSqliteDb = {
   exec: (sql: string) => void;
   close: () => void;
   pragma: (s: string) => unknown;
+  /** better-sqlite3 wraps `fn` in BEGIN/COMMIT and rolls back if it throws. */
+  transaction: <T>(fn: () => T) => () => T;
 };
 
 export class ApmeStore {
@@ -565,8 +568,55 @@ export class ApmeStore {
         try { this.db.exec(sql); } catch { /* ignore */ }
       }
     }
-    // sample_events table + indexes are created via CREATE TABLE IF NOT EXISTS
-    // in DDL; nothing to ALTER. The v_sample_scorecard view likewise.
+    // ── Graph-integrity columns ──
+    // The row model is a clean hierarchy (run → task → turn → event) EXCEPT for
+    // two severed edges, both of which a graph projection would have to guess at:
+    //
+    //  1. sample_events pointed at a turn by `turn_index`, an integer that is
+    //     only unique within a run — so the trajectory could not be walked back
+    //     to its turn without a compound join, and a task spanning turns had no
+    //     first-class event→turn edge at all.
+    //  2. `/clear` splits a session into a fresh run (`splitRun`) with no
+    //     pointer to the run it continues, so one conversation shows up as N
+    //     disconnected components. One live session here had 127 such runs.
+    const sevCols = (this.db.prepare("PRAGMA table_info(sample_events)").all() as Array<{ name: string }>).map(c => c.name);
+    if (!sevCols.includes('turn_id')) {
+      try { this.db.exec('ALTER TABLE sample_events ADD COLUMN turn_id TEXT'); } catch { /* ignore */ }
+      try { this.db.exec('CREATE INDEX IF NOT EXISTS idx_sevents_turn ON sample_events(turn_id)'); } catch { /* ignore */ }
+      // Backfill from the compound key the column replaces. One-shot: the
+      // column only appears once, so this never re-scans on later boots.
+      try {
+        this.db.exec(
+          `UPDATE sample_events SET turn_id = (
+             SELECT t.id FROM turns t
+             WHERE t.run_id = sample_events.run_id AND t.turn_index = sample_events.turn_index
+           ) WHERE turn_id IS NULL AND turn_index IS NOT NULL`,
+        );
+      } catch { /* best-effort backfill */ }
+    }
+    if (!cols.includes('parent_run_id')) {
+      try { this.db.exec('ALTER TABLE runs ADD COLUMN parent_run_id TEXT'); } catch { /* ignore */ }
+      try { this.db.exec('CREATE INDEX IF NOT EXISTS idx_runs_parent ON runs(parent_run_id)'); } catch { /* ignore */ }
+    }
+
+    // ── Covering indexes for the per-run/per-task rollups ──
+    // better-sqlite3 is synchronous on a single connection, so ANY slow query
+    // here stalls the daemon's whole HTTP path — this is a latency budget, not
+    // a nice-to-have. `MAX(ts)` over a run's steps was reading full rows to
+    // reach one integer, and `steps.payload` holds entire hook bodies, so the
+    // abandoned-run sweep was touching hundreds of megabytes and taking 22s.
+    // (run_id, ts) answers it from the index alone.
+    for (const sql of [
+      'CREATE INDEX IF NOT EXISTS idx_steps_run_ts ON steps(run_id, ts)',
+      'CREATE INDEX IF NOT EXISTS idx_sevents_run_ts ON sample_events(run_id, ts)',
+      'CREATE INDEX IF NOT EXISTS idx_turns_run_started ON turns(run_id, started_at)',
+      // evals had an index on run_id only, while the task rollup and the task
+      // list both look up by task_id.
+      'CREATE INDEX IF NOT EXISTS idx_evals_task ON evals(task_id)',
+      'CREATE INDEX IF NOT EXISTS idx_tasks_started ON tasks(started_at)',
+    ]) {
+      try { this.db.exec(sql); } catch { /* ignore */ }
+    }
   }
 
   private seedDefaultRubric(): void {
@@ -650,6 +700,7 @@ export class ApmeStore {
       exitCode: 'exit_code',
       gitBefore: 'git_before',
       gitAfter: 'git_after',
+      parentRunId: 'parent_run_id',
       hwProfile: 'hw_profile',
       taskSignals: 'task_signals',
       taskCategory: 'task_category',
@@ -808,6 +859,83 @@ export class ApmeStore {
       : `SELECT * FROM tasks ORDER BY started_at DESC LIMIT ?`;
     const rows = this.db.prepare(sql).all(limit) as Array<Record<string, unknown>>;
     return rows.map(rowToTask);
+  }
+
+  /** One page of task units with the run context needed to read them without a
+   *  second query — the browse surface for "every work unit we have processed".
+   *
+   *  `listAllTasks` returns bare task rows, which is why the dashboard could
+   *  only reach a task by drilling into its run: the row alone carries no agent,
+   *  model, project or prompt. Tasks are the canonical evaluation unit, so they
+   *  need a first-class list of their own.
+   *
+   *  `total` is the unpaged count for the same filters, so a caller can page
+   *  without guessing when it has reached the end. */
+  listTaskPage(opts: {
+    limit?: number;
+    offset?: number;
+    agentType?: string;
+    projectName?: string;
+    category?: string;
+    outcome?: string;
+    /** 'closed' — boundary hit; 'open' — still accumulating; default both. */
+    state?: 'closed' | 'open';
+    /** Substring match over the task summary and its run's first prompt. */
+    q?: string;
+  } = {}): { total: number; tasks: ApmeTaskListRow[] } {
+    if (!this.db) return { total: 0, tasks: [] };
+    const limit = Math.min(Math.max(opts.limit ?? 50, 1), 500);
+    const offset = Math.max(opts.offset ?? 0, 0);
+    const where: string[] = [];
+    const args: unknown[] = [];
+    // `_empty` runs are bookkeeping shells, never work the user did.
+    where.push("COALESCE(r.task_category, '') != '_empty'");
+    if (opts.agentType) { where.push('r.agent_type = ?'); args.push(opts.agentType); }
+    if (opts.projectName) { where.push('r.project_name = ?'); args.push(opts.projectName); }
+    if (opts.category) { where.push('COALESCE(t.task_category, r.task_category) = ?'); args.push(opts.category); }
+    if (opts.outcome) { where.push('t.outcome = ?'); args.push(opts.outcome); }
+    if (opts.state === 'closed') where.push('t.ended_at IS NOT NULL');
+    if (opts.state === 'open') where.push('t.ended_at IS NULL');
+    if (opts.q) {
+      where.push('(t.summary LIKE ? OR r.task_prompt LIKE ?)');
+      const like = `%${opts.q}%`; args.push(like, like);
+    }
+    const whereSql = `WHERE ${where.join(' AND ')}`;
+    const total = (this.db.prepare(
+      `SELECT COUNT(*) AS n FROM tasks t JOIN runs r ON r.id = t.run_id ${whereSql}`,
+    ).get(...args) as { n: number }).n;
+    const rows = this.db.prepare(
+      `SELECT t.*,
+              r.session_id, r.agent_type, r.model_id AS run_model_id, r.project_name,
+              r.project_path, r.task_prompt AS run_prompt, r.parent_run_id,
+              (SELECT COUNT(*) FROM turns tu WHERE tu.task_id = t.id) AS turn_count,
+              (SELECT COUNT(*) FROM turns tu WHERE tu.task_id = t.id AND tu.response IS NOT NULL) AS answered_turns,
+              (SELECT COUNT(*) FROM sample_events se WHERE se.task_id = t.id) AS event_count,
+              (SELECT COUNT(*) FROM sample_events se WHERE se.task_id = t.id AND se.kind = 'tool') AS tool_count,
+              (SELECT tu.prompt FROM turns tu WHERE tu.task_id = t.id ORDER BY tu.turn_index ASC LIMIT 1) AS first_prompt,
+              (SELECT e.score FROM evals e WHERE e.task_id = t.id AND e.metric = 'overall' ORDER BY e.created_at DESC LIMIT 1) AS overall_score,
+              (SELECT COUNT(*) FROM evals e WHERE e.task_id = t.id) AS eval_count
+       FROM tasks t JOIN runs r ON r.id = t.run_id
+       ${whereSql}
+       ORDER BY t.started_at DESC
+       LIMIT ? OFFSET ?`,
+    ).all(...args, limit, offset) as Array<Record<string, unknown>>;
+    return { total, tasks: rows.map(rowToTaskListRow) };
+  }
+
+  /** Distinct values behind the task list's filters, so the UI offers what the
+   *  data actually contains rather than a hardcoded menu. */
+  taskFacets(): { agents: string[]; projects: string[]; categories: string[]; outcomes: string[] } {
+    if (!this.db) return { agents: [], projects: [], categories: [], outcomes: [] };
+    const col = (sql: string): string[] =>
+      (this.db!.prepare(sql).all() as Array<{ v: string | null }>)
+        .map((r) => r.v).filter((v): v is string => typeof v === 'string' && v.length > 0);
+    return {
+      agents: col('SELECT DISTINCT agent_type AS v FROM runs ORDER BY v'),
+      projects: col('SELECT DISTINCT project_name AS v FROM runs ORDER BY v'),
+      categories: col("SELECT DISTINCT COALESCE(task_category,'') AS v FROM tasks WHERE v != '' ORDER BY v"),
+      outcomes: col("SELECT DISTINCT COALESCE(outcome,'') AS v FROM tasks WHERE v != '' ORDER BY v"),
+    };
   }
 
   listTurnsForTask(taskId: string): Array<Record<string, unknown>> {
@@ -1032,6 +1160,85 @@ export class ApmeStore {
     return rows.map((r) => ({ id: r.id, runId: r.run_id }));
   }
 
+  /** Abandoned runs: real work that was never closed. The daemon restarted (or
+   *  crashed) mid-session, so the in-memory session→run map `closeRun` depends
+   *  on is gone and nothing will ever finalize these rows.
+   *
+   *  Distinct from `listOrphanedRuns`, which by design only matches empty
+   *  shells (`task_prompt IS NULL` + no turns) and so steps right over the case
+   *  that actually costs data: a run carrying prompts, turns and a whole tool
+   *  trajectory stays open forever, its task never closes, and a task that
+   *  never closes is never evaluated.
+   *
+   *  Staleness is measured from the LAST recorded activity, never
+   *  `started_at` — a live multi-hour session must not be reaped out from
+   *  under the process that owns it (session bridges share this sqlite file
+   *  and the daemon cannot see their in-memory state). Callers additionally
+   *  skip runs their own collector still holds open.
+   *  `lastActivity` is returned so the caller can close the rows AT the last
+   *  activity instead of `now`, keeping durations honest. */
+  listAbandonedRuns(staleSec: number = 7200, limit: number = 20): Array<{ id: string; projectPath: string | null; lastActivity: number }> {
+    if (!this.db) return [];
+    const cutoff = Date.now() - staleSec * 1000;
+    const rows = this.db.prepare(
+      `SELECT id, project_path, last_activity FROM (
+         SELECT r.id AS id, r.project_path AS project_path,
+           MAX(
+             r.started_at,
+             COALESCE((SELECT MAX(MAX(t.started_at, COALESCE(t.ended_at, 0))) FROM turns t WHERE t.run_id = r.id), 0),
+             COALESCE((SELECT MAX(s.ts) FROM steps s WHERE s.run_id = r.id), 0),
+             COALESCE((SELECT MAX(se.ts) FROM sample_events se WHERE se.run_id = r.id), 0)
+           ) AS last_activity
+         FROM runs r
+         WHERE r.ended_at IS NULL
+           -- Sound pre-filter, not an approximation: last_activity is a MAX that
+           -- includes started_at, so last_activity < cutoff implies
+           -- started_at < cutoff. Checking it first lets idx_runs_started skip
+           -- every recent run before the correlated MAXes are evaluated.
+           AND r.started_at < ?
+           AND EXISTS (SELECT 1 FROM turns t WHERE t.run_id = r.id)
+       )
+       WHERE last_activity < ?
+       ORDER BY last_activity ASC
+       LIMIT ?`,
+    ).all(cutoff, cutoff, limit) as Array<{ id: string; project_path: string | null; last_activity: number }>;
+    return rows.map((r) => ({ id: r.id, projectPath: r.project_path, lastActivity: r.last_activity }));
+  }
+
+  /** Finalize an abandoned run: close its dangling turns, close its tasks with
+   *  `boundary_signal='orphaned'`, then close the run itself — all stamped at
+   *  `endedAt` (the run's last activity), not `now`, so a run abandoned last
+   *  night doesn't report a 12-hour turn.
+   *
+   *  Tasks are backfilled with their real first/last turn index when the
+   *  in-memory close never ran, since the task rollup reads those columns.
+   *  Returns the closed task ids so the caller can enqueue task-level evals —
+   *  the whole point of closing them. */
+  reapAbandonedRun(runId: string, endedAt: number): Array<{ id: string; category: string | null }> {
+    if (!this.db) return [];
+    const bounds = this.db.prepare(
+      'SELECT MIN(turn_index) AS lo, MAX(turn_index) AS hi FROM turns WHERE run_id = ?',
+    ).get(runId) as { lo: number | null; hi: number | null } | undefined;
+    const tasks = this.db.prepare(
+      'SELECT id, task_category FROM tasks WHERE run_id = ? AND ended_at IS NULL',
+    ).all(runId) as Array<{ id: string; task_category: string | null }>;
+    const tx = this.db.transaction(() => {
+      this.db!.prepare('UPDATE turns SET ended_at = ? WHERE run_id = ? AND ended_at IS NULL').run(endedAt, runId);
+      this.db!.prepare(
+        `UPDATE tasks SET ended_at = ?, boundary_signal = 'orphaned',
+           first_turn_index = COALESCE(first_turn_index, ?),
+           last_turn_index  = COALESCE(last_turn_index, ?)
+         WHERE run_id = ? AND ended_at IS NULL`,
+      ).run(endedAt, bounds?.lo ?? null, bounds?.hi ?? null, runId);
+      this.db!.prepare('UPDATE runs SET ended_at = ? WHERE id = ? AND ended_at IS NULL').run(endedAt, runId);
+    });
+    try { tx(); } catch (err) {
+      debug('APME', `reapAbandonedRun ${runId.slice(0, 8)} failed: ${String(err)}`);
+      return [];
+    }
+    return tasks.map((t) => ({ id: t.id, category: t.task_category }));
+  }
+
   /** Orphaned runs: started long ago, never closed, no turns.
    *  Typically from session bridges that crashed without cleanup. */
   listOrphanedRuns(staleSec: number = 1800): string[] {
@@ -1057,11 +1264,11 @@ export class ApmeStore {
     if (!this.db) return false;
     const res = this.db.prepare(
       `INSERT OR IGNORE INTO sample_events
-        (task_id, run_id, turn_index, seq, ts, kind, model, input_tokens, output_tokens,
+        (task_id, run_id, turn_index, turn_id, seq, ts, kind, model, input_tokens, output_tokens,
          cost_usd, latency_ms, tool_name, tool_status, tool_error, payload, dedup_key)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     ).run(
-      row.taskId, row.runId, row.turnIndex ?? null, row.seq, row.ts, row.kind,
+      row.taskId, row.runId, row.turnIndex ?? null, row.turnId ?? null, row.seq, row.ts, row.kind,
       row.model ?? null, row.inputTokens ?? null, row.outputTokens ?? null,
       row.costUsd ?? null, row.latencyMs ?? null,
       row.toolName ?? null, row.toolStatus ?? null, row.toolError ?? null,
@@ -1232,6 +1439,7 @@ function rowToRun(r: Record<string, unknown>): ApmeRunRow {
     exitCode: (r.exit_code as number | null) ?? null,
     gitBefore: (r.git_before as string | null) ?? null,
     gitAfter: (r.git_after as string | null) ?? null,
+    parentRunId: (r.parent_run_id as string | null) ?? null,
     hwProfile: (r.hw_profile as string | null) ?? null,
     taskSignals: (r.task_signals as string | null) ?? null,
     taskCategory: (r.task_category as string | null) ?? null,
@@ -1267,12 +1475,35 @@ function rowToTask(r: Record<string, unknown>): ApmeTaskRow {
   };
 }
 
+/** Task row + the run context that makes it readable on its own. `modelId`
+ *  prefers the task's own sample header and falls back to the run's, since only
+ *  newer tasks carry one. */
+function rowToTaskListRow(r: Record<string, unknown>): ApmeTaskListRow {
+  return {
+    ...rowToTask(r),
+    sessionId: r.session_id as string,
+    agentType: r.agent_type as ApmeTaskListRow['agentType'],
+    modelId: (r.model_id as string | null) ?? (r.run_model_id as string | null) ?? null,
+    projectName: (r.project_name as string | null) ?? null,
+    projectPath: (r.project_path as string | null) ?? null,
+    parentRunId: (r.parent_run_id as string | null) ?? null,
+    firstPrompt: (r.first_prompt as string | null) ?? (r.run_prompt as string | null) ?? null,
+    turnCount: (r.turn_count as number | null) ?? 0,
+    answeredTurns: (r.answered_turns as number | null) ?? 0,
+    eventCount: (r.event_count as number | null) ?? 0,
+    toolCount: (r.tool_count as number | null) ?? 0,
+    evalCount: (r.eval_count as number | null) ?? 0,
+    overallScore: (r.overall_score as number | null) ?? (r.composite_score as number | null) ?? null,
+  };
+}
+
 function rowToSampleEvent(r: Record<string, unknown>): ApmeSampleEventRow {
   return {
     id: r.id as number,
     taskId: r.task_id as string,
     runId: r.run_id as string,
     turnIndex: (r.turn_index as number | null) ?? null,
+    turnId: (r.turn_id as string | null) ?? null,
     seq: r.seq as number,
     ts: r.ts as number,
     kind: r.kind as ApmeSampleEventRow['kind'],

--- a/bridge/src/apme/types.ts
+++ b/bridge/src/apme/types.ts
@@ -18,6 +18,7 @@ export type {
   ApmeScorecardRow,
   ApmeCategoryScorecardRow,
   ApmeTaskRow,
+  ApmeTaskListRow,
   TaskBoundarySignal,
   ParsedJudge,
   ResponseKind,

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -77,6 +77,16 @@ const OBSERVED_APPROVAL_HOLD_MS = Math.min(
   50_000,
   Math.max(5_000, Number(process.env.AGENTDECK_APPROVAL_HOLD_MS) || 25_000),
 );
+/** Inactivity after which an unclosed APME run is treated as abandoned and
+ *  finalized. Deliberately generous: an orphan stays reapable forever, so
+ *  closing it late costs nothing, while reaping a live run corrupts the unit
+ *  being measured. Session bridges own their own collector state and are
+ *  invisible to this daemon, so only elapsed silence protects them (runs this
+ *  daemon still holds are skipped via `collector.isLiveRun`). */
+const APME_ABANDONED_RUN_STALE_SEC = Math.max(
+  600,
+  Number(process.env.AGENTDECK_APME_ABANDON_SEC) || 7200,
+);
 import { VoiceManager } from './voice.js';
 import { VoiceAssistantManager } from './voice-assistant.js';
 import {
@@ -2144,6 +2154,26 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           const respRaw = responseText.length > 0
             ? cleanRawText(responseText.length > 200 ? responseText.slice(0, 197) + '...' : responseText)
             : '';
+          // APME: the text below is the assistant half of the turn — hand it to
+          // the collector on the SAME branch that decides the timeline row.
+          // `setTurnResponse` was reachable only from the PTY session bridge
+          // (bridge/src/index.ts), which hook-observed sessions (direct
+          // `claude` / `codex` / standalone `opencode`) never go through, so
+          // every such turn archived a prompt and its tool calls but no reply:
+          // `turns.response` stayed NULL and no `assistant_message` trajectory
+          // event was ever written. The dashboard therefore could not replay a
+          // conversation the timeline shows in full, and the judge scored those
+          // turns against silence. Empty text is still worth recording — it
+          // tags `response_kind` tool_only/empty so the runner skips judging.
+          if (apme) {
+            if (turnOpen) apme.collector.setTurnResponse(hookSid, responseText);
+            else if (responseText.length > 0) {
+              // No open turn: a missed prompt hook or a late/duplicate stop.
+              // The last-closed fallback refuses to overwrite an existing
+              // response, so a duplicate stop is a no-op instead of a clobber.
+              apme.collector.setLastClosedTurnResponse(hookSid, responseText);
+            }
+          }
           if (turnOpen && lastStart) {
             const now = Date.now();
             const taskId = (apme
@@ -4816,6 +4846,41 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       const orphans = apme!.store.listOrphanedRuns(1800); // 30 min stale threshold
       for (const id of orphans) {
         apme!.store.updateRun(id, { endedAt: Date.now(), taskCategory: '_empty' });
+      }
+      // 5. Reap ABANDONED runs — the ones step 4 cannot see. A daemon restart
+      //    (or crash) drops the in-memory session→run map, so every run that
+      //    was mid-session is left with ended_at NULL forever. Those carry real
+      //    prompts and turns, so they fail step 4's empty-shell predicate, and
+      //    because their TASK also never closes they are never evaluated: the
+      //    store had accumulated 65 open tasks against 9 closed ones.
+      //    Closing the run makes step 1 pick it up next tick; the task eval has
+      //    to be enqueued here, since its normal trigger (`onTaskClosed`) fires
+      //    from the collector's in-memory close path, which is exactly what
+      //    went missing.
+      //    Batched small: `enqueueTask` dispatches immediately with no
+      //    concurrency cap, so a backlog is drained a few per tick rather than
+      //    fired at the judge all at once.
+      const abandoned = apme!.store.listAbandonedRuns(APME_ABANDONED_RUN_STALE_SEC, 5);
+      for (const run of abandoned) {
+        if (apme!.collector.isLiveRun(run.id)) continue; // still owned by us
+        const closedTasks = apme!.store.reapAbandonedRun(run.id, run.lastActivity);
+        for (const task of closedTasks) {
+          // Judge only what there is something to judge. The backlog this
+          // reaper drains predates the response-capture fix, so most of those
+          // tasks hold prompts and tool calls but no reply — scoring them would
+          // push hundreds of "judged against silence" rows into the scorecard,
+          // the same noise `response_kind` exists to keep out. Closing the row
+          // is the data-hygiene win; the eval is a bonus when it can be earned.
+          const hasReply = apme!.store.listTurnsForTask(task.id)
+            .some((t) => typeof t.response === 'string' && t.response.trim().length > 0);
+          if (!hasReply) continue;
+          apme!.runner.enqueueTask({
+            runId: run.id, taskId: task.id,
+            ...(task.category ? { category: task.category } : {}),
+            boundarySignal: 'orphaned',
+          });
+        }
+        debug('APME', `reaped abandoned run ${run.id.slice(0, 8)} — ${closedTasks.length} task(s) closed`);
       }
     }, 30_000); // every 30s
     core.addInterval(apmeEvalTimer);

--- a/docs/apme.md
+++ b/docs/apme.md
@@ -103,7 +103,7 @@ daemon 없이 session bridge 단독 사용 시 데이터만 축적되고 coding 
 id, session_id, agent_type, model_id, project_name, project_path,
 task_prompt, started_at, ended_at,
 input_tokens, output_tokens, cost_usd, exit_code,
-git_before, git_after, hw_profile,
+git_before, git_after, parent_run_id, hw_profile,
 task_signals, task_category, task_category_source,
 outcome, outcome_confidence,
 efficiency_json, composite_score
@@ -115,6 +115,18 @@ efficiency_json, composite_score
 - `task_category` — 10개 카테고리 중 하나, `task_category_source` 는 `'rule' | 'llm' | 'auto'`
 - `outcome` — `committed | iterated | exploratory | abandoned | interrupted | ab_winner | ab_loser | pending`
 - `composite_score` — 4차원 가중합 (outcome + judge + efficiency + vibe)
+- `parent_run_id` — `/clear` 로 갈라진 직전 run. `/clear` 는 컨텍스트를 리셋할 뿐 사용자의 작업을 끝내지 않으므로, 이 엣지가 없으면 한 대화가 서로 끊긴 N개의 run 으로 흩어진다 (실제로 한 세션에 127 run 관측). 진짜 세션 시작이면 NULL
+
+### 그래프 투영 — 행 저장소를 property graph 로 보기
+
+`runs → tasks → turns → sample_events` 는 실제 FK 를 가진 containment tree 라 그대로 그래프가 된다. 하지만 **작업 단위끼리 이어주는 간선**(공통 조상이 없는 두 task 의 연결)은 컬럼에 문자열로 눌려 있었다. 그래서:
+
+- **스키마로 고친 것** — `sample_events.turn_id`(기존엔 run 안에서만 유일한 `turn_index` 뿐이라 event→turn 엣지가 아예 없었음), `runs.parent_run_id`(위 참고). 둘 다 마이그레이션에서 backfill.
+- **투영으로 유도하는 것** — session / project / model / agent / tool / file 은 행이 아니라 컬럼·payload 이므로 `bridge/src/apme/graph.ts` 가 노드로 materialize 한다. 특히 **file 노드**는 tool payload 의 `file_path` 에서 뽑아 run 의 `project_path` 기준 상대경로로 키잉하므로, 같은 파일을 worktree 와 본 체크아웃에서 만졌어도 한 노드로 합쳐진다. 커버리지는 부분적이다(경로를 받지 않는 Bash/WebFetch 등) — `stats.fileCoverage` 가 그 비율을 그대로 보고한다.
+
+모델 정의는 `shared/src/apme-graph.ts`(SSOT), 빌더는 `bridge/src/apme/graph.ts`, 노출은 `GET /apme/graph`, 뷰어는 대시보드 **Graph** 탭(외부 라이브러리 없이 canvas force layout — 대시보드는 self-contained HTML 이라 CDN 을 못 쓴다).
+
+투영은 파생물이며 저장하지 않는다 — 마이그레이션 없이 형태를 바꿀 수 있다.
 
 ### turns — 멀티턴 세션의 개별 턴
 
@@ -186,6 +198,8 @@ v_category_scorecard    -- (task_category, model_id) 그룹: runs, avg_overall,
 2. **Claude Code**: `adapter.on('event', 'hook')` → `apme.collector.ingestHook(sessionId, event, data)`
 3. **Non-Claude 에이전트** (OpenClaw/OpenCode/Codex): `wireAgentApme(adapter, agentType, apme, core, ptyRingBuffer)` — timeline 이벤트 + PTY parser 이벤트를 collector로 변환
 4. **Claude Code PTY 응답 캡처**: `spinner_stop` 이벤트 + 500ms 지연 → 링버퍼 tail에서 `⏺` 마커 기반 파싱 → `setTurnResponse()`. `pendingPtyResponse` 3-path race 해결
+
+> **관측(observed) 세션의 응답 캡처는 데몬 쪽에 따로 있다.** 위 PTY 경로는 `agentdeck claude` 로 띄운 managed 세션 전용이라, 직접 실행한 `claude`/`codex`/`opencode` 는 이 경로를 타지 않는다. 그 결과 hook 으로만 관측되는 세션은 프롬프트와 툴 궤적만 아카이빙되고 **응답은 통째로 유실**됐다 (claude-code turn 1589개 중 response 219개, 마지막이 2026-07-11; `assistant_message` 궤적 이벤트는 전 기간 15개뿐이고 그중 12개가 OpenClaw). 대시보드가 TIMELINE 이 온전히 보여주는 대화를 재현할 수 없었고, judge 는 침묵을 채점하고 있었다. 지금은 `daemon-server.ts` 의 stop 훅 핸들러가 타임라인 행을 결정하는 **같은 분기에서** `setTurnResponse()` 를 호출한다. Swift 데몬도 같은 증상이었지만 원인이 달랐다 — `getLastEntry(type:"chat_end")` 를 읽었는데 `chat_end` 는 응답이 **없을 때만** 나오는 행이라 구조적으로 응답을 볼 수 없었다(`DaemonServer.appendClaudeCodeChatEnd` 로 이동).
 5. `usage_info` 메타데이터 → `apme.collector.updateUsage(sessionId, snapshot)`
 6. `state_changed` → `apme.collector.updateModel(sessionId, modelName)`
 
@@ -202,7 +216,8 @@ v_category_scorecard    -- (task_category, model_id) 그룹: runs, avg_overall,
   1. 미평가 run 큐에 enqueue
   2. 10초 이상 닫힌 run의 outcome 계산
   3. `task_category IS NULL` 재분류 (세션 프로세스 조기 종료 복구)
-  4. orphan run 태깅
+  4. orphan run 태깅 — `task_prompt` 도 turn 도 없는 **빈 껍데기**만 대상
+  5. **abandoned run 수확** — 4번이 볼 수 없는 것들. 데몬이 재시작하면 in-memory `sessionToRun` 맵이 사라져 진행 중이던 run 이 영원히 `ended_at IS NULL` 로 남는다. 이들은 실제 프롬프트·턴·툴 궤적을 갖고 있어 4번의 빈-껍데기 술어를 통과하지 못하고, **task 도 닫히지 않으므로 평가가 아예 돌지 않는다** (실측: open task 65 vs closed 9). 마지막 활동 시각 기준 2시간 무활동(`AGENTDECK_APME_ABANDON_SEC`)이면 turn/task/run 을 **그 마지막 활동 시각으로** 닫고(`boundary_signal='orphaned'`), 응답 텍스트가 있는 task 만 judge 에 enqueue 한다. `collector.isLiveRun()` 으로 자기 프로세스가 아직 쥐고 있는 run 은 건너뛴다
 - `apme.runner.onResult()` 리스너: 평가 완료마다 `apme_eval` WS 브로드캐스트 + `BridgeTimeline.addEntry({ type: 'eval_result' })`
 
 ## Task classification
@@ -379,7 +394,9 @@ composite = 0.40 × outcomeScore
 | GET | `/apme` | 대시보드 HTML (inline SPA) |
 | GET | `/apme/runs?limit=&agent=&model=` | 최근 runs + evals + overallScore |
 | GET | `/apme/run/:id` | 단일 run 상세 (steps, turns, per-turn evals, vibe) |
-| GET | `/apme/tasks/:id` | run 의 task 목록 + task별 rollup |
+| GET | `/apme/tasks?limit=&offset=&agent=&project=&category=&outcome=&state=&q=` | **처리된 task 단위 전체 목록** (paged + faceted) |
+| GET | `/apme/tasks/:id` | 단일 task 상세 — task row + run context + turns + evals + SessionSample |
+| GET | `/apme/graph?limit=&minHubDegree=&turns=&files=&agent=&project=&category=` | 행 저장소의 property-graph 투영 (nodes/edges/stats) |
 | GET | `/apme/scorecard` | `v_model_scorecard` |
 | GET | `/apme/categories` | `v_category_scorecard` |
 | GET | `/apme/samples` | sample-granularity 스코어카드 (Pareto 입력) |

--- a/shared/src/apme-graph.ts
+++ b/shared/src/apme-graph.ts
@@ -1,0 +1,116 @@
+/**
+ * APME graph projection — the row store viewed as a property graph.
+ *
+ * ## Is the row model graph-shaped?
+ *
+ * Partly, and the gaps are worth naming because they decide what a graph view
+ * can honestly show.
+ *
+ * What is already a graph: `runs → tasks → turns → sample_events` is a strict
+ * containment tree with real foreign keys, and `evals` attach at three of those
+ * levels (`run_id` / `task_id` / `turn_id`). That part projects directly.
+ *
+ * What was NOT, and is repaired at the schema level rather than guessed at here:
+ *   - `sample_events` addressed its turn by `turn_index`, an integer unique only
+ *     within a run — no event→turn edge existed. Now `sample_events.turn_id`.
+ *   - `/clear` opens a fresh run with no pointer to the one it continues, so a
+ *     single conversation appeared as N disconnected components (one live
+ *     session held 127 runs). Now `runs.parent_run_id`.
+ *
+ * What is still denormalized, and is therefore DERIVED here rather than read:
+ * session, project, model, agent, tool and file are string columns, not rows.
+ * They are exactly the interesting hubs — they connect work units that share no
+ * ancestor — so this projection materializes them as nodes. That is a deliberate
+ * choice: they are cheap to derive, they change meaning as the schema evolves,
+ * and promoting them to tables would buy nothing the projection cannot do.
+ *
+ * File nodes come from tool payloads (`input.file_path` and friends), which is
+ * the highest-value cross-link in the store — "which units touched this file"
+ * is not answerable any other way — but coverage is partial by nature: only
+ * file-taking tools carry one.
+ *
+ * The projection is read-only and derived on demand. Nothing persists it, so it
+ * can be reshaped without a migration.
+ */
+
+/** Node kinds. Containment nodes mirror rows; entity nodes are derived hubs. */
+export type ApmeGraphNodeKind =
+  // ── containment (backed by a row) ──
+  | 'run'
+  | 'task'
+  | 'turn'
+  // ── entities (derived from denormalized columns / payloads) ──
+  | 'session'
+  | 'project'
+  | 'model'
+  | 'agent'
+  | 'tool'
+  | 'file';
+
+export type ApmeGraphEdgeKind =
+  /** Containment: run→task, task→turn. */
+  | 'contains'
+  /** run→run across a `/clear` context reset (`parent_run_id`). */
+  | 'continues'
+  /** session→run, project→run, model→run, agent→run. */
+  | 'produced'
+  /** turn→tool, task→tool — the turn invoked this tool. */
+  | 'used'
+  /** turn→file, task→file — the turn read or wrote this path. */
+  | 'touched';
+
+export interface ApmeGraphNode {
+  /** `${kind}:${naturalKey}` — stable across rebuilds so a client can diff. */
+  id: string;
+  kind: ApmeGraphNodeKind;
+  label: string;
+  /** Wall-clock anchor for time-ordered layouts. Null for entity hubs. */
+  ts?: number | null;
+  /** Judge score where one exists, for weight/colour. */
+  score?: number | null;
+  /** How many graph edges reference this node — entity hubs are ranked by it. */
+  degree?: number;
+  /** Kind-specific extras (outcome, category, cost, turn count, …). */
+  meta?: Record<string, string | number | null>;
+}
+
+export interface ApmeGraphEdge {
+  from: string;
+  to: string;
+  kind: ApmeGraphEdgeKind;
+  /** Repetition count for collapsed parallel edges (e.g. 12 Read calls). */
+  weight?: number;
+}
+
+export interface ApmeGraphSlice {
+  nodes: ApmeGraphNode[];
+  edges: ApmeGraphEdge[];
+  /** What the slice covered and what it deliberately left out, so a viewer
+   *  never reads a truncated graph as a complete one. */
+  stats: {
+    taskCount: number;
+    nodeCount: number;
+    edgeCount: number;
+    /** Tasks matching the filter beyond `limit` — omitted from this slice. */
+    truncatedTasks: number;
+    /** File nodes are only as complete as the tools that name a path. */
+    fileCoverage: { toolEvents: number; withPath: number };
+  };
+}
+
+export interface ApmeGraphResponse extends ApmeGraphSlice {
+  schema: number;
+}
+
+/** Node id helpers — one place so producer and consumer cannot drift. */
+export const apmeGraphNodeId = {
+  run: (id: string) => `run:${id}`,
+  task: (id: string) => `task:${id}`,
+  turn: (id: string) => `turn:${id}`,
+  session: (id: string) => `session:${id}`,
+  project: (name: string) => `project:${name}`,
+  model: (id: string) => `model:${id}`,
+  agent: (t: string) => `agent:${t}`,
+  tool: (name: string) => `tool:${name}`,
+  file: (path: string) => `file:${path}`,
+} as const;

--- a/shared/src/eval-schema.ts
+++ b/shared/src/eval-schema.ts
@@ -37,6 +37,11 @@ export interface ApmeRunRow {
   exitCode?: number | null;
   gitBefore?: string | null;
   gitAfter?: string | null;
+  /** The run this one continues after a `/clear` context reset. `/clear` splits
+   *  a session into a fresh run so each gets its own evaluation unit; this edge
+   *  keeps the conversation reconstructible across the split instead of leaving
+   *  N disconnected runs behind one session id. Null for a genuine session start. */
+  parentRunId?: string | null;
   /** JSON string. Per-run hardware sample (cpu/memory/load). */
   hwProfile?: string | null;
   /** JSON string. Output of the rule-based classifier — tool counts, file scopes, etc. */
@@ -251,6 +256,41 @@ export interface ApmeRunWithEvalsSummary extends ApmeRunRow {
 
 export interface ApmeRunsResponse extends ApmeApiEnvelope {
   runs: ApmeRunWithEvalsSummary[];
+}
+
+/** A task unit carrying enough run context to be read on its own.
+ *
+ *  Tasks are the canonical evaluation unit, but a bare `ApmeTaskRow` names no
+ *  agent, model, project or prompt — which is why the only way to reach one used
+ *  to be drilling into its run. This is the shape the task browse surface lists. */
+export interface ApmeTaskListRow extends ApmeTaskRow {
+  sessionId: string;
+  agentType: AgentType;
+  /** Task-level model when the sample recorded one, else the run's. */
+  modelId: string | null;
+  projectName: string | null;
+  /** Run's working directory — the root a file path is made relative to. */
+  projectPath: string | null;
+  parentRunId: string | null;
+  /** The task's own first prompt; falls back to the run prompt when the task
+   *  predates per-turn prompt capture. */
+  firstPrompt: string | null;
+  turnCount: number;
+  /** Turns whose assistant reply was archived. `turnCount - answeredTurns > 0`
+   *  marks a unit the judge can only partly see. */
+  answeredTurns: number;
+  eventCount: number;
+  toolCount: number;
+  evalCount: number;
+  overallScore: number | null;
+}
+
+export interface ApmeTaskListResponse extends ApmeApiEnvelope {
+  total: number;
+  limit: number;
+  offset: number;
+  tasks: ApmeTaskListRow[];
+  facets: { agents: string[]; projects: string[]; categories: string[]; outcomes: string[] };
 }
 
 export interface ApmeRunDetailResponse extends ApmeApiEnvelope {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -26,5 +26,6 @@ export * from './idotmatrix-identity.js';
 export * from './llm-settings.js';
 export * from './eval-schema.js';
 export * from './sample.js';
+export * from './apme-graph.js';
 export * from './pricing.js';
 export * from './telemetry-envelope.js';

--- a/shared/src/sample.ts
+++ b/shared/src/sample.ts
@@ -171,6 +171,11 @@ export interface ApmeSampleEventRow {
   taskId: string;
   runId: string;
   turnIndex?: number | null;
+  /** The turn this event belongs to, as an id rather than the run-scoped
+   *  `turnIndex`. Both are kept: `turnIndex` is the ordering key the collector
+   *  and dedup path work in, `turnId` is the edge a graph projection (or any
+   *  join that starts from a turn) can follow directly. */
+  turnId?: string | null;
   /** Monotonic order within the task. */
   seq: number;
   ts: number;


### PR DESCRIPTION
## The gap

TIMELINE showed each turn's reply in full while APME stored none of it. `turns.response` was NULL for every recent claude-code turn — 219 captured out of 1589, none newer than 2026-07-11 — and only 15 `assistant_message` trajectory events existed store-wide, 12 of them OpenClaw's. The dashboard could not replay a conversation the timeline showed completely, and the judge was scoring turns against silence.

Side-by-side on one session, before:

| TIMELINE | APME |
|---|---|
| `chat_start` 23:30 → `chat_response` 23:32 (**811B**) | turn0 23:30→23:32, tools=8, `response=NULL` |
| `chat_start` 23:32 → `chat_response` 23:35 (**610B**) | turn1 23:32→23:52, tools=5, `response=NULL` |
| `chat_start` 23:57 → `chat_response` 00:02 (**1917B**) | turn3 23:57→00:03, tools=9, `response=NULL` |

Prompts, timestamps and tool calls matched 1:1. Only the reply was lost.

## Why it survived

The cause differed per daemon.

**Node** reached `setTurnResponse` only from the PTY session bridge, so hook-observed sessions — direct `claude` / `codex` / `opencode`, i.e. most of them — never hit it. The stop handler already had the text; it only wrote it to the timeline. It now hands it to the collector on the same branch that decides the row.

**Swift** did call `setTurnResponse`, but sourced it from the last `chat_end` row. That row is emitted exactly when there is *no* reply, and its raw is `"Completed · 2m 19s"` — the lookup structurally could not see a response. Recording moved to the hook handler, where the text is already session-scoped and the turn anchor is known.

## Eval starvation

A daemon restart drops the in-memory session→run map, so runs mid-session stay open forever; because their tasks never close either, they are never judged — **65 open tasks against 9 closed**. The existing orphan reaper only matches empty shells (no prompt, no turns), so it stepped over every one of them.

`listAbandonedRuns` / `reapAbandonedRun` close them at their *last activity* rather than at `now`, close the run **last** so a partial failure retries instead of stranding an open task behind a closed run, skip runs the collector still owns, and enqueue only tasks that have a reply worth judging.

## Performance

That sweep took **22s** on the real store: `MAX(steps.ts)` was reading full rows — `payload` holds entire hook bodies — to reach one integer. better-sqlite3 is synchronous on one connection, so it stalled the whole daemon every 30s. Covering indexes bring it to **7ms**.

## Task browse surface

Tasks are the canonical evaluation unit but could only be reached by drilling into a run, so there was no way to see everything processed. `GET /apme/tasks` pages and facets the lot (974 units locally) and a Tasks tab browses them, surfacing `turnCount` vs `answeredTurns` so a partly-archived unit is visible rather than reading as unscored.

## Graph projection

The containment spine (`runs → tasks → turns → sample_events`) is already a graph. Two edges were severed and the interesting hubs were denormalized strings.

Fixed in the schema, not guessed at in the projection:
- `sample_events.turn_id` — previously only a run-scoped `turn_index`, so no event→turn edge existed.
- `runs.parent_run_id` — `/clear` opened a fresh run with no pointer to the one it continued; one session here held **127 disconnected runs**.

Both backfill on migration. Session / project / model / agent / tool / file stay columns and are materialized as nodes by a derived, unpersisted projection behind `GET /apme/graph`, rendered by a self-contained canvas layout (the dashboard ships as one inlined HTML document, so no CDN layout library).

File nodes key on the path **relative to the run's project root**. A fixed path-tail rule merges two checkouts only when their repo-relative depths happen to match, which for a repo worked on through worktrees fails routinely — a test caught this. The slice reports its own truncation and file-path coverage so a partial graph never reads as the whole history.

## Verification

Against the live daemon, not just unit tests:
- Synthetic hook turn lands both `turns.response` and an `assistant_message` event; real sessions then archived 2404 / 1380 / 1052-char replies.
- Reaper drained the backlog: 783 orphaned tasks closed, 5 genuinely-live tasks left.
- `turn_id` backfilled 20735/20736.
- Endpoint latency 16–61ms (`/apme/tasks`, `/apme/graph`, `/apme/runs`).
- Synthetic verification rows deleted from the store afterwards.

27 new tests; full suite 2609 passing; macOS target `BUILD SUCCEEDED`; `docs:check`, `design-system:check` and token-sync gates green on this branch's clean base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)