### PR TITLE
fix(observer): expire silent Claude processing states

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 2026-08-07 — Passive Claude sessions recover from abandoned turns
+
+Passively observed Claude transcripts that remain in `processing` without a
+write for more than ten minutes now return to `idle`, matching the existing
+end-event-loss safeguard for Codex rollouts. The observer keeps the session
+visible, clears only the stale task label, and resumes live processing on the
+next transcript write.
+
 ## 2026-08-08 — npm 1.0.14: tarball을 발행 머신에서 독립시키다
 
 ### 문제

--- a/bridge/src/__tests__/passive-observer.test.ts
+++ b/bridge/src/__tests__/passive-observer.test.ts
@@ -6,6 +6,7 @@ import {
   isAntigravityProcessCommand,
   isClaudeSessionProcessCommand,
   isCodexSessionProcessCommand,
+  observedStateAfterSilence,
   parseCimProcessTable,
   parseClaudeTranscript,
   parseCodexRollout,
@@ -18,6 +19,14 @@ function jsonl(records: unknown[]): string {
 }
 
 describe('passive-observer parsers', () => {
+  it('expires a silent observed processing state without hiding fresh work', () => {
+    const now = Date.parse('2026-08-07T04:00:00.000Z');
+    expect(observedStateAfterSilence('processing', now - 11 * 60_000, now)).toBe('idle');
+    expect(observedStateAfterSilence('processing', now - 9 * 60_000, now)).toBe('processing');
+    expect(observedStateAfterSilence('idle', now - 11 * 60_000, now)).toBe('idle');
+    expect(observedStateAfterSilence('processing', undefined, now)).toBe('processing');
+  });
+
   it('parses ps output without depending on fixed command columns', () => {
     // ps columns: pid ppid rss tty command (tty added for observed-answer injection)
     const rows = parseProcessTable([

--- a/bridge/src/passive-observer.ts
+++ b/bridge/src/passive-observer.ts
@@ -124,8 +124,20 @@ export interface ObservedSession extends EnrichedSession {
 const SCAN_INTERVAL_MS = 5_000;
 const MAX_TAIL_BYTES = 512 * 1024;
 const MAX_SAMPLE_BYTES = 1024 * 1024;
-/** Rollout silence (no writes) after which an end-event-less turn is presumed dead. */
+/** Transcript/rollout silence after which an end-event-less turn is presumed dead. */
 const STALE_TURN_MS = 10 * 60 * 1000;
+
+export function observedStateAfterSilence(
+  state: ObservedState,
+  lastActivityAt: number | undefined,
+  now = Date.now(),
+): ObservedState {
+  return state === 'processing'
+    && lastActivityAt !== undefined
+    && now - lastActivityAt > STALE_TURN_MS
+    ? 'idle'
+    : state;
+}
 
 interface CodexRolloutFileInfo {
   mtimeMs: number;
@@ -621,6 +633,8 @@ function collectClaudeSessions(processes: ProcInfo[]): ObservedSession[] {
     const summary = transcript
       ? parseClaudeTranscript(readFileHeadAndTail(transcript, 64 * 1024, MAX_TAIL_BYTES))
       : { state: 'idle' as const };
+    const lastActivityAt = transcript ? fileMtimeMs(transcript) : undefined;
+    const state = observedStateAfterSilence(summary.state, lastActivityAt);
     sessions.push({
       id: `observed:claude:${sessionFile.sessionId}`,
       port: 0,
@@ -628,18 +642,18 @@ function collectClaudeSessions(processes: ProcInfo[]): ObservedSession[] {
       projectName: projectNameFromCwd(sessionFile.cwd),
       agentType: 'claude-code',
       alive: true,
-      state: summary.state,
+      state,
       modelName: summary.modelName,
       startedAt: new Date(sessionFile.startedAt).toISOString(),
       controlMode: 'observed',
       cwd: sessionFile.cwd,
       tty: proc.tty,
       appName: proc.tty ? undefined : resolveHostApp(proc.pid, byPid),
-      currentTask: summary.currentTask,
+      currentTask: state === 'processing' ? summary.currentTask : undefined,
       goal: summary.goal,
       contextPercent: summary.contextPercent,
       totalTokens: summary.totalTokens,
-      lastActivityAt: transcript ? fileMtimeMs(transcript) : undefined,
+      lastActivityAt,
     });
   }
   return sessions;


### PR DESCRIPTION
## Summary

- Move passively observed Claude sessions from processing to idle when their transcript has not changed for ten minutes.
- Clear the stale current-task text at the same transition.
- Keep active and awaiting sessions unchanged while fresh activity is present.

This prevents a completed passive Claude session from remaining visually stuck in a running state without adding polling, control, or mutation behavior.

## Verification

- Focused passive-observer tests: 25 passed.
- Full workspace suite: 2,758 passed, 1 skipped.
- Workspace build passed.