### PR TITLE
fix(design-lint): repair R6, which has never flagged an emoji

### DIFF
--- a/design/__tests__/lint-r6.sh
+++ b/design/__tests__/lint-r6.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Boundary cases for design lint rule R6 (emoji in product UI).
+#
+# R6 shipped broken and stayed broken because nothing exercised it: the rule
+# contributed 0 findings, which is indistinguishable from "the codebase is
+# clean". This asserts the pattern matches emoji and, just as importantly,
+# leaves typography alone.
+#
+# Usage: bash design/__tests__/lint-r6.sh
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LINT_SH="$(dirname "$SCRIPT_DIR")/lint.sh"
+
+# Keep this in lockstep with the R6 pattern in design/lint.sh.
+PATTERN=$(grep -A1 '^scan "R6_emoji_in_ui"' "$LINT_SH" | tail -1 | sed "s/^ *//; s/ *\\\\$//")
+eval "R6=$PATTERN"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# check <expect: hit|miss> <label> <utf8-bytes…>
+check() {
+  local expect="$1" label="$2"; shift 2
+  printf "$*\n" > "$TMP/probe"
+  local got=miss
+  LC_ALL=C grep -qE "$R6" "$TMP/probe" && got=hit
+  if [[ "$got" == "$expect" ]]; then
+    pass=$(( pass + 1 ))
+    printf '  \033[32m✓\033[0m %-34s %s\n' "$label" "$expect"
+  else
+    fail=$(( fail + 1 ))
+    printf '  \033[31m✗\033[0m %-34s expected %s, got %s\n' "$label" "$expect" "$got"
+  fi
+}
+
+printf '\n\033[1mR6 — emoji in product UI\033[0m\n'
+
+printf '\n  must flag (emoji)\n'
+check hit  'U+1F525 fire'                '\xf0\x9f\x94\xa5'
+check hit  'U+2600 first of misc'        '\xe2\x98\x80'
+check hit  'U+27BF last of dingbats'     '\xe2\x9e\xbf'
+check hit  'U+2B00 first of stars'       '\xe2\xac\x80'
+check hit  'U+2B7F last of stars'        '\xe2\xad\xbf'
+check hit  'U+1F300 first pictograph'    '\xf0\x9f\x8c\x80'
+check hit  'U+1FAFF last supplement'     '\xf0\x9f\xab\xbf'
+check hit  'emoji mid-line'              'color: red; /* \xf0\x9f\x94\xa5 */'
+
+printf '\n  must ignore (typography and scripts)\n'
+check miss 'U+2014 em dash'              '\xe2\x80\x94'
+check miss 'U+201C curly quote'          '\xe2\x80\x9c'
+check miss 'U+2026 ellipsis'             '\xe2\x80\xa6'
+check miss 'U+2022 bullet'               '\xe2\x80\xa2'
+check miss 'U+25FF just below range'     '\xe2\x97\xbf'
+check miss 'U+27C0 just above range'     '\xe2\x9f\x80'
+check miss 'Hangul'                      '\xed\x95\x9c\xea\xb8\x80'
+check miss 'Kanji'                       '\xe6\x97\xa5\xe6\x9c\xac'
+check miss 'plain ASCII'                 'border-radius: 8px;'
+
+printf '\n────────────────────────────────────────────────────────────\n'
+if [[ $fail -eq 0 ]]; then
+  printf '\033[32m✓ %d/%d passed.\033[0m\n\n' "$pass" "$(( pass + fail ))"
+  exit 0
+fi
+printf '\033[31m✗ %d of %d failed.\033[0m\n\n' "$fail" "$(( pass + fail ))"
+exit 1

