### PR TITLE
chore(voice): retire the whisper wiring the engine swap left behind

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -149,6 +149,37 @@ EXISTS(turns)` — 빈 껍데기 전용 술어라 실제 작업을 담은 run �
 검증: vitest 2,581 통과(신규 20건) · macOS `BUILD SUCCEEDED` · ESP32 `ips10`/`amoled`/
 `t_embed` 컴파일 · `docs:check` · `design-system:check`.
 
+### 후속 — 같은 지도를 재검증하다 나온 whisper 잔재
+
+지도를 실제 프로세스/설정으로 다시 대조하면서 걸린 나머지. **엔진은 2026-07-26 에 갈아탔는데
+그 엔진을 부르던 배선의 이름·로그·문서가 그대로 남아 있었다.**
+
+- `check-deps.ts` 가 `whisper-cli` / `whisper-server` 를 선택 의존성으로 프로브하며
+  `brew install whisper-cpp && whisper-cli --download-model large-v3-turbo` 를 안내했다.
+  **부르는 코드가 없는 바이너리를 사용자에게 설치시키는 안내**가 남아 있던 셈. 삭제.
+- `VoiceManager.connectToServer()` / `disconnectFromServer()` — 전자는 실제로는 헬퍼 프로브,
+  후자는 완전한 no-op 이었다. `probeSpeechHelper()` 로 개명하고 no-op 은 호출부(index.ts ·
+  daemon-server.ts teardown 2곳)와 함께 삭제. 실패 로그도
+  `whisper-server connection failed` → `speech helper probe failed` 로 정정 —
+  **원인이 엉뚱하게 찍히는 로그는 없느니만 못하다.**
+- `docs/daemon.md` 의 `## Whisper-server` 절이 포트 **9100** 과
+  `~/.agentdeck/whisper-server.json` 을 살아 있는 계약처럼 서술하고 있었다(둘 다 없음). 삭제.
+  `docs/protocol.md` 파일 트리의 `whisper-server-manager.ts` 줄, 아키텍처 ASCII 도식의
+  `whisper.cpp` 상자, `architecture/devices/android-ui/testing` 의 "whisper transcription"
+  서술도 함께 정정.
+
+남긴 것: "왜 뺐나" 를 적은 코드 주석, `docs/voice-setup.md § Why we removed whisper.cpp`,
+`retired-surfaces.md`, App Store 문서의 **금지 문자열 목록**(`whisper-cli` 가 *없어야 한다*는
+검증용이라 정확). 판별 기준은 하나 — **그 문장이 지금의 동작을 주장하는가, 과거를 기록하는가.**
+
+같은 재검증에서 지도 자체의 오류도 나왔다: 판정 lane 은 이 기기에서 FM→MLX 가 아니라
+`backend:"mlx"` 고정으로 **MLX 직행**(FM 미진입), `session-activity` 는 폴백이 아니라
+**휴리스틱 먼저 → FM 이 나중에 덮어쓰기**, `POST /generate` 는 "콜드 7초 회피" 가 아니라
+**왕복 4–22 s 실측**, TTS 는 한 갈래가 아니라 **둘**(기기 응답 = fm-helper `speak`,
+웨이크워드 대화 = macOS `say`). 도식은 코드보다 빨리 낡는다.
+
+검증: vitest 2,609 통과 · `pnpm build` 전체 · `docs:check` 91파일.
+
 ---
 
 ## 2026-08-05 — 자식이 살아 있다는 건 링크가 붙어 있다는 뜻이 아니다: BLE 패널 연결 상태 보고

