### PR TITLE
docs: write down what may change on the wire, and gate it

### DIFF
--- a/agentdeck-design-system/catalog.json
+++ b/agentdeck-design-system/catalog.json
@@ -20,6 +20,7 @@
     "hardware.compatibility": { "en": "Compatibility", "ko": "호환성", "ja": "互換性" },
     "spec.devices": { "en": "Devices", "ko": "디바이스", "ja": "デバイス" },
     "spec.esp32": { "en": "ESP32 firmware", "ko": "ESP32 펌웨어", "ja": "ESP32 firmware" },
+    "spec.wire-compatibility": { "en": "Wire compatibility", "ko": "와이어 호환성", "ja": "ワイヤ互換性" },
     "spec.esp32-client": { "en": "ESP32 client", "ko": "ESP32 클라이언트", "ja": "ESP32 client" },
     "spec.android": { "en": "Android app", "ko": "Android 앱", "ja": "Android app" },
     "design.android-ui": { "en": "Android UI", "ko": "Android UI", "ja": "Android UI" },
@@ -140,6 +141,12 @@
       "id": "spec.esp32",
       "sources": {
         "en": "docs/esp32.md"
+      }
+    },
+    {
+      "id": "spec.wire-compatibility",
+      "sources": {
+        "en": "docs/wire-compatibility.md"
       }
     },
     {

--- a/agentdeck-design-system/catalog.json
+++ b/agentdeck-design-system/catalog.json
@@ -16,11 +16,11 @@
     "arch.daemon": { "en": "Daemon", "ko": "데몬", "ja": "デーモン" },
     "arch.protocol": { "en": "Bridge protocol", "ko": "브리지 규약", "ja": "ブリッジ規約" },
     "arch.gateway-protocol": { "en": "Gateway protocol", "ko": "Gateway 규약", "ja": "Gateway 規約" },
+    "spec.wire-compatibility": { "en": "Wire compatibility", "ko": "와이어 호환성", "ja": "ワイヤ互換性" },
     "arch.apme": { "en": "APME", "ko": "APME", "ja": "APME" },
     "hardware.compatibility": { "en": "Compatibility", "ko": "호환성", "ja": "互換性" },
     "spec.devices": { "en": "Devices", "ko": "디바이스", "ja": "デバイス" },
     "spec.esp32": { "en": "ESP32 firmware", "ko": "ESP32 펌웨어", "ja": "ESP32 firmware" },
-    "spec.wire-compatibility": { "en": "Wire compatibility", "ko": "와이어 호환성", "ja": "ワイヤ互換性" },
     "spec.esp32-client": { "en": "ESP32 client", "ko": "ESP32 클라이언트", "ja": "ESP32 client" },
     "spec.android": { "en": "Android app", "ko": "Android 앱", "ja": "Android app" },
     "design.android-ui": { "en": "Android UI", "ko": "Android UI", "ja": "Android UI" },
@@ -118,6 +118,12 @@
       }
     },
     {
+      "id": "spec.wire-compatibility",
+      "sources": {
+        "en": "docs/wire-compatibility.md"
+      }
+    },
+    {
       "id": "arch.apme",
       "sources": {
         "en": "docs/apme.md"
@@ -141,12 +147,6 @@
       "id": "spec.esp32",
       "sources": {
         "en": "docs/esp32.md"
-      }
-    },
-    {
-      "id": "spec.wire-compatibility",
-      "sources": {
-        "en": "docs/wire-compatibility.md"
       }
     },
     {

--- a/bridge/src/__tests__/docs-wire-contract.test.ts
+++ b/bridge/src/__tests__/docs-wire-contract.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Binds the documented LAN boundary to the code that implements it.
+ *
+ * `docs/daemon.md` and `docs/wire-compatibility.md` both quote the exact body
+ * an unauthenticated LAN peer receives. That payload is the security-relevant
+ * one — it is the only thing a stranger on the Wi-Fi can read (issue #145) —
+ * and prose drifts silently, so nothing but a test keeps the two honest.
+ *
+ * If this fails because you added a field to `buildPublicHealth`, stop and ask
+ * whether it belongs in front of an unauthenticated peer before updating docs.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { buildPublicHealth, gateHttpRequest } from '../http-auth-gate.js';
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+/** Pull the documented public-health JSON out of a doc's fenced/inline sample. */
+function documentedPublicHealth(markdown: string): Record<string, unknown> {
+  const match = markdown.match(/\{"status":"ok","mode":"daemon"[^}]*\}/);
+  if (!match) throw new Error('no public-health sample found in doc');
+  return JSON.parse(match[0]);
+}
+
+describe('documented LAN boundary matches the gate', () => {
+  it('daemon.md quotes exactly the fields buildPublicHealth emits', () => {
+    const documented = documentedPublicHealth(read('docs/daemon.md'));
+    expect(Object.keys(documented).sort()).toEqual(Object.keys(buildPublicHealth(9120)).sort());
+  });
+
+  it('the documented payload carries no credential, inventory or state', () => {
+    const documented = documentedPublicHealth(read('docs/daemon.md'));
+    for (const key of Object.keys(documented)) {
+      expect(key).not.toMatch(/token|secret|credential|password/i);
+    }
+    // The fields #145 found leaking, none of which may reappear.
+    for (const forbidden of ['pairingToken', 'modules', 'sessions', 'state', 'devices', 'pid']) {
+      expect(documented).not.toHaveProperty(forbidden);
+    }
+  });
+
+  it('GET /health is the only route an unauthorized peer reaches', () => {
+    expect(gateHttpRequest('GET', '/health', false)).toBe('public-health');
+    for (const route of ['/status', '/sessions', '/timeline', '/devices', '/setup-status', '/sse']) {
+      expect(gateHttpRequest('GET', route, false)).toBe('deny');
+    }
+    // Method matters: only GET reaches the public payload.
+    expect(gateHttpRequest('POST', '/health', false)).toBe('deny');
+  });
+});
+
+describe('wire compatibility contract stays bound to its subjects', () => {
+  const doc = read('docs/wire-compatibility.md');
+
+  it('is cataloged in the design system', () => {
+    const catalog = JSON.parse(read('agentdeck-design-system/catalog.json'));
+    const entry = catalog.documents.find((d: { id: string }) => d.id === 'spec.wire-compatibility');
+    expect(entry?.sources?.en).toBe('docs/wire-compatibility.md');
+  });
+
+  it('names helpers that still exist, so the id rules stay actionable', () => {
+    for (const symbol of ['rawSessionId', 'sameSession']) {
+      expect(doc).toContain(symbol);
+      expect(read('shared/src/session-utils.ts')).toContain(`export function ${symbol}`);
+    }
+  });
+
+  it('quotes the retain-on-absent merge shape the rules depend on', () => {
+    expect(doc).toContain('s.x = e.x ?? s.x');
+  });
+});

--- a/bridge/src/__tests__/docs-wire-contract.test.ts
+++ b/bridge/src/__tests__/docs-wire-contract.test.ts
@@ -51,6 +51,44 @@ describe('documented LAN boundary matches the gate', () => {
   });
 });
 