--- a/design/lint.sh
+++ b/design/lint.sh
@@ -81,7 +81,12 @@ scan() {
     [[ "$file" =~ $exclude ]] && continue
     text="${text#"${text%%[![:space:]]*}"}"   # ltrim
     emit "$rule" "$file" "$line" "${text:0:160}"
-  done < <(grep -rnHE --include='*.html' --include='*.css' --include='*.jsx' --include='*.js' \
+    # LC_ALL=C makes the scan byte-oriented and therefore identical on every
+    # runner. R6's pattern is written in raw UTF-8 bytes, which a UTF-8 locale
+    # rejects outright ("grep: illegal byte sequence" — on stderr, which both
+    # this function and the CI step discard, so the rule failed in silence).
+    # Every other pattern here is ASCII, where the two locales agree.
+  done < <(LC_ALL=C grep -rnHE --include='*.html' --include='*.css' --include='*.jsx' --include='*.js' \
             --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.github \
             --exclude-dir=dist --exclude-dir=coverage --exclude-dir=generated \
             --exclude-dir=.zig-cache --exclude-dir=.zig-global-cache \
@@ -117,10 +122,23 @@ scan "R5_non_warm_shadow" \
   'box-shadow:[^;]*rgba\(\s*0\s*,\s*0\s*,\s*0\s*,' \
   "$TOKEN_FILES"
 
-# ── Rule R6: emoji in product UI (covers most ranges used in slop) ─────
-# Hits BMP emoji & symbols ranges; opt-out via data-allow-emoji=""
+# ── Rule R6: emoji in product UI ───────────────────────────────────────
+# One alternative per UTF-8 lead byte, NOT one bracket set spanning all of
+# them. The previous form — [\xE2\x98-\xE2\x9F\xE2\xAD\xF0\x9F] — is a single
+# byte set holding one range, \x98-\xE2, so it stood for "almost every high
+# byte": in a C locale it flagged every em dash, ellipsis and curly quote as an
+# emoji, and in a UTF-8 locale grep rejected the pattern as an illegal byte
+# sequence and matched nothing at all. Either way it never did its job.
+#
+# Ranges, as bytes (see the boundary cases in design/__tests__/lint-r6.sh):
+#   U+2600–U+27BF  misc symbols + dingbats   \xE2[\x98-\x9E][\x80-\xBF]
+#   U+2B00–U+2B7F  stars and arrows          \xE2[\xAC-\xAD][\x80-\xBF]
+#   U+1F300–U+1FAFF  pictographs + supplement  \xF0\x9F[\x8C-\xAB][\x80-\xBF]
+#
+# Deliberately excludes General Punctuation (U+2000–U+206F): an em dash is
+# typography, not slop. Opt out per-element via data-allow-emoji="".
 scan "R6_emoji_in_ui" \
-  $'[\xE2\x98-\xE2\x9F\xE2\xAD\xF0\x9F][\x80-\xBF][\x80-\xBF]' \
+  $'(\xE2[\x98-\x9E][\x80-\xBF]|\xE2[\xAC-\xAD][\x80-\xBF]|\xF0\x9F[\x8C-\xAB][\x80-\xBF])' \
   "$TOKEN_FILES"
 
 # ── Rule R7: non-token border-radius ───────────────────────────────────


### PR DESCRIPTION
## The bug

Design lint rule R6 ("Emoji in UI code") has never worked. Its pattern:

```
[\xE2\x98-\xE2\x9F\xE2\xAD\xF0\x9F][\x80-\xBF][\x80-\xBF]
```

reads as a single byte set containing one range, `\x98-\xE2` — "almost any high byte" — rather than the several UTF-8 lead-byte ranges it was meant to describe. What that produces depends on the locale:

| locale | behaviour |
|---|---|
| UTF-8 (every dev machine, every CI runner) | `grep: illegal byte sequence`, **zero matches** |
| `C` | matches every em dash, ellipsis and curly quote — typography, not emoji |

The error goes to stderr, and both `scan()` (`2>/dev/null`) and the CI step (`2>/dev/null`) discard it. So the rule has been reporting a clean codebase for its entire life, which is indistinguishable from actually being clean — that's why it survived.

## The fix

One alternative per lead byte:

```
(\xE2[\x98-\x9E][\x80-\xBF]|\xE2[\xAC-\xAD][\x80-\xBF]|\xF0\x9F[\x8C-\xAB][\x80-\xBF])
```

- `U+2600–U+27BF` misc symbols + dingbats
- `U+2B00–U+2B7F` stars and arrows
- `U+1F300–U+1FAFF` pictographs + supplement

General Punctuation (`U+2000–U+206F`) is deliberately excluded — an em dash is typography, and the repo's prose uses them heavily.

`scan()` now runs its grep under `LC_ALL=C`, so the byte pattern is well defined and every rule counts identically on every runner. All other patterns are ASCII, where the two locales agree.

## Regression test

`design/__tests__/lint-r6.sh` — 17 cases, both directions, on the range boundaries (`U+25FF`/`U+2600`, `U+27BF`/`U+27C0`, `U+2B00`/`U+2B7F`, `U+1F300`/`U+1FAFF`), plus em dash, curly quote, ellipsis, bullet, Hangul, Kanji and plain ASCII on the must-ignore side. It reads the pattern back out of `lint.sh` rather than restating it, so the two can't drift.

```
✓ 17/17 passed.
```

## Baseline: unchanged at 89

The rule now works *and* the scanned surface is genuinely emoji-free, so `docs/design-lint-baseline.md` needs no edit and the CI gate stays green.

Verified end to end rather than assumed — dropping a probe file containing both an emoji and an em dash into the scan scope:

```
this branch:  ▸ R6_emoji_in_ui (1)
                ./design/__r6probe.css:1  .probe { content: "🔥"; }
              90 violation(s) across 4 rule(s)     ← em dash correctly ignored
master:       no R6 block at all
```

With the probe removed, both report 89 across 3 rules.

## Credit

Found by @Roja430 in #165 (`fix(design-lint): repair R6, which had never matched an emoji`). That PR bundled 49 commits and was self-closed; this lifts the finding out so it can be reviewed alone. The pattern here is written independently and the locale pinning is additional — their diagnosis of the bracket-set bug is what made it visible.
