### PR TITLE
release: npm 1.0.13 — carry the push-to-talk fixes out

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/bridge",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/bridge/src/daemon.ts
+++ b/bridge/src/daemon.ts
@@ -22,7 +22,7 @@ const program = new Command();
 program
   .name('agentdeck')
   .description('AgentDeck daemon (legacy entry point — use `agentdeck daemon` instead)')
-  .version('1.0.12');
+  .version('1.0.13');
 
 program
   .command('start', { isDefault: true })

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/hooks",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": false,
   "type": "module",
   "files": [

--- a/setup/package.json
+++ b/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/setup",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/shared",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
The helper changes merged in #158 only reach users through this package: `prepack` recompiles `agentdeck-fm-helper` and `assets/fm-helper` ships in `files`, so a publish is what puts them on other machines.

## What this carries

- **The helper's stdin read loop no longer blocks on slow work**, so `record_stop` is read while an LLM `generate` is in flight. Without this a push-to-talk stop could be deferred up to 25 s and the capture ran to its 30 s cap — on *both* decks, depending only on whether the daemon happened to be doing LLM work at that moment.
- **A stop that arrives during capture setup is latched** instead of dropped, so a short hold — and every sub-250 ms cancel, whose whole meaning is "never mind" — ends the capture instead of leaving it to record the room for 30 s and deliver it as a prompt.
- **`daemon restart` no longer spawns with `stdio: 'ignore'`**, which sent every log line to `/dev/null`. Both start paths now share one rotating-log opener, which also creates the directory it writes to.
- **`GET /setup-status`** — the one secret-free route a webview may read cross-origin, used by the Ulanzi Property Inspector's setup check. `/health` could not be it: it carries `pairingToken`.
- Voice turns that deliver nothing (empty transcript, or no target session) now say so in the log instead of vanishing silently.

Version bump only: `bridge` / `setup` / `shared` / `hooks` 1.0.12 → 1.0.13, plus the CLI's own `--version` mirror.

Publishing happens on the `npm-v1.0.13` tag after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)