### PR TITLE
docs(apple): record the review state App Store Connect actually shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | Channel | Tag | Status |
 |---|---|---|
 | **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.7](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.7) |
-| **Apple App Store** — macOS | `apple-v*` | [1.0.2 live](https://apps.apple.com/app/id6784822497) (released 2026-07-24); 1.0.3 submitted for macOS and iPhone/iPad, superseding the 1.0.2 companion rejected on 2026-08-04 under Guideline 2.1(a) |
+| **Apple App Store** — macOS | `apple-v*` | [1.0.2 live](https://apps.apple.com/app/id6784822497) (released 2026-07-24); macOS 1.0.3 (build 4101) approved 2026-08-05 and set to release automatically; the iPhone/iPad companion 1.0.2 (build 4002) is back in review after the 2026-08-04 Guideline 2.1(a) rejection |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.4 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-05) |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.2 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.2); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.4](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.4) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,7 +78,18 @@ Tag prefixes remain because channels ship independently and may point to differe
 
 ### Apple (TestFlight / App Store)
 
-macOS has been publicly available since 2026-07-21 at [AgentDeck Dashboard on the Mac App Store](https://apps.apple.com/app/id6784822497), first as `1.0.0` and — since the 2026-07-24 approval of build 3901 — as `1.0.2`. The iPhone/iPad companion's first release (also `1.0.2`, build 3901) was **rejected on 2026-08-04 under Guideline 2.1(a)**. Build `4002` carrying the correction reached TestFlight, but the same run's macOS archive died on the certificate cap, and #124 then landed a push-to-talk repair that build predates — so `1.0.2` is superseded rather than resubmitted, and both platforms ship together as `1.0.3`. A successful CI upload reaches App Store Connect/TestFlight; public App Store release remains a separate App Store Connect action.
+macOS has been publicly available since 2026-07-21 at [AgentDeck Dashboard on the Mac App Store](https://apps.apple.com/app/id6784822497), first as `1.0.0` and — since the 2026-07-24 approval of build 3901 — as `1.0.2`. The iPhone/iPad companion's first release (also `1.0.2`, build 3901) was **rejected on 2026-08-04 under Guideline 2.1(a)**.
+
+**The two platforms then diverged, and their version records do not match.** Verified in App Store Connect on 2026-08-06:
+
+| Platform | Version record | Build | State |
+|---|---|---|---|
+| macOS | `1.0.3` | 4101 | Submitted 2026-08-05, **approved**; release option is *automatic* and locked |
+| iPhone/iPad | `1.0.2` | 4002 | Resubmitted 2026-08-05 with the Resolution Center reply, **Waiting for Review** |
+
+iOS was answered as a `1.0.2` resubmission rather than moved up to `1.0.3`: a rejected version keeps its `MARKETING_VERSION`, and attaching the already-uploaded 4002 kept the reply and the binary consistent. macOS had no such constraint, so it went out at `1.0.3` with the newer 4101. **Do not describe an Apple release state from the tag or from the repository's own version numbers** — a single `apple-v*` tag can produce two builds whose store-side version records differ, as it did here. Read App Store Connect → 앱 심사 / App Review, whose submission table gives version, build and state per platform in one place.
+
+A successful CI upload reaches App Store Connect/TestFlight; public App Store release remains a separate App Store Connect action.
 
 While a version sits in **Waiting for Review**, do not upload a replacement build for it: attaching one requires a developer reject, which loses the queue position without helping. Land further work on the next patch instead.
 

--- a/apple/APP_REVIEW_NOTES.md
+++ b/apple/APP_REVIEW_NOTES.md
@@ -7,15 +7,15 @@ locale: en
 canonical: true
 status: required
 owner: Apple release maintainers
-reviewed: 2026-08-05
-revision: 2026-08-05
+reviewed: 2026-08-06
+revision: 2026-08-06
 source_of_truth: apple/APP_REVIEW_NOTES.md
 validators: [bash apple/scripts/verify-appstore-archive.sh]
 ---
 
 # AgentDeck Dashboard — App Review Notes
 
-**Release status:** macOS 1.0.0 was approved and released on 2026-07-21: [AgentDeck Dashboard on the Mac App Store](https://apps.apple.com/app/id6784822497). The first iPhone/iPad submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept showing an activity indicator after discovery had completed. The replacement build fixes that terminal state and adds an offline Device Preview entry point.
+**Release status** (verified in App Store Connect, 2026-08-06): macOS has been on the [Mac App Store](https://apps.apple.com/app/id6784822497) since 2026-07-21, publicly at 1.0.2, with **1.0.3 (4101) approved on 2026-08-05** and set to release automatically. The first iPhone/iPad submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept showing an activity indicator after discovery had completed; **1.0.2 (4002)** carries the fix plus an offline Device Preview entry point and is **Waiting for Review**.
 
 _Paste the relevant sections into App Store Connect's "Notes" field when submitting `apple-v<version>`._
 
@@ -221,7 +221,7 @@ Review on a clean Mac with only AgentDeck installed. The app starts its own Swif
 
 ## Resolution Center — Guideline 2.1(a) launch indicator reply
 
-Use this response for the 2026-08-04 rejection. The correction ships as version 1.0.3, build 4101 rather than as a 1.0.2 resubmission: 1.0.2's replacement build 4002 reached TestFlight, but the same release run left macOS unbuilt and later fixes landed on top of it, so both platforms go out together under the next version:
+**Sent 2026-08-05 03:18 KST against iOS 1.0.2, build 4002** — the text below is that message as it actually went out, not a draft. This section previously staged the reply around build 4101 / version 1.0.3 on the assumption that both platforms would ship together under the next version; that is not what happened. iOS was answered as a `1.0.2` resubmission (a rejected version keeps its `MARKETING_VERSION`, and 4002 was already on TestFlight carrying the fix), while macOS went out separately as `1.0.3` / 4101. A stored reply naming a build the reviewer will not see is the exact failure this file exists to prevent, so it is kept in sync with the send:
 
 ```text
 Thank you for identifying this issue. We reproduced the behavior shown in your
@@ -234,7 +234,7 @@ attempt had already finished after 10 seconds, but the screen continued to say
 “Searching for AgentDeck…” and continued animating. This was a UI state bug, not
 a stalled network request.
 
-We corrected the issue in build 4101 (version 1.0.3):
+We corrected the issue in build 4002:
 • The activity indicator is now tied only to the bounded foreground search or an
   active connection attempt.
 • After approximately 10 seconds with no Mac found, the indicator stops and the
@@ -249,11 +249,9 @@ We corrected the issue in build 4101 (version 1.0.3):
 • We added regression coverage for the searching, connecting, permission-denied,
   reconnecting, and completed-empty-search states, plus tests that drive the real
   connection state machine and assert the indicator always stops and always
-  leaves the user an action. The corrected no-Mac paths were verified on an iPad
-  Air 11-inch simulator running iPadOS 26.5, and the same connection-state change
-  was installed on a physical iPad Air 11-inch (M2) running iPadOS 26.5.2 as build
-  4002, where it connected successfully. Build 4101 carries that identical change
-  along with later fixes to voice capture and Bluetooth display discovery.
+  leaves the user an action. We verified the corrected no-Mac paths on an iPad Air
+  11-inch (M4) simulator running iPadOS 26.5. Build 4002 was also installed and
+  connected successfully on a physical iPad Air 11-inch (M2) running iPadOS 26.5.2.
 
 To verify on a clean iPad: complete onboarding, allow Local Network access, and
 wait approximately 10 seconds without an AgentDeck Mac on the same Wi-Fi. The


### PR DESCRIPTION
Read from App Store Connect today (2026-08-06). Three surfaces described a submission that did not happen.

**Claimed:** `1.0.3` submitted for macOS and iPhone/iPad, superseding the `1.0.2` companion rejected on 2026-08-04.

**Actual** — App Review → 제출 table, per platform:

| Platform | Version record | Build | State |
|---|---|---|---|
| macOS | `1.0.3` | 4101 | Submitted 08-05 10:02, **승인됨 / Approved**; release option *automatic*, locked |
| iPhone/iPad | `1.0.2` | 4002 | Resubmitted 08-05 03:25, **심사 대기 중 / Waiting for Review** |

The store still serves macOS `1.0.2` (iTunes lookup, 2026-08-06T00:07Z), so the approved `1.0.3` has not propagated yet.

The two platforms are not inconsistent, just different: a rejected version keeps its `MARKETING_VERSION`, so answering the 2.1(a) rejection meant reattaching the already-uploaded 4002 under `1.0.2`, while macOS had no such constraint and moved to `1.0.3`. **One `apple-v*` tag produced both** — which is why a release state cannot be read off the tag or off the repo's version numbers. `RELEASING.md` now states that and points at the submission table as the per-platform answer.

**The Resolution Center reply is the part that mattered.** `apple/APP_REVIEW_NOTES.md` staged the reply around build 4101 / version 1.0.3, but the message sent on 08-05 03:18 names **build 4002**. This file exists because a reply naming a build the reviewer cannot see is how the first submission went wrong — so it now carries the sent text verbatim, including the verification device (iPad Air 11-inch M4 simulator, iPadOS 26.5; physical M2 on 26.5.2).

Changes: `README.md` release row, `RELEASING.md` § Apple (state table + the read-it-from-ASC rule), `apple/APP_REVIEW_NOTES.md` (release status, reply framing, sent text, frontmatter dates).

Gates: `check-docs.mjs`, `build-design-system-viewer.mjs --check`, `verify-version-sync.mjs` pass. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)