### PR TITLE
Record npm 1.0.19 delivery

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -66,8 +66,10 @@
   2,909 tests). 관련 6개 파일의 targeted Vitest 251개도 통과했다.
 - `pnpm verify-version`, `pnpm docs:check`, targeted ESLint(error 0),
   `git diff --check`를 통과했다.
-- 외부 배포는 아직 하지 않았다. npm은 네 public package를 같은 1.0.19로 태그 배포해야
-  하며, wire/UI 변경이 없어 Apple/Android/Stream Deck/Ulanzi/ESP32 재배포는 필요 없다.
+- PR #184를 squash merge(`4e959b4e`)하고 `npm-v1.0.19`를 같은 커밋에 태그했다.
+  npm Release workflow `31610628648`이 네 public package를 게시하고 exact/latest 1.0.19를
+  레지스트리에서 재검증한 뒤 GitHub Release를 생성했다. wire/UI 변경이 없어
+  Apple/Android/Stream Deck/Ulanzi/ESP32는 재배포하지 않았다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 
 | Channel | Tag | Status |
 |---|---|---|
-| **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.18](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.18) |
+| **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.19](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.19) |
 | **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [1.0.5 live](https://apps.apple.com/app/id6784822497) on both platforms — macOS build 4701 and iPhone/iPad build 4702 |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.5 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-10) |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.3 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.3); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: required
 owner: Release maintainers
-reviewed: 2026-08-12
-revision: 2026-08-12
+reviewed: 2026-08-13
+revision: 2026-08-13
 source_of_truth: RELEASING.md
 validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-version]
 ---
@@ -17,7 +17,7 @@ validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-ve
 
 AgentDeck uses one `major.minor` compatibility line across every maintained surface. Two numeric `X.Y.Z` product versions are mutually compatible if and only if their first two components match. Patch values are ignored in both directions: for example, `1.0.1` and `1.0.9` are compatible regardless of which side is newer.
 
-Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI source is prepared at `1.0.19`; Stream Deck is at `1.0.5`; Android is at `1.0.8`; Apple is at `1.0.6`; ESP32 is at `1.0.4`; Ulanzi is at `1.0.3`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. **This sentence is a mirror, not a source** — take the declared values from `pnpm verify-version`, which reads each target's own manifest, and distinguish them from delivered state. As verified on 2026-08-12: Apple `1.0.5` is live on macOS and iPhone/iPad while `1.0.6` build 5101 is uploaded to App Store Connect/TestFlight but not submitted, Stream Deck `1.0.5` is published, Ulanzi `1.0.3` is under review, Android Play `1.0.6` (versionCode 8) remains in review while Android `1.0.8` is available through GitHub Releases, and npm `1.0.18` is published (`1.0.19` is not delivered until its tag workflow completes).
+Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI is at `1.0.19`; Stream Deck is at `1.0.5`; Android is at `1.0.8`; Apple is at `1.0.6`; ESP32 is at `1.0.4`; Ulanzi is at `1.0.3`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. **This sentence is a mirror, not a source** — take the declared values from `pnpm verify-version`, which reads each target's own manifest, and distinguish them from delivered state. Apple `1.0.5` is live on macOS and iPhone/iPad while `1.0.6` build 5101 is uploaded to App Store Connect/TestFlight but not submitted, Stream Deck `1.0.5` is published, Ulanzi `1.0.3` is under review, Android Play `1.0.6` (versionCode 8) remains in review while Android `1.0.8` is available through GitHub Releases (all last verified 2026-08-12), and npm `1.0.19` is published (verified 2026-08-13).
 
 Run `pnpm verify-version` before every build or release. CI rejects a `major.minor` compatibility split or a target-internal mismatch. Release CI additionally requires a channel tag's full `X.Y.Z` to equal that target's own declared version; it does not compare the tag's patch with root `VERSION`.
 


### PR DESCRIPTION
## What changed

- update the README release table to npm 1.0.19
- record the verified npm and GitHub Release delivery state in `RELEASING.md`
- replace the pre-release note in the development log with the completed workflow and channel scope

## Verification

- all four public packages report exact and latest version 1.0.19 from npm
- `@agentdeck/setup` registry README is non-empty
- GitHub Release `npm-v1.0.19` is published
- `pnpm docs:check`
- `git diff --check`
