### PR TITLE
feat(android): target Android 16 (API 36), and stop the phone HUD rails from overlapping

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,12 +3,13 @@ import java.util.Properties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {
     namespace = "dev.agentdeck"
-    compileSdk = 34
+    compileSdk = 36
 
     signingConfigs {
         create("release") {
@@ -35,7 +36,7 @@ android {
     defaultConfig {
         applicationId = "dev.agentdeck"
         minSdk = 29
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 6
         versionName = "1.0.4"
     }
@@ -56,17 +57,9 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         buildConfig = true
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
     }
 
     testOptions {
@@ -76,8 +69,16 @@ android {
     }
 }
 
+// Kotlin 2.x removed `android.kotlinOptions`; the JVM target now lives on the
+// Kotlin extension's compilerOptions DSL.
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2024.02.00")
+    val composeBom = platform("androidx.compose:compose-bom:2026.03.01")
     implementation(composeBom)
 
     // Compose
@@ -93,8 +94,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 
     // Kotlin
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Networking
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
@@ -107,6 +108,6 @@ dependencies {
 
     // Test
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.11.1")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    testImplementation("org.robolectric:robolectric:4.16.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/AttentionTheaterHUD.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/AttentionTheaterHUD.kt
@@ -69,6 +69,7 @@ fun AttentionTheaterHUD(
     onRespond: (Int) -> Unit,
     onFocus: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    scale: MonitorLayoutScale = MonitorLayoutScale.tablet,
 ) {
     val infinite = rememberInfiniteTransition(label = "attention")
     val breathe by infinite.animateFloat(
@@ -93,11 +94,19 @@ fun AttentionTheaterHUD(
     val effectiveOptions = effectiveOptions(featured.options)
     val useHorizontal = useHorizontalLayout(effectiveOptions, featured.promptType)
 
+    // A card is only allowed to be translucent when there is something worth
+    // seeing behind it. On a tablet it floats over open terrarium and 0.65
+    // reads as depth. A phone has no such space: the card lands squarely on
+    // the two HUD rails, and at 0.65 their text shows straight through the
+    // question — the one thing on screen that has to be readable. Phones get
+    // a near-opaque fill instead.
+    val cardScrim = if (scale.isTablet) 0.65f else 0.94f
+
     Column(
         modifier = modifier
             .widthIn(max = 460.dp)
             .background(
-                color = Color.Black.copy(alpha = 0.65f),
+                color = Color.Black.copy(alpha = cardScrim),
                 shape = RoundedCornerShape(12.dp),
             )
             .border(

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorLayoutScale.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorLayoutScale.kt
@@ -48,6 +48,12 @@ data class MonitorLayoutScale(
     val sizeClass: ScreenSizeClass,
     val sessionPanelMaxWidth: Dp,
     val topologyPanelMaxWidth: Dp,
+    /** Share of the parent width each side rail may take. The two rails are
+     *  independently anchored (TopStart / TopEnd) inside one Box, so nothing
+     *  stops them from meeting in the middle — only these fractions do. They
+     *  must therefore sum to less than 1, with room left for the gap. */
+    val sessionPanelWidthFraction: Float,
+    val topologyPanelWidthFraction: Float,
     val panelPadding: Dp,
     val panelEdgeInset: Dp,
     val sessionRowSpacing: Dp,
@@ -75,6 +81,8 @@ data class MonitorLayoutScale(
             sizeClass = ScreenSizeClass.Compact,
             sessionPanelMaxWidth = 220.dp,
             topologyPanelMaxWidth = 300.dp,
+            sessionPanelWidthFraction = 0.42f,
+            topologyPanelWidthFraction = 0.46f,
             panelPadding = 8.dp,
             panelEdgeInset = 12.dp,
             sessionRowSpacing = 4.dp,
@@ -94,6 +102,8 @@ data class MonitorLayoutScale(
             sizeClass = ScreenSizeClass.Medium,
             sessionPanelMaxWidth = 300.dp,
             topologyPanelMaxWidth = 300.dp,
+            sessionPanelWidthFraction = 0.22f,
+            topologyPanelWidthFraction = 0.32f,
             panelPadding = 8.dp,
             panelEdgeInset = 12.dp,
             sessionRowSpacing = 4.dp,
@@ -114,6 +124,8 @@ data class MonitorLayoutScale(
             sizeClass = ScreenSizeClass.Expanded,
             sessionPanelMaxWidth = 340.dp,
             topologyPanelMaxWidth = 340.dp,
+            sessionPanelWidthFraction = 0.22f,
+            topologyPanelWidthFraction = 0.32f,
             panelPadding = 10.dp,
             panelEdgeInset = 16.dp,
             sessionRowSpacing = 5.dp,

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -895,12 +895,19 @@ private fun MonitorHUD(
     val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
     val scale = rememberMonitorLayoutScale()
     BoxWithConstraints(modifier = Modifier.fillMaxSize().padding(top = systemBarsPadding.calculateTopPadding())) {
-        // Tablet-only: mirror the SwiftUI MonitorHUD proportions
-        // (`min(width * 0.22, 220)` / `min(width * 0.32, 300)`) so Android
-        // tablets do not inflate the dashboard rails into oversized cards.
+        // Both rails are proportional, on every size class. Tablets keep the
+        // SwiftUI MonitorHUD proportions (0.22 / 0.32) so the dashboard rails
+        // are not inflated into oversized cards; phones get their own pair
+        // (0.42 / 0.46) that still sums below 1.
+        //
+        // Phones used to take `widthIn(max = …)` instead — a ceiling with no
+        // relation to the screen. The rails are anchored TopStart and TopEnd in
+        // the same Box, so on a 411dp phone a 220dp session list and a 300dp
+        // topology rail simply drew through each other for ~109dp, and the HUD
+        // was two unreadable columns of overlapping text.
         val parentWidth = maxWidth
-        val sessionPanelWidth = minOf(parentWidth * 0.22f, scale.sessionPanelMaxWidth)
-        val topologyPanelWidth = minOf(parentWidth * 0.32f, scale.topologyPanelMaxWidth)
+        val sessionPanelWidth = minOf(parentWidth * scale.sessionPanelWidthFraction, scale.sessionPanelMaxWidth)
+        val topologyPanelWidth = minOf(parentWidth * scale.topologyPanelWidthFraction, scale.topologyPanelMaxWidth)
         // Top-left: Agent list (logo + sessions + mode). AnimatedVisibility
         // both fades AND removes from composition when hidden so the
         // collapsed panels stop intercepting any future tap dispatch.
@@ -928,10 +935,7 @@ private fun MonitorHUD(
                     // the panel instead of painting over the timeline strip that
                     // occupies the bottom third of the screen.
                     .heightIn(max = maxHeight * 0.60f)
-                    .then(
-                        if (scale.isTablet) Modifier.width(sessionPanelWidth)
-                        else Modifier.widthIn(max = scale.sessionPanelMaxWidth)
-                    ),
+                    .width(sessionPanelWidth),
             )
         }
 
@@ -950,10 +954,7 @@ private fun MonitorHUD(
                 scale = scale,
                 modifier = Modifier
                     .padding(end = scale.panelEdgeInset, top = scale.panelEdgeInset)
-                    .then(
-                        if (scale.isTablet) Modifier.width(topologyPanelWidth)
-                        else Modifier.widthIn(max = scale.topologyPanelMaxWidth)
-                    ),
+                    .width(topologyPanelWidth),
             )
         }
 

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -1003,6 +1003,7 @@ private fun MonitorHUD(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = 14.dp),
+                scale = scale,
             )
         }
     }

--- a/android/app/src/test/kotlin/dev/agentdeck/ui/monitor/MonitorLayoutScaleTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/ui/monitor/MonitorLayoutScaleTest.kt
@@ -33,6 +33,46 @@ class MonitorLayoutScaleTest {
         assertEquals(MonitorLayoutScale.expanded, scaleFor(ScreenSizeClass.Expanded))
     }
 
+    /**
+     * The two HUD rails are anchored TopStart and TopEnd inside one Box, so
+     * nothing but these fractions keeps them apart. Phones shipped with a bare
+     * `widthIn(max = …)` — a 220dp session list and a 300dp topology rail on a
+     * 411dp screen, which drew through each other for ~109dp and made the HUD
+     * two columns of overlapping text.
+     *
+     * Asserting the fractions alone would restate the constants. Assert the
+     * property that actually has to hold: at the narrowest width each class can
+     * see, the two resolved rail widths still fit side by side.
+     */
+    @Test
+    fun `side rails cannot overlap at the narrowest width of their size class`() {
+        // (scale, narrowest dp the class is used at). Compact starts at 320dp;
+        // Tiny renders the unsupported screen but shares the phone scale.
+        val cases = listOf(
+            MonitorLayoutScale.phone to 320f,
+            MonitorLayoutScale.tablet to 600f,
+            MonitorLayoutScale.expanded to 840f,
+        )
+        for ((scale, widthDp) in cases) {
+            val session = minOf(widthDp * scale.sessionPanelWidthFraction, scale.sessionPanelMaxWidth.value)
+            val topology = minOf(widthDp * scale.topologyPanelWidthFraction, scale.topologyPanelMaxWidth.value)
+            val insets = scale.panelEdgeInset.value * 2
+            assertTrue(
+                "rails overlap at ${widthDp}dp for ${scale.sizeClass}: " +
+                    "$session + $topology + $insets > $widthDp",
+                session + topology + insets <= widthDp,
+            )
+        }
+    }
+
+    @Test
+    fun `rail fractions leave room for the terrarium between them`() {
+        for (scale in listOf(MonitorLayoutScale.phone, MonitorLayoutScale.tablet, MonitorLayoutScale.expanded)) {
+            val used = scale.sessionPanelWidthFraction + scale.topologyPanelWidthFraction
+            assertTrue("${scale.sizeClass} rails claim $used of the width", used < 1f)
+        }
+    }
+
     @Test
     fun `isTablet is true exactly for the classes with room for side rails`() {
         assertFalse(scaleFor(ScreenSizeClass.Tiny).isTablet)

--- a/android/app/src/test/resources/robolectric.properties
+++ b/android/app/src/test/resources/robolectric.properties
@@ -1,0 +1,12 @@
+# Robolectric instruments against the app's targetSdk by default. Since
+# targetSdk moved to 36, that default demands a Java 21 toolchain — Robolectric
+# refuses to build an SDK 36 sandbox on anything older ("Android SDK 36
+# requires Java 21"). The repository baseline, the build script, and CI are all
+# JDK 17, so pin the sandbox to 35 instead of forcing every contributor and the
+# release workflow onto a new JDK.
+#
+# This is safe for what these tests cover: they exercise protocol parsing,
+# terrarium state and device classification — plain logic with no API 36
+# behavior in it. Raise this to 36 (and the toolchain to JDK 21) when a test
+# actually needs Android 16 runtime behavior.
+sdk=35

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
-    id("com.android.application") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
+    // Required from Kotlin 2.0: the Compose compiler ships as its own Gradle
+    // plugin instead of `composeOptions.kotlinCompilerExtensionVersion`.
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21" apply false
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/hardware-compatibility.md
+++ b/docs/hardware-compatibility.md
@@ -144,7 +144,7 @@ Operational exceptions:
 |---|---|---|---|
 | macOS | macOS 26 · Xcode 26.6 · Swift 6 | In-process Swift daemon on port 9120 | App Store sandbox; no subprocesses or bundled interpreter |
 | iOS / iPadOS | iOS 17 · Swift 6 | Bonjour + same-LAN WS | Client only; no direct hardware modules |
-| Android | minSdk 29 · target/compileSdk 34 · JDK 17 | ADB localhost first, then mDNS | ADB reverse is CLI-only; same-LAN discovery is sandbox-safe |
+| Android | minSdk 29 · target/compileSdk 36 · JDK 17 | ADB localhost first, then mDNS | ADB reverse is CLI-only; same-LAN discovery is sandbox-safe |
 | Node bridge | Node.js 22+ | Daemon on port 9120 | Supported on macOS and Windows 11; Linux is not an official host |
 
 Android e-ink uses vendor-native refresh controls: Crema and MOAAN use `EinkManager`, Onyx uses its update-mode API, Bigme uses a color palette path, and Kobo falls back to invalidation. Android and Apple share the wire protocol; their render and discovery layers remain platform-native.


### PR DESCRIPTION
Google Play stops accepting uploads targeting below **API 36 on 2026-08-31**, and the app was on 34 — below even today's API 35 floor, so an AAB would be rejected at upload, not at review.

## Toolchain

targetSdk cannot move alone: **AGP 8.2.2 → 8.13.2**, **Kotlin 1.9.22 → 2.3.21** (the Compose compiler is its own Gradle plugin from Kotlin 2.0, and `android.kotlinOptions.jvmTarget` is now a hard error), **Gradle 8.5 → 8.14.5**, **Compose BOM → 2026.03.01**, `compileSdk`/`targetSdk` → 36.

AndroidX libraries were deliberately **not** bumped: their current releases require compileSdk 37 + AGP 9.1, which is a second migration with its own risk. Nothing here needs their new APIs and Play only asks for targetSdk 36.

## Verified on a real Android 16 emulator, not just compiled

Both form factors boot, connect and render: **phone** 1080×2400 @420dpi and **10" tablet** 2560×1600 @320dpi, on `system-images;android-36;google_apis;arm64-v8a`.

The three API-36 behavior changes that break apps do not apply here — edge-to-edge is already handled (`enableEdgeToEdge` + `WindowInsets`), there are no native libraries to 16KB-page-align, and there are no orientation/resizability locks to trip the large-screen adaptive requirement.

Release artifacts build and sign: **AAB 5.2 MB**, APK 4.4 MB, `aapt2 dump badging` → `targetSdkVersion:'36' compileSdkVersion='36'`.

## The emulator run found a real defect

The two HUD rails are anchored `TopStart` and `TopEnd` inside one `Box`. Tablets sized them proportionally (`min(w*0.22, 220)` / `min(w*0.32, 300)`), but phones took a bare `widthIn(max = …)` — a ceiling with no relation to the screen. On a 411dp phone, a 220dp session list and a 300dp topology rail **drew through each other for ~109dp**, and the dashboard was two columns of unreadable overlapping text.

Both rails are now proportional on every size class, with the fractions living in `MonitorLayoutScale` beside the widths they bound (phone 0.42/0.46, tablet and expanded keep 0.22/0.32).

The test asserts the property, not the constants: *at the narrowest width each size class is used at, the two resolved rail widths plus edge insets still fit*. It fails on the old geometry — verified by restoring it.

## Robolectric

Pinned to SDK 35 via `robolectric.properties`. Its SDK 36 sandbox demands a **Java 21** toolchain while the repository baseline, `build-android-release.sh` and CI are all JDK 17. The three affected classes cover protocol parsing, terrarium state and device classification — no API 36 runtime behavior in any of them. Raising this is a JDK-21 decision, not a blocker for Play.

**319 unit tests pass.** `check-docs`, `design-system --check` and `sync-hardware-spec-cards --check` pass; the platform matrix row now reads target/compileSdk 36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)