+/**
+ * The published design-system rail renders one collapsible group, closed by
+ * default. A contract nobody opens is a contract nobody reads, so the auth and
+ * wire specs must not sit inside it — they belong in an always-expanded
+ * category alongside the other surface specs.
+ */
+describe('auth and wire specs stay visible in the published rail', () => {
+  const AUTH_AND_WIRE_DOCS = [
+    'docs/wire-compatibility.md',
+    'docs/protocol.md',
+    'docs/gateway-protocol.md',
+    'docs/daemon.md',
+  ];
+
+  /** The one category the viewer collapses, read from the viewer itself. */
+  function collapsibleCategory(): string {
+    const app = read('agentdeck-design-system/viewer/app.js');
+    const match = app.match(/const isProject = category === '([^']+)'/);
+    if (!match) throw new Error('viewer no longer marks a single collapsible category');
+    return match[1];
+  }
+
+  function categoryOf(rel: string): string {
+    const match = read(rel).match(/^category:\s*(.+)$/m);
+    if (!match) throw new Error(`${rel} has no category frontmatter`);
+    return match[1].trim();
+  }
+
+  it.each(AUTH_AND_WIRE_DOCS)('%s is not in the collapsed group', (rel: string) => {
+    expect(categoryOf(rel)).not.toBe(collapsibleCategory());
+  });
+
+  it('groups them with the other surface specs', () => {
+    const categories = new Set(AUTH_AND_WIRE_DOCS.map(categoryOf));
+    expect(categories).toEqual(new Set([categoryOf('docs/esp32-client-contract.md')]));
+  });
+});
+
 describe('wire compatibility contract stays bound to its subjects', () => {
   const doc = read('docs/wire-compatibility.md');
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -2,7 +2,7 @@
 id: arch.daemon
 title: Daemon Hub
 description: The singleton daemon on port 9120 — session-bridge push, mDNS recovery, usage relay, multi-surface monitoring.
-category: Engineering
+category: Specs
 locale: en
 canonical: true
 status: stable

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -137,6 +137,31 @@ The daemon deliberately binds `0.0.0.0` — companion apps, ESP32 boards, and pu
 - **Loopback-only opt-out**: `AGENTDECK_LOOPBACK_ONLY=1` binds `127.0.0.1` for users with no LAN devices. Startup logs state the bind mode either way.
 - Tests: `bridge/src/__tests__/http-auth-gate.test.ts`, `mdns-hostname.test.ts` (TXT token absence), `discovery-security.test.ts` (UDP and startup-log absence), `ws-server-auth.test.ts`, Swift `HttpAccessPolicyTests`.
 
+### Verifying the boundary by hand
+
+**You cannot test this from the daemon's own machine.** `isLocalConnection()` trusts loopback *and every address on this host's own interfaces*, so `curl http://<my-own-LAN-IP>:9120/health` from the Mac returns the full payload — pairing token included — and that is correct behaviour, not a leak. Reading it as one is a measurement error that has already been made once (2026-08-09, while closing #145).
+
+A real check needs a second host. The cheapest one in this repo is an attached ADB device on the same Wi-Fi:
+
+```bash
+adb -s <serial> shell "curl -s http://<daemon-LAN-IP>:9120/health"
+# {"status":"ok","mode":"daemon","port":9120,"sameSocketControl":true,"authRequired":true}
+```
+
+Expected results from a genuinely remote peer: `GET /health` → 200 with that minimal body; `/status`, `/sessions`, `/timeline`, `/devices` and a wrong `?token=` → 401.
+
+Two traps when reading the results:
+
+- **A WebSocket upgrade answering `101` is not a failure.** Both daemons complete the handshake and then close `4001 Unauthorized` before registering the socket or sending any state. Check for the close code, not the status line.
+- **Not every device image has `curl`** — several e-ink Android builds do not. Pick the device before concluding the daemon is unreachable.
+
+The other two discovery transports are checkable locally, since neither is request-scoped:
+
+```bash
+dns-sd -Z _agentdeck._tcp local     # TXT must carry project/agent/v/port/ip only
+# UDP beacon: bind 0.0.0.0:9121 with SO_REUSEADDR+SO_REUSEPORT alongside the daemon
+```
+
 ## Multi-surface monitoring
 
 - mDNS (`_agentdeck._tcp`, daemon only), auth token (`~/.agentdeck/auth-token`), SSE (`/sse`), remote WS token validation

--- a/docs/gateway-protocol.md
+++ b/docs/gateway-protocol.md
@@ -2,7 +2,7 @@
 id: arch.gateway-protocol
 title: Gateway Protocol
 description: OpenClaw Gateway WebSocket — frame format, Ed25519 handshake, RPC and event catalog, versioning rules.
-category: Engineering
+category: Specs
 locale: en
 canonical: true
 status: stable

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -16,6 +16,8 @@ validators: [pnpm generate-protocol, pnpm test]
 
 Internal reference for the AgentDeck state machine, WebSocket protocol, and project structure.
 
+This document describes **what** the daemon and its clients say to each other. Before changing any of it, read the [Wire Compatibility Contract](wire-compatibility.md) — most consumers are software we cannot update (App Store apps, marketplace plugins, flashed firmware), and it sets out which changes are safe, which look additive but break the fleet, and how to introduce one that genuinely isn't.
+
 ---
 
 ## Architecture Diagram

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -2,7 +2,7 @@
 id: arch.protocol
 title: Bridge Protocol
 description: The bridge-to-client WebSocket protocol — event catalog, state machine, and the generated Swift/Kotlin type mirrors.
-category: Engineering
+category: Specs
 locale: en
 canonical: true
 status: stable

--- a/docs/wire-compatibility.md
+++ b/docs/wire-compatibility.md
@@ -2,7 +2,7 @@
 id: spec.wire-compatibility
 title: Wire Compatibility Contract
 description: What may change on the daemon↔client wire without breaking software already in users' hands — change classes, the retain-on-absent merge rule, freshness axes, and how to introduce a genuinely breaking change.
-category: Engineering
+category: Specs
 locale: en
 canonical: true
 status: stable

--- a/docs/wire-compatibility.md
+++ b/docs/wire-compatibility.md
@@ -1,0 +1,118 @@
+---
+id: spec.wire-compatibility
+title: Wire Compatibility Contract
+description: What may change on the daemon↔client wire without breaking software already in users' hands — change classes, the retain-on-absent merge rule, freshness axes, and how to introduce a genuinely breaking change.
+category: Engineering
+locale: en
+canonical: true
+status: stable
+owner: Bridge maintainers
+reviewed: 2026-08-09
+revision: 2026-08-09
+source_of_truth: shared/src/protocol.ts
+validators: [pnpm test, pnpm generate-protocol]
+---
+# Wire Compatibility Contract
+
+`docs/protocol.md` lists **what** the daemon and its clients say to each other. This document says **what you are allowed to change about it**, because most of AgentDeck's consumers are software we cannot update: apps on the App Store, a plugin on the Elgato Marketplace, firmware flashed onto boards on someone's desk.
+
+Scope is the daemon↔client surface: the dashboard WebSocket, the daemon's HTTP routes, discovery, and the ESP32 serial link. The Gateway frame protocol has its own contract in `docs/gateway-protocol.md`; the authentication boundary has its own in [Daemon Hub → LAN security model](daemon.md). This document does not restate either.
+
+## 1. The compatibility surface
+
+Every change ships into a fleet that is already running. As of 2026-08-09:
+
+| consumer | shipped as | updatable by us? |
+|---|---|---|
+| iOS / iPadOS companion | App Store 1.0.4 | no — user updates, on Apple's schedule |
+| macOS app (+ in-process Swift daemon) | App Store 1.0.4 | no |
+| Stream Deck plugin | Elgato Marketplace 1.0.2 | no — DRM-signed, review-gated |
+| Ulanzi D200H plugin | Ulanzi Marketplace 1.0.3 | no |
+| ESP32 firmware | flashed; WiFi OTA where reachable | partly — a board that is off, or serial-only, keeps its old build |
+| Node CLI / bridge | npm 1.0.15 | yes — `npx @agentdeck/setup@latest` |
+
+Only the last row updates when we say so. Design every wire change for the other six.
+
+## 2. What the version rule does and does not promise
+
+The repository rule is that numeric `X.Y.Z` versions are mutually compatible exactly when `X.Y` matches, and `pnpm verify-version` enforces it.
+
+That rule is about **field-level** evolution, and it is silent about everything in §3 that is not field-level. Every consumer in the table above is `1.0.x`, so `verify-version` will call them all compatible no matter what you do to the shape of a payload. A green `verify-version` is not evidence that a wire change is safe.
+
+## 3. Change classes
+
+### Safe — additive, ignored by clients that do not know them
+
+- **A new optional field on an existing message.** Swift `Codable`, Kotlin, and the TS types all ignore unknown keys.
+- **A new top-level event `type`.** `BridgeEventParser.parse` returns `nil` for an unrecognised `type` and logs it; the other surfaces dispatch the same way. An old client silently skips the event.
+- **A new value in an open-ended string field** where the consumer already has a `default` branch — `StreamDeckDeviceInfo.family` is deliberately `String` rather than an enum for exactly this reason.
+
+### Breaking — even though it looks additive
+
+- **A new *kind of row* in an existing collection.** `sessions_list` is the canonical trap. Every shipped client treats each element as a session: it is sorted into the deck, **consumes a physical key**, counts toward session totals, and is tappable. A client that has never heard of your discriminator field cannot opt out of rendering the row. This is what blocked PR #163, which appended synthetic `codex-goal:<threadId>` entries: correct in the new code, and a corrupted deck on every 1.0.x client.
+- **A new session-id namespace.** Ids are normalised (`rawSessionId` / `sameSession`), matched by prefix after devices truncate them to 31 characters (`resolveSessionIdPrefix`), and pattern-matched in several surfaces. A new prefix silently misses all of it.
+- **Reinterpreting an existing field.** Worse than removing it: consumers keep parsing successfully and act on the old meaning. There is no error to notice.
+- **Removing a field.** This is a consumer migration, not a deletion — see issues #145 → #149, where dropping the pairing token from discovery made three independent clients destroy their own stored credential, because each treated absence as "clear it". Grep the **consumers**, and specifically the code that *stores* the value.
+
+### The rule behind the last two
+
+> **Absence means "no information". It never means "empty".**
+
+A client merging retain-on-absent (`s.x = e.x ?? s.x`) cannot distinguish "unchanged" from "cleared" unless you make the cleared case explicit.
+
+## 4. Optional booleans must carry both signals
+
+In a retain-on-absent protocol, a flag that is only ever sent when `true` can be set but never retracted. It latches, permanently.
+
+Never write `x || undefined` or `x ? true : undefined` on the producer side. Emit the explicit `false`.
+
+`usageStale` demonstrated both halves of this within eight days: 2026-07-17 added only the positive signal, and the missing negative signal then pinned a "stale" badge over live percentages on the macOS dashboard until relaunch (2026-07-25). Producers: `bridge/src/usage-event.ts`, `DaemonServer.buildUsageEvent`.
+
+When a legacy producer may still omit the key, the consumer precedence is **explicit flag > data presence > retain** — never data-presence as a peer of the flag, since "had data, now stale" legitimately ships numbers alongside `true`.
+
+## 5. Freshness is three axes, and none of them is a hard signal
+
+Usage snapshots carry three independent qualifiers. Collapsing any of them into "hide the gauge" is a bug:
+
+| axis | question | signal | consumer behaviour |
+|---|---|---|---|
+| **stale** | has this *window* ended? | `resetsAt` in the past | drop the gauge — the number describes a window that no longer exists |
+| **age** | how old is this *reading*? | `capturedAt`, compared against the **consumer's own** clock | keep rendering, dimmed, with the age in place of the countdown |
+| **plan** | was this minted under a plan the account still holds? | snapshot `planType` vs live tier | void — an explicit windowless snapshot on the wire |
+
+Two rules that fall out:
+
+- **Age is derived at the consumer, never shipped as a producer-computed boolean.** Such a flag freezes between pushes exactly like the number it qualifies — which is how a 4-hour-old 94% once read as live.
+- **A missing `capturedAt` is "unknown", not "old".** Never dim on an absent stamp.
+
+The grace window for a just-reset gauge is 1 hour, in `adjustUsagePercent` (TS) and `formatResetTime(graceSeconds:)` (Swift). Adding a fourth rule at a fourth layer with a different constant is what PR #161 attempted; if the policy is wrong, change it where it already lives.
+
+## 6. Introducing a genuinely breaking change
+
+Two supported routes. Pick one; do not skip straight to emitting.
+
+1. **Capability negotiation.** Clients already announce themselves with `client_register` (`clientType`, `clientLabel`, `devices`). Gate the new payload on a client having asked for it, and emit nothing to everyone else. Costs one field; makes the change invisible to the fleet.
+2. **A new event type.** Unknown `type` values are dropped by every shipped client (§3), so a separate event is inherently safe where a new row in an existing collection is not.
+
+Both keep the old shape intact. Bumping `X.Y` is not a third option while `1.0.x` clients are live — nothing in the fleet re-negotiates on a version change.
+
+## 7. Constraints inherited from the auth boundary
+
+Full model in [Daemon Hub → LAN security model](daemon.md). Three invariants constrain wire design and are repeated here only because they are easy to violate from a message-shape change:
+
+- **Discovery names an endpoint; it never carries a credential.** mDNS TXT, the UDP 9121 beacon, and the unauthenticated `GET /health` advertise `authRequired` and nothing secret.
+- **Never add an unauthenticated route.** Unauthenticated LAN peers reach exactly one: minimal `GET /health`.
+- **Compare bridges by endpoint (host+port), never by full URL string** — a paired URL carries `?token=`, and a full-string compare against a tokenless discovered URL never matches.
+
+## 8. Review checklist
+
+For any diff touching `shared/src/protocol.ts` or a payload builder:
+
+- [ ] Does it add a **row kind** or an **id namespace** to an existing collection? → §6 first.
+- [ ] Does any new boolean have an explicit `false` path? → §4.
+- [ ] Does a removed or renamed field have a consumer sweep, including code that *stores* it? → §3.
+- [ ] Is a new cross-surface constant defined once with a drift gate, rather than mirrored by hand? → CLAUDE.md, "Cross-platform rules are SSOT-first".
+- [ ] Were the generated mirrors regenerated (`pnpm generate-protocol`) — remembering that a comment-only edit still drifts them?
+- [ ] Would a 1.0.x client that has never heard of this change render something wrong, or merely render nothing?
+
+The last question is the one that matters. "Renders nothing" is a safe change. "Renders something wrong" is not.


### PR DESCRIPTION
## Why

Three things this week broke, or nearly broke, rules that existed only in reviewers' heads:

- **#163** appended a new *kind of row* to `sessions_list`. It followed every written rule — optional fields only, generated mirrors regenerated, the Swift fold guard mirrored, `appstore-feature-matrix.md` updated in the same commit — and would still have consumed physical Stream Deck keys and produced untappable rows on iOS 1.0.4, plugin 1.0.2 and every flashed board. Nothing said that a new row kind is not an additive change, and `pnpm verify-version` calls all 1.0.x mutually compatible regardless.
- **#161** added a fourth freshness rule at a fourth layer with a 5-minute grace, next to the 1-hour grace that `adjustUsagePercent` and `formatResetTime` already share.
- Closing **#145** needed a probe from a second host. Nothing recorded that, and the first attempt at it misread a correct result as a live vulnerability.

An external contributor followed every rule we had written and still shipped a fleet-breaking change. That says the written rules are read — and that this one was missing.

## What this adds

**`docs/wire-compatibility.md`** — the contract for the daemon↔client surface:

- Who is downstream, and which of them we cannot update (App Store 1.0.4 ×2, Elgato 1.0.2, Ulanzi 1.0.3, flashed firmware — only the npm CLI updates on our schedule)
- What the `X.Y` version rule actually promises, and that a green `verify-version` is not evidence a wire change is safe
- Change classes: safe-additive vs. **breaking-though-it-looks-additive** (new row kind, new id namespace, reinterpreting a field, removing a field)
- The retain-on-absent merge rule (`s.x = e.x ?? s.x`) and its optional-boolean corollary — `usageStale` demonstrated both failure directions within eight days
- The three freshness axes (window ended / reading age / plan void) and why none may collapse into "hide the gauge"
- The two supported routes for a genuinely breaking change: capability negotiation via `client_register`, or a new event type
- A review checklist ending on the question that matters: *would a 1.0.x client render something wrong, or merely render nothing?*

**Auth is deliberately not restated.** `docs/daemon.md`'s LAN security model already covers it thoroughly and is already cataloged as `arch.daemon`; duplicating it would create exactly the drift the coverage gate exists to prevent. The contract links to it and carries only the three invariants that constrain message shape.

**`docs/daemon.md`** gains the one thing it was missing — how to verify the boundary:

> You cannot test this from the daemon's own machine. `isLocalConnection()` trusts loopback *and every address on this host's own interfaces*, so `curl http://<my-own-LAN-IP>:9120/health` returns the full token-bearing payload, and that is correct behaviour.

…plus the second-host procedure via ADB, and the two traps in reading the result: a `101` WebSocket upgrade is not a failure (the daemon closes `4001` before sending state), and several e-ink Android images have no `curl`.

## Verified, not asserted

Claims in the doc were checked against the code before writing them — `BridgeEventParser.parse` returning `nil` on unknown `type` (which is what makes route 2 safe), `rawSessionId`/`sameSession` still existing, `client_register`'s actual shape.

**`bridge/src/__tests__/docs-wire-contract.test.ts`** keeps the prose bound to the code: the documented public `/health` body must equal `buildPublicHealth()`, must carry no credential/inventory/state field, and `GET /health` must remain the only route an unauthorized peer reaches.

The gate was negative-tested in both drift directions:

| mutation | result |
|---|---|
| doc sample regains `pairingToken` | 2 tests fail |
| gate opens `/setup-status` to unauthenticated peers | 1 test fails |
| restored | 6/6 pass |

`docs:check` (97 files), `design-system:check` (28 documents, coverage satisfied) and the security suite (22 tests across 4 files) all pass.

## Note

`catalog.json` is +7/-0 — an earlier revision of this branch round-tripped it through a JSON writer and reformatted all 27 `navigationLabels` entries. That churn was removed; the entry is inserted textually beside `spec.esp32-client`, the other contract doc.
