### PR TITLE
docs(apple): the companion shipped — both platforms are live now

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | Channel | Tag | Status |
 |---|---|---|
 | **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.7](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.7) |
-| **Apple App Store** — macOS | `apple-v*` | [1.0.2 live](https://apps.apple.com/app/id6784822497) (released 2026-07-24); macOS 1.0.3 (build 4101) approved 2026-08-05 and set to release automatically; the iPhone/iPad companion 1.0.2 (build 4002) is back in review after the 2026-08-04 Guideline 2.1(a) rejection |
+| **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [Live](https://apps.apple.com/app/id6784822497) on both platforms: macOS 1.0.3 (build 4101, approved 2026-08-05) and the **iPhone/iPad companion 1.0.2** (build 4002, released 2026-08-06 — its first release, after the 2026-08-04 Guideline 2.1(a) rejection) |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.4 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-05) |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.2 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.2); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.4](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.4) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,10 +84,12 @@ macOS has been publicly available since 2026-07-21 at [AgentDeck Dashboard on th
 
 | Platform | Version record | Build | State |
 |---|---|---|---|
-| macOS | `1.0.3` | 4101 | Submitted 2026-08-05, **approved**; release option is *automatic* and locked |
-| iPhone/iPad | `1.0.2` | 4002 | Resubmitted 2026-08-05 with the Resolution Center reply, **Waiting for Review** |
+| macOS | `1.0.3` | 4101 | Submitted 2026-08-05, **approved**, automatic release |
+| iPhone/iPad | `1.0.2` | 4002 | Resubmitted 2026-08-05, **approved** — released 2026-08-06T08:46Z, the companion's first public release |
 
 iOS was answered as a `1.0.2` resubmission rather than moved up to `1.0.3`: a rejected version keeps its `MARKETING_VERSION`, and attaching the already-uploaded 4002 kept the reply and the binary consistent. macOS had no such constraint, so it went out at `1.0.3` with the newer 4101. **Do not describe an Apple release state from the tag or from the repository's own version numbers** — a single `apple-v*` tag can produce two builds whose store-side version records differ, as it did here. Read App Store Connect → 앱 심사 / App Review, whose submission table gives version, build and state per platform in one place.
+
+**The iTunes lookup shortcut stopped answering for macOS the day the companion shipped.** While the app was Mac-only, `curl -s "https://itunes.apple.com/lookup?id=6784822497&entity=macSoftware"` returned a `mac-software` record whose `version` was the live Mac version — the fastest login-free release check there is. Once the iPhone/iPad companion went live, that id resolves to a single unified `software` record instead, and its `version`, `minimumOsVersion` (`17.0`) and `fileSizeBytes` all describe the **iOS** app; `entity=macSoftware`, `entity=iPadSoftware` and a store search all return that same record. So the endpoint still confirms the iOS side and its release timestamp, but the Mac version is no longer readable from it — take that one from App Store Connect.
 
 A successful CI upload reaches App Store Connect/TestFlight; public App Store release remains a separate App Store Connect action.
 

--- a/apple/APP_REVIEW_NOTES.md
+++ b/apple/APP_REVIEW_NOTES.md
@@ -15,7 +15,7 @@ validators: [bash apple/scripts/verify-appstore-archive.sh]
 
 # AgentDeck Dashboard — App Review Notes
 
-**Release status** (verified in App Store Connect, 2026-08-06): macOS has been on the [Mac App Store](https://apps.apple.com/app/id6784822497) since 2026-07-21, publicly at 1.0.2, with **1.0.3 (4101) approved on 2026-08-05** and set to release automatically. The first iPhone/iPad submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept showing an activity indicator after discovery had completed; **1.0.2 (4002)** carries the fix plus an offline Device Preview entry point and is **Waiting for Review**.
+**Release status** (verified in App Store Connect, 2026-08-06): both platforms are approved and live at [AgentDeck Dashboard](https://apps.apple.com/app/id6784822497). macOS has been on the Mac App Store since 2026-07-21 and is at **1.0.3 (4101)**, approved 2026-08-05. The first iPhone/iPad submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept showing an activity indicator after discovery had completed; **1.0.2 (4002)** carried the fix plus an offline Device Preview entry point, was approved, and **released on 2026-08-06** as the companion's first public version.
 
 _Paste the relevant sections into App Store Connect's "Notes" field when submitting `apple-v<version>`._
 


### PR DESCRIPTION
Follow-up to #139, from a fresh App Store Connect read.

**iOS 1.0.2 (4002) is approved and released.** ASC's App Review submission now reads 승인됨 / Approved, the review-issue badge is gone, and the App Store record shows `currentVersionReleaseDate 2026-08-06T08:46:04Z`. That closes the 2026-08-04 Guideline 2.1(a) rejection and makes it the iPhone/iPad companion's **first public release**. macOS 1.0.3 (4101) remains approved from 2026-08-05.

| Platform | Version | Build | State |
|---|---|---|---|
| macOS | 1.0.3 | 4101 | Approved 08-05, automatic release |
| iPhone/iPad | 1.0.2 | 4002 | Approved, **released 2026-08-06T08:46Z** — first public version |

**A measurement habit dies with it, and that is the part worth writing down.** While the app was Mac-only, `itunes.apple.com/lookup?id=…&entity=macSoftware` returned a `mac-software` record whose `version` was the live Mac version — the login-free check RELEASING.md recommends. The same id now resolves to a single unified `software` record describing the **iOS** app (`minimumOsVersion 17.0`, 6.5 MB), and `entity=macSoftware`, `entity=iPadSoftware` and a store search all return that one record. The endpoint still dates the iOS release; the Mac version has to come from ASC.

Without this note the next audit reads `version 1.0.2` off that endpoint and concludes macOS regressed from 1.0.3.

Changes: `README.md` release row (now covers both platforms), `RELEASING.md` § Apple state table + the lookup caveat, `apple/APP_REVIEW_NOTES.md` release status. Gates pass; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)