--- a/bridge/src/__tests__/tier3-integration.test.ts
+++ b/bridge/src/__tests__/tier3-integration.test.ts
@@ -283,7 +283,7 @@ describe('Voice transcription endpoint', () => {
 
   it('returns 500 when voice manager throws', async () => {
     hookServer.setVoiceManager({
-      transcribeFile: async () => { throw new Error('whisper not found'); },
+      transcribeFile: async () => { throw new Error('speech helper not found'); },
     } as any);
 
     const wavData = Buffer.alloc(200);
@@ -297,7 +297,7 @@ describe('Voice transcription endpoint', () => {
 
     expect(res.status).toBe(500);
     const json = await res.json() as any;
-    expect(json.error).toContain('whisper not found');
+    expect(json.error).toContain('speech helper not found');
   });
 });
 

--- a/bridge/src/check-deps.ts
+++ b/bridge/src/check-deps.ts
@@ -38,18 +38,10 @@ const SHARED_DEPS: DepCheck[] = [
     required: false,
     installHint: 'brew install sox',
   },
-  {
-    name: 'whisper-cli',
-    command: 'which whisper-cli',
-    required: false,
-    installHint: 'brew install whisper-cpp && whisper-cli --download-model large-v3-turbo',
-  },
-  {
-    name: 'whisper-server',
-    command: 'which whisper-server',
-    required: false,
-    installHint: 'brew install whisper-cpp (includes whisper-server)',
-  },
+  // Transcription needs no dependency check: it runs through the bundled
+  // agentdeck-fm-helper (Apple on-device Speech). The whisper-cli /
+  // whisper-server probes that used to live here outlived the code path and
+  // told users to `brew install whisper-cpp` for a binary nothing calls.
 ];
 
 export function checkDependencies(agentType?: AgentType): { ok: boolean; warnings: string[]; agentVersion?: string } {

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -3318,8 +3318,8 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
   if (wakeWordEnabled) {
     voiceManager = new VoiceManager();
-    voiceManager.connectToServer().catch((err) => {
-      debug('daemon', `whisper-server connection failed: ${err}`);
+    voiceManager.probeSpeechHelper().catch((err) => {
+      debug('daemon', `speech helper probe failed: ${err}`);
     });
 
     voiceAssistant = new VoiceAssistantManager({
@@ -4912,7 +4912,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     focusRelay.stop();
     timelineRelay.stop();
     voiceAssistant?.stop();
-    voiceManager?.disconnectFromServer();
     bridgeLogStream.stop();
     // Flush synchronously — the process exits a few lines below and a pending
     // debounce timer would take the last turn's entries with it.

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -311,9 +311,9 @@ export async function startSession(opts: SessionOptions): Promise<void> {
   // Timeline log stream (OpenClaw/Claude Code)
   const bridgeLogStream = agentType === 'openclaw' ? new BridgeLogStream() : null;
 
-  // Voice server (non-blocking)
-  voiceManager.connectToServer().catch((err) => {
-    debug('agentdeck', `whisper-server connection failed: ${err}`);
+  // Speech helper probe (non-blocking)
+  voiceManager.probeSpeechHelper().catch((err) => {
+    debug('agentdeck', `speech helper probe failed: ${err}`);
   });
 
   // Voice assistant (wake word → STT → LLM → TTS)
@@ -1363,7 +1363,6 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     postit?.cleanup();
     utilityProxy.cleanup();
     voiceAssistant?.stop();
-    voiceManager.disconnectFromServer();
     bridgeLogStream?.stop();
     journal.close();
 

--- a/bridge/src/voice-assistant.ts
+++ b/bridge/src/voice-assistant.ts
@@ -5,7 +5,7 @@
  * 1. WakeWordListener detects "오픈클로"
  * 2. Record user speech via sox/rec (reusing VoiceManager's approach)
  * 3. VAD: stop recording on silence
- * 4. Transcribe via whisper-server
+ * 4. Transcribe via the bundled helper (Apple on-device Speech)
  * 5. Route to OpenClaw Gateway (or Claude Code) via adapter
  * 6. Receive response text
  * 7. Synthesize + play via macOS say
@@ -85,7 +85,7 @@ function computeTrailingRms(wavFile: string, seconds: number): number {
 export interface VoiceAssistantOptions {
   /** Callback to send a prompt to the active agent */
   sendPrompt: (text: string) => void;
-  /** Callback to transcribe a WAV file via whisper-server */
+  /** Callback to transcribe a WAV file (Apple on-device Speech via the helper) */
   transcribeFile: (filePath: string) => Promise<string>;
   /** Function that returns true if push-to-talk is recording (mutex) */
   isPttRecording?: () => boolean;

--- a/bridge/src/voice.ts
+++ b/bridge/src/voice.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
-import { spawn, execSync, type ChildProcess } from 'child_process';
-import { tmpdir, homedir } from 'os';
+import { spawn, type ChildProcess } from 'child_process';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { unlinkSync, existsSync, statSync, readFileSync } from 'fs';
 import { debug } from './logger.js';
@@ -14,7 +14,6 @@ function findBinary(candidates: string[], fallback: string): string {
   return fallback;
 }
 
-/** Check if a whisper-cli binary has Metal GPU support (native arm64 + libggml-metal). */
 /** Compute RMS energy of a 16-bit PCM WAV file (skip 44-byte header). */
 function computeRms(wavFile: string): number {
   const buf = readFileSync(wavFile);
@@ -43,18 +42,15 @@ export class VoiceManager extends EventEmitter {
     debug('Voice', `Binaries: rec=${this.recBin}, sox=${this.soxBin} (transcription: Apple Speech via bundled helper)`);
   }
 
-  /** No-op kept so callers written for the whisper-server era keep compiling.
-   *  Transcription now goes through the bundled Swift helper, which the
-   *  Foundation Models client already manages as a long-lived process. */
-  async connectToServer(): Promise<void> {
+  /** Probe the bundled Swift helper so an unavailable recognizer shows up in
+   *  the log at startup rather than on the user's first utterance. There is
+   *  nothing to connect to or tear down — the helper is a long-lived process
+   *  owned by foundation-models-helper.ts. */
+  async probeSpeechHelper(): Promise<void> {
     const status = await probeFoundationModelsHelper();
     if (!status.available) {
       debug('Voice', `Speech helper unavailable: ${status.reason ?? 'unknown'}`);
     }
-  }
-
-  disconnectFromServer(): void {
-    // Helper lifetime is owned by foundation-models-helper.ts.
   }
 
   startRecording(): void {
@@ -133,7 +129,8 @@ export class VoiceManager extends EventEmitter {
       throw new Error('Recording too short or empty');
     }
 
-    // Check audio RMS to detect silence (whisper hallucinates on silent audio)
+    // Check audio RMS to detect silence — a recognizer handed silence returns
+    // invented text rather than an error, so catch it before transcribing.
     const rms = computeRms(this.audioFile);
     debug('Voice', `Audio RMS: ${rms.toFixed(4)}`);
     if (rms < 0.001) {
@@ -141,7 +138,7 @@ export class VoiceManager extends EventEmitter {
       throw new Error('No audio detected — check microphone permission');
     }
 
-    // --- Transcription: prefer whisper-server, fallback to whisper-cli ---
+    // --- Transcription: Apple on-device Speech via the bundled helper ---
     try {
       const text = await this.transcribeViaHelper(this.audioFile);
       debug('Voice', `Transcription result: "${text.slice(0, 80)}"`);

--- a/docs/android-ui.md
+++ b/docs/android-ui.md
@@ -116,7 +116,7 @@ TIMELINE
 
 **Deck button grid**: Bridge `button_state` 프로토콜 우선, 로컬 fallback. CompactStatusBar(36dp) 상단 + 직사각형 버튼(80dp) + 넓은 ContextArea. 터치 피드백(scale 0.95+alpha 0.85), AWAITING시 전체 옵션 리스트 항상 표시, PROCESSING시 LinearProgressIndicator, IDLE시 suggestedPrompt AssistChip.
 
-**Voice**: Android AudioRecord → WAV → HTTP POST `/voice/transcribe` → whisper.
+**Voice**: Android AudioRecord → WAV → HTTP POST `/voice/transcribe` → 데몬이 번들 헬퍼(Apple 온디바이스 Speech)로 전사.
 
 **Utility proxy**: `bridge/src/utility-proxy.ts` — osascript macOS volume/brightness/media control via Android remote.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Core bridge architecture, adapter hierarchy, and module system. See [daemon.md](
 
 ## Monorepo layout
 
-- **bridge/** — Node.js server: Daemon (sole hub for all clients, mDNS, device modules) + Session Bridge (PTY, hook HTTP, state machine). BridgeCore (shared infra), PtyAdapter hierarchy, output parser, WebSocket server, voice (whisper.cpp), usage API client, auth token, SSE broadcast, TUI dashboard (`tui/`)
+- **bridge/** — Node.js server: Daemon (sole hub for all clients, mDNS, device modules) + Session Bridge (PTY, hook HTTP, state machine). BridgeCore (shared infra), PtyAdapter hierarchy, output parser, WebSocket server, voice (Apple on-device Speech via the bundled helper), usage API client, auth token, SSE broadcast, TUI dashboard (`tui/`)
 - **plugin/** — Stream Deck SDK v2 plugin: actions for buttons/encoders, bridge WebSocket client
 - **shared/** — TypeScript types and utilities shared between bridge and plugin (protocol, states, timeline, adapter interfaces, `format-utils` time/count/bytes formatters, `timeline-summarizer` extractTopicHint/cleanLLMOutput, `deduplicateEntry` pipeline, `session-utils` stateRank/sortSessions/assignDisplayNames — 세션 정렬/번호 공통 유틸리티, 6곳에서 import)
 - **hooks/** — Claude Code CLI hook installer for `~/.claude/settings.json` (the App Store opt-in UI writes the same user-global file, user-selected), Codex lifecycle hook installer for `~/.codex/config.toml`, and OpenCode observer plugin installer for `~/.config/opencode/plugins/agentdeck.js`

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -88,10 +88,6 @@ Daemon owns port **9120** (default, fallback to 9121+ if occupied by non-daemon)
   - A user unit only auto-starts on login; for boot-without-login on a headless host the user runs `loginctl enable-linger $USER` once (surfaced as an install-time hint, not run automatically).
   - `daemon.json` discovery, port fallback, singleton guard, and graceful `/shutdown` are reused unchanged across all three platforms.
 
-## Whisper-server
-
-Uses fixed singleton port **9100** (`~/.agentdeck/whisper-server.json` info file for discovery, last session exit kills server).
-
 ## Session timeline relay
 
 `SessionTimelineRelay` (`session-timeline-relay.ts`) — daemon subscribes to sibling session bridges' WS to relay `timeline_event`/`timeline_history` events + `state_update.modelCatalog` (Claude Code OAuth catalog → daemon `cachedModelCatalog`, merged with Gateway catalog by name dedup). 10s sync interval detects new/removed sessions. Eliminates client-side `StateTimelineGenerator` duplication (Android/Apple) — daemon provides unified timeline stream for all agent types.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -133,7 +133,7 @@ WebSocket and SSE forward all 13 `BridgeEvent` types without filtering.
 - **Discovery**: NSD mDNS (`_agentdeck._tcp`, daemon only advertises) → ADB reverse tunnel → QR pairing
 - **Auth**: Token from mDNS TXT record or QR code
 - **Special endpoints** (on daemon):
-  - `POST /voice/transcribe` — WAV upload → whisper transcription
+  - `POST /voice/transcribe` — WAV upload → on-device transcription (bundled helper, Apple Speech)
   - `GET /health` — Daemon health check (includes `mode: 'daemon'`)
   - `GET /usage` — Usage data relay
 - **ADB reverse**: Daemon polls USB devices every 30s, auto-sets `adb reverse tcp:{daemonPort}`
@@ -145,7 +145,7 @@ WebSocket and SSE forward all 13 `BridgeEvent` types without filtering.
 - **Discovery**: NWBrowser (Network.framework) mDNS (`_agentdeck._tcp`, daemon only advertises) → QR pairing (VisionKit)
 - **Auth**: Token from mDNS TXT record or QR code
 - **Special endpoints**:
-  - `POST /voice/transcribe` — WAV upload → whisper transcription (AVAudioEngine 16kHz mono)
+  - `POST /voice/transcribe` — WAV upload → on-device transcription (AVAudioEngine 16kHz mono)
 - **Platform**: SwiftUI Multiplatform — single Xcode project, iOS + macOS native targets (no Mac Catalyst)
 - **Deployment target**: iOS 17.0 / iPadOS 17.0 / macOS 26.0 (macOS app now targets Apple Intelligence / Foundation Models availability; iOS remains a read-only companion)
 - **State**: `@Observable` (Observation framework) — equivalent to Android's MutableStateFlow

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -43,7 +43,7 @@ Internal reference for the AgentDeck state machine, WebSocket protocol, and proj
                                         │         │                               │
 ┌──────────────────────┐  HTTP POST     │  ┌──────▼───────┐  ┌──────────────┐    │
 │  Claude Code Hooks   │───────────────►│  │ Output       │  │ Voice        │    │
-│  (settings.json)     │                │  │ Parser → SM  │  │ whisper.cpp  │    │
+│  (settings.json)     │                │  │ Parser → SM  │  │ fm-helper    │    │
 └──────────────────────┘                │  └──────────────┘  └──────────────┘    │
                                         └─────────────────────────────────────────┘
 ```
@@ -196,7 +196,7 @@ AgentDeck/
 │       ├── index.ts              # Re-exports
 │       ├── states.ts             # State enum, transitions, StateSnapshot
 │       ├── protocol.ts           # WebSocket event/command types, constants
-│       └── voice-paths.ts        # Shared binary/model path constants (rec, whisper)
+│       └── voice-paths.ts        # Shared binary/model path constants (rec, sox, wake word)
 │
 ├── bridge/                       # Bridge server (PTY + Hook + WS + Voice)
 │   └── src/
@@ -211,8 +211,7 @@ AgentDeck/
 │       ├── session-registry.ts   # Session registry + daemon.json port discovery
 │       ├── usage-tracker.ts      # Session usage tracking (tokens, cost)
 │       ├── usage-api.ts          # Anthropic API usage fetch (OAuth + Keychain)
-│       ├── voice.ts              # sox capture + whisper.cpp transcription
-│       ├── whisper-server-manager.ts  # Singleton whisper-server lifecycle (port 9100)
+│       ├── voice.ts              # sox capture + on-device transcription (bundled helper)
 │       ├── mdns.ts               # mDNS advertising (_agentdeck._tcp)
 │       ├── auth.ts               # Auth token management (~/.agentdeck/auth-token)
 │       ├── utility-proxy.ts      # Node CLI macOS osascript proxy (volume/brightness/media)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -168,7 +168,7 @@ pnpm vitest run --coverage       # Terminal summary + lcov + json-summary
 | **SVG renderers** | 10 renderer files | Visual output — snapshot testing TBD |
 | **TUI dashboard** | 6 files | Terminal rendering — visual inspection |
 | **Device modules** | adb, serial, mdns, pixoo | Hardware-dependent |
-| **Voice system** | voice, whisper, TTS | Audio hardware + external process |
+| **Voice system** | voice, speech helper, TTS | Audio hardware + external process |
 | **Daemon server** | daemon-server.ts | Requires full process lifecycle |
 | **Android UI** | 31 Compose files | Compose UI testing framework TBD |
 | **Android terrarium** | 20 creature/env files | Canvas rendering — screenshot testing TBD |


### PR DESCRIPTION
Transcription moved to the bundled Swift helper (Apple on-device Speech) on 2026-07-26. The wiring around it kept its whisper-era names, logs, and docs — nothing broken, just claims that are false in the places a user or a new contributor reads first.

Found while re-verifying the local-inference map against the actually-running processes.

## Code

- **`check-deps.ts`** — dropped the `whisper-cli` / `whisper-server` optional-dependency probes. They told users to `brew install whisper-cpp && whisper-cli --download-model large-v3-turbo` for binaries no code path calls. The `sox (rec)` check stays: capture still shells out to `rec`.
- **`voice.ts`** — `connectToServer()` only probes the helper, so it is now `probeSpeechHelper()`; `disconnectFromServer()` was a pure no-op and is gone along with its two teardown call sites (`index.ts`, `daemon-server.ts`). Also removed an orphan doc comment for a long-deleted Metal-probe function and two now-unused imports.
- **`index.ts` · `daemon-server.ts`** — failure log `whisper-server connection failed` → `speech helper probe failed`. It pointed diagnosis at a process that does not exist.
- **`voice-assistant.ts`**, **`tier3-integration.test.ts`** — comment and fixture text.

## Docs

- **`docs/daemon.md`** — deleted the `## Whisper-server` section, which described a singleton on port **9100** with a `~/.agentdeck/whisper-server.json` discovery file as a live contract. Both are gone.
- **`docs/protocol.md`** — removed the deleted `whisper-server-manager.ts` tree entry, fixed the `whisper.cpp` box in the architecture diagram and the `voice-paths.ts` description (its real exports are rec/sox/wake-word).
- **`architecture.md` · `devices.md` · `android-ui.md` · `testing.md`** — "whisper transcription" claims.

Kept every comment and doc that *records* why whisper was removed (`docs/voice-setup.md § Why we removed whisper.cpp`, `retired-surfaces.md`, the rationale comments), and the App Store forbidden-string lists — those are accurate precisely because `whisper-cli` must be absent. The test is whether a sentence asserts current behavior or records history.

## Verification

`pnpm test` 2,609 passed · `pnpm build` all packages · `pnpm docs:check` 91 files (no anchor broken by the daemon.md section removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)