### PR TITLE
release(android): 1.0.5 — Android 16 target and the phone HUD fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,25 @@ this is the patch that makes it work, so prefer it over `1.0.5`.
 
 ## 1.0.5
 
+### Android dashboard
+
+- Target Android 16 (API 36). Google Play stops accepting uploads below API 36
+  on 2026-08-31, and the app was still on 34 — under even the API 35 floor in
+  force since 2025-08-31, so a bundle would have been rejected at upload rather
+  than at review. The toolchain moved with it: AGP 8.13.2, Kotlin 2.3.21,
+  Gradle 8.14.5, Compose BOM 2026.03.01
+  ([#146](https://github.com/puritysb/AgentDeck/pull/146))
+- Stop the two HUD rails from drawing through each other on phones. Tablets
+  sized them against the screen; phones took a bare maximum width, so a 220dp
+  session list and a 300dp topology rail overlapped by ~109dp on a 411dp
+  display and the dashboard read as two interleaved columns of text
+  ([#146](https://github.com/puritysb/AgentDeck/pull/146))
+- Make the attention card opaque where it lands on those rails. At a 65% fill
+  it was depth on a tablet and unreadable on a phone, with session names and
+  quota figures showing through the agent's own question
+  ([#146](https://github.com/puritysb/AgentDeck/pull/146))
+
+
 ### CLI and daemon — npm
 
 - Validate the daemon port before a hook constructs a loopback URL, so a

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [Live](https://apps.apple.com/app/id6784822497) on both platforms: macOS 1.0.3 (build 4101, approved 2026-08-05) and the **iPhone/iPad companion 1.0.2** (build 4002, released 2026-08-06 — its first release, after the 2026-08-04 Guideline 2.1(a) rejection) |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.4 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-05) |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.2 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.2); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |
-| **GitHub Release** — Android APK | `android-v*` | [1.0.4](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.4) |
+| **GitHub Release** — Android APK | `android-v*` | [1.0.5](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.5) |
 | **GitHub Release** — ESP32 firmware | `esp32-v*` | [1.0.2](https://github.com/puritysb/AgentDeck/releases/tag/esp32-v1.0.2) — one binary per Shipping board |
 | **Google Play** — Android AAB | `android-v*` | Organization account registered; listing copy and assets in [marketplace/play/](marketplace/play/LISTING.md), upload gated on `ANDROID_PLAY_ENABLED` + a service-account key |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: required
 owner: Release maintainers
-reviewed: 2026-08-06
-revision: 2026-08-06
+reviewed: 2026-08-07
+revision: 2026-08-07
 source_of_truth: RELEASING.md
 validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-version]
 ---
@@ -17,7 +17,7 @@ validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-ve
 
 AgentDeck uses one `major.minor` compatibility line across every maintained surface. Two numeric `X.Y.Z` product versions are mutually compatible if and only if their first two components match. Patch values are ignored in both directions: for example, `1.0.1` and `1.0.9` are compatible regardless of which side is newer.
 
-Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI is at `1.0.8`; Stream Deck and Android are at `1.0.4`; Apple is at `1.0.3`; ESP32 is at `1.0.2`; Ulanzi is at `1.0.2`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. The public Mac App Store release is `1.0.2` (live since 2026-07-24); the iPhone/iPad companion's own first release, also `1.0.2`, was rejected on 2026-08-04 and has not shipped.
+Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI is at `1.0.9`; Stream Deck is at `1.0.4`; Android is at `1.0.5`; Apple is at `1.0.3`; ESP32 is at `1.0.2`; Ulanzi is at `1.0.2`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. Both Apple platforms are live: macOS `1.0.3` (approved 2026-08-05) and the iPhone/iPad companion `1.0.2`, whose first public release landed 2026-08-06 after the 2026-08-04 rejection.
 
 Run `pnpm verify-version` before every build or release. CI rejects a `major.minor` compatibility split or a target-internal mismatch. Release CI additionally requires a channel tag's full `X.Y.Z` to equal that target's own declared version; it does not compare the tag's patch with root `VERSION`.
 
@@ -26,7 +26,7 @@ Run `pnpm verify-version` before every build or release. CI rejects a `major.min
 | Surface | Target version | Independent monotonic value | Tag / delivery |
 |---|---|---|---|
 | **Apple** (iOS+macOS) | `apple/project.yml` `MARKETING_VERSION` | `CURRENT_PROJECT_VERSION` (CI-owned) | `apple-v*` → TestFlight / App Store |
-| **Android** | `android/app/build.gradle.kts` `versionName` | `versionCode` (currently 5) | `android-v*` → APK Release / optional Play |
+| **Android** | `android/app/build.gradle.kts` `versionName` | `versionCode` (currently 7) | `android-v*` → APK Release / optional Play |
 | **npm** (`@agentdeck/hooks`, `shared`, `bridge`, `setup`) | public `package.json` files | npm registry version floor | `npm-v*` → manual publish |
 | **ESP32** | `esp32/src/config.h` `FIRMWARE_VERSION` | build hash / epoch in firmware metadata | `esp32-v*` → firmware Release |
 | **Stream Deck** | plugin manifest `Version` as `X.Y.Z.0` | fourth component if a same-product-version plugin rebuild is ever required | `streamdeck-v*` → Elgato Maker portal |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "dev.agentdeck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.0.4"
+        versionCode = 7
+        versionName = "1.0.5"
     }
 
     buildTypes {

--- a/marketplace/play/LISTING.md
+++ b/marketplace/play/LISTING.md
@@ -8,6 +8,30 @@ created after 2023-11-13 does not apply — production is reachable directly.
 The APK on GitHub Releases stays; Play is an additional channel, not a
 replacement. Nothing in the app changes between them.
 
+## Blocked: developer account verification (2026-08-07)
+
+**Nothing can be uploaded yet, and the reason is not the artifact.** The Play
+Console home shows *"앱을 게시하려면 개발자 계정 설정을 완료하세요"* and the
+**Create app button is locked** — there is no app record to upload to. Two
+verification steps are outstanding, and the console states that **both are
+restricted to the account owner**:
+
+| Step | Console note | What it takes |
+|---|---|---|
+| **Organization website verification** | "계정 소유자만 조직의 웹사이트를 제공하고 인증할 수 있습니다" | Register the org's primary site in **Google Search Console**, enter that URL in account details, then send the verification request — it goes to the owner registered in Search Console |
+| **Phone number verification** | "계정 소유자만 전화번호를 인증할 수 있습니다" | Owner verifies by phone |
+
+Note for the website step: the site this project publishes is
+`https://puritysb.github.io/AgentDeck/`, a `github.io` subdomain. Search Console
+takes it as a **URL-prefix property** verified by an HTML file or meta tag,
+which GitHub Pages can serve — a domain-level property is not available for a
+subdomain you do not control the DNS for.
+
+Everything downstream of this — creating the app, the store listing, the
+internal-track upload, data safety, content rating — stays unreachable until
+both are green. The AAB itself is ready and was built and signed against
+`targetSdk 36`.
+
 ## Release gate
 
 Play refuses an upload below its target API floor before a human ever sees it.


### PR DESCRIPTION
Cuts the Android track at **1.0.5 / versionCode 7**.

The APK channel should get the targetSdk 36 move (#146) and both phone layout repairs regardless of Play, and Play will need a `versionCode` above anything it has seen when it eventually opens.

## Play is blocked, and not on anything we build

I went to submit and got no further than the console home. **The Create-app button is locked** — there is no app record to upload into. Two account verification steps are outstanding, and the console states that **both are restricted to the account owner**:

| Step | Console note |
|---|---|
| Organization website verification | "계정 소유자만 조직의 웹사이트를 제공하고 인증할 수 있습니다" |
| Phone number verification | "계정 소유자만 전화번호를 인증할 수 있습니다" |

Everything downstream — store listing, internal-track upload, data safety, content rating — is unreachable until both are green. `marketplace/play/LISTING.md` now records this next to the assets, including the practical note that `puritysb.github.io/AgentDeck` verifies in Search Console as a **URL-prefix** property (HTML file or meta tag, which Pages can serve), not a domain property.

## Also in this cut

Two stale claims in the same `RELEASING.md` paragraph: npm read `1.0.8` against a published `1.0.9`, and the iPhone/iPad companion was still described as never shipped although it went live 2026-08-06.

`verify-version-sync`, `check-docs` and `design-system --check` pass. Merging does not publish anything — `android-release.yml` fires on the `android-v1.0.5` tag and, with `ANDROID_PLAY_ENABLED` unset, only builds and attaches the signed APK to a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)