### PR TITLE
fix(scripts): stop a failed protocol run from truncating committed schemas

### DIFF
--- a/scripts/generate-protocol.sh
+++ b/scripts/generate-protocol.sh
@@ -35,27 +35,40 @@ fi
 
 mkdir -p "$OUT_DIR"
 
+# Staging area for step 1. A shell redirection truncates its target BEFORE the
+# command runs, so `generator > committed-file.json` destroys that file the
+# moment the generator fails — and OUT_DIR defaults to the repository, where
+# these schemas are committed artifacts guarded by the drift gate. `set -e`
+# then aborts, leaving a 0-byte file staged for the next unwary `git commit`.
+#
+# The failure is routine on Windows: when `bash` resolves to WSL's bash, the
+# drift gate's AGENTDECK_PROTOCOL_OUT_DIR override does not cross the WSL
+# boundary (WSL forwards only variables named in WSLENV), so the "regenerate
+# into a temp dir and byte-compare" path writes to the real directory instead —
+# and truncates three tracked files on its way to failing.
+#
+# Generating into a scratch dir and moving on success keeps a failed run
+# read-only with respect to OUT_DIR.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Emit one JSON Schema. `set -e` aborts before the `mv` when the generator
+# exits non-zero, so OUT_DIR keeps whatever it already had.
+gen_schema() {
+  local src="$1" type="$2" out="$3"
+  npx ts-json-schema-generator \
+    --path "$PROJECT_DIR/$src" \
+    --type "$type" \
+    --tsconfig "$PROJECT_DIR/shared/tsconfig.json" \
+    --no-type-check \
+    > "$TMP_DIR/$out"
+  mv "$TMP_DIR/$out" "$OUT_DIR/$out"
+}
+
 echo "=== Step 1: Generate JSON Schema from TypeScript ==="
-npx ts-json-schema-generator \
-  --path "$PROJECT_DIR/shared/src/protocol.ts" \
-  --type "BridgeEvent" \
-  --tsconfig "$PROJECT_DIR/shared/tsconfig.json" \
-  --no-type-check \
-  > "$OUT_DIR/bridge-event-schema.json"
-
-npx ts-json-schema-generator \
-  --path "$PROJECT_DIR/shared/src/protocol.ts" \
-  --type "PluginCommand" \
-  --tsconfig "$PROJECT_DIR/shared/tsconfig.json" \
-  --no-type-check \
-  > "$OUT_DIR/plugin-command-schema.json"
-
-npx ts-json-schema-generator \
-  --path "$PROJECT_DIR/shared/src/gateway-protocol.ts" \
-  --type "GatewayFrame" \
-  --tsconfig "$PROJECT_DIR/shared/tsconfig.json" \
-  --no-type-check \
-  > "$OUT_DIR/gateway-frame-schema.json"
+gen_schema shared/src/protocol.ts         BridgeEvent   bridge-event-schema.json
+gen_schema shared/src/protocol.ts         PluginCommand plugin-command-schema.json
+gen_schema shared/src/gateway-protocol.ts GatewayFrame  gateway-frame-schema.json
 
 echo "   → bridge-event-schema.json"
 echo "   → plugin-command-schema.json"


### PR DESCRIPTION
## The bug

`scripts/generate-protocol.sh` step 1 writes each JSON Schema with a shell redirection:

```sh
npx ts-json-schema-generator … > "$OUT_DIR/bridge-event-schema.json"
```

A redirection truncates its target **before** the command runs. `OUT_DIR` defaults to `$PROJECT_DIR/generated/protocol` — the committed artifacts the protocol drift gate compares against. So any generator failure empties a tracked file, and `set -e` then aborts before anything can restore it.

This isn't hypothetical on Windows. When `bash` resolves to WSL's bash, the drift gate's `AGENTDECK_PROTOCOL_OUT_DIR` override doesn't cross the WSL boundary — WSL forwards only variables named in `WSLENV` — so the "regenerate into a temp dir and byte-compare, never mutating the working tree" path (the comment at the top of the script promises exactly this) writes into the real directory instead, and truncates three tracked files on the way to failing.

## The fix

Generate into `mktemp -d` and `mv` into `OUT_DIR` only after the generator exits 0. `set -e` aborts before the `mv`, so a failed run is read-only with respect to `OUT_DIR`.

Scope is deliberately step 1 only. Steps 2–3 hand quicktype an `--out` path rather than redirecting, and quicktype builds in memory before opening that file, so it does not carry the same guaranteed-destructive-on-failure property.

## Verification

**Destructiveness, with a stub `npx` that always exits 1** — sentinel files of 26 bytes each in `OUT_DIR`:

| artifact | master | this branch |
|---|---|---|
| `bridge-event-schema.json` | **0 bytes** | 26 |
| `plugin-command-schema.json` | 26 | 26 |
| `gateway-frame-schema.json` | 26 | 26 |

**Output neutrality on the success path** — ran both the master script and this one into separate directories with the same toolchain: all 12 generated artifacts are byte-identical. No regenerated artifacts are committed here.

## Credit

Diagnosis and the tmp-then-`mv` approach are from @Roja430, in #165 (commit `e63ad1c7`, `fix(scripts): make the protocol generator work on Windows`). That PR bundled 49 commits and was self-closed; this lifts one self-contained fix out of it so it can be reviewed on its own. The WSLENV explanation is theirs and it's correct.
