### PR TITLE
Fix 1.0.19 AWAITING wedge and missed-Stop recovery (npm 1.0.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@ of these was not called out in the 1.0.19 notes.
 - Close a managed session's permission/option/diff prompt state when the user
   answers at the keyboard. 1.0.19 left such sessions wedged in "awaiting"
   forever (with the stale question still answerable from devices); prompts now
-  exit on the turn's tool-activity hooks (after a short grace so a parallel
-  tool cannot dismiss a freshly drawn prompt), on Stop, and on the next prompt
-  submit
+  exit on the turn's tool-activity hooks, on Stop, and on the next prompt
+  submit. Guards keep a live prompt safe: a short grace after the prompt is
+  drawn, a parallel sibling finishing never dismisses while the gated tool is
+  still pending, a straggler tool-end after Stop never reopens a finished
+  session, and the daemon hub's multiplexed state machine opts out of
+  tool-activity recovery entirely
 - Recover Claude turns whose Stop hook never arrives: a watchdog probes the
   transcript JSONL tail (never the screen) once the hook channel goes quiet
   and closes state, timeline, and the APME turn through a synthetic Stop. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ repository baseline, not a patch ceiling: any numeric `A.B.C` and `A.B.D` are
 mutually compatible. `pnpm verify-version` gates the shared `A.B` line and
 target-internal version consistency. See [RELEASING.md](RELEASING.md).
 
+## 1.0.20
+
+### CLI and daemon — npm
+
+Fixes two regressions that shipped in 1.0.19 when the terminal parser stopped
+driving lifecycle state, plus follow-up hardening. 1.0.19 removed the parser
+exit signals from the AWAITING states without adding hook-based replacements,
+and removed the Claude missed-Stop recovery without a substitute — the second
+of these was not called out in the 1.0.19 notes.
+
+- Close a managed session's permission/option/diff prompt state when the user
+  answers at the keyboard. 1.0.19 left such sessions wedged in "awaiting"
+  forever (with the stale question still answerable from devices); prompts now
+  exit on the turn's tool-activity hooks (after a short grace so a parallel
+  tool cannot dismiss a freshly drawn prompt), on Stop, and on the next prompt
+  submit
+- Recover Claude turns whose Stop hook never arrives: a watchdog probes the
+  transcript JSONL tail (never the screen) once the hook channel goes quiet
+  and closes state, timeline, and the APME turn through a synthetic Stop. A
+  genuine open prompt (`stop_reason: "tool_use"`) is never force-closed
+- Recover a dropped `UserPromptSubmit`: tool-activity hooks arriving while
+  IDLE now move the session to processing
+- Warn once, on the timeline and in the session log, when a managed Codex
+  session's terminal is active but no lifecycle hook or notify event ever
+  arrives — hooks and notify share one curl/port path, so a stale port kills
+  both silently
+- Map only an explicit `error` key on `codex_stop` to an error row. A bare
+  `message` is no longer treated as an error (it carries content on every
+  other Codex event; neither key appears in any of 311 recorded real Stop
+  payloads)
+- Read the Codex lifecycle baseline from the package's `compatibleCodex`
+  field instead of a hardcoded literal, and align the remaining
+  architecture docs (protocol, APME pipeline) with the hook-primary design
+
 ## 1.0.19
 
 ### CLI and daemon — npm

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -47,12 +47,33 @@
   서술), `docs/why-apme.md`, `docs/roadmap.md` — hook-primary 구조와 watchdog 반영.
   `states.ts`/`state-machine.ts`의 낡은 주석도 함께 수정.
 
+### 머지 전 적대적 리뷰 반영 (2차 커밋)
+
+- 병렬 sibling 오해제: PostToolUse 해제는 in-flight 카운터(PreToolUse++/
+  PostToolUse--)가 0일 때만 — gated tool 이 pending 인 동안 sibling 완료는 해제
+  증거가 아니다. same-kind 프롬프트 재감지는 grace 를 갱신한다.
+- 늦은 tool-end straggler 가 Stop 후 IDLE 을 5분 phantom PROCESSING 으로 재개방하던
+  것 차단 (IDLE 복구는 tool START 만).
+- 데몬 hub 의 전역 상태머신은 관측 세션 전부를 멀티플렉스하므로
+  `toolActivityRecovery: false` — 남의 세션 tool hook 이 OpenClaw 승인 프롬프트를
+  지우는 오염 차단. Swift 미러 테이블도 states.ts 와 동기화 (hub 드라이버는
+  tool_activity 를 방출하지 않는다는 계약 주석 포함).
+- watchdog: SessionEnd 가 `stopped` 를 영구 래치하던 것 수정 — `/clear` 가
+  SessionEnd+SessionStart 를 쌍으로 발화하므로 래치는 첫 `/clear` 이후 복구를
+  영원히 껐다. 영구 정지는 `core.onShutdown → stop()` 경로만.
+- `readTurnEndProbe` 를 fd 기반 tail 읽기(256KB)로 교체 — 60MB transcript 를 5초
+  폴마다 전체 slurp 하던 것 제거. codex_session_start 조기 유실로 인한 hook-silence
+  오경보 수정 (adapter.start 전 조기 리스너). `compatibleCodex` 필드는 shape 검증
+  (satisfiesRange 가 미지원 문법을 조용히 통과시키는 fail-open 차단).
+
 ### 검증
 
-- 상태머신 hook-탈출 10케이스는 실경로(`handleHookEvent`)로 구동. watchdog 9케이스,
+- 상태머신 hook-탈출 15케이스는 실경로(`handleHookEvent`)로 구동. watchdog 10케이스,
   transcript 프로브 6케이스, hook-silence 5케이스, codex_stop 매핑 2케이스 신규.
+  전체 182 파일 2,945 테스트 green.
 - Stop 유실이 현재도 실재함을 실측: 1.0.19 배포 후 Claude 턴 9개 중 2개 open 잔존,
   닫힌 7개 중 3개 response 없음 (apme.sqlite, Claude Code 2.1.231).
+- codex_stop payload 실측 311건 (≤0.146.0): `message`/`error` 키 등장 0회.
 
 ---
 

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,60 @@
 
 ---
 
+## 2026-08-14 — 1.0.19 AWAITING wedge·Stop 유실 회귀 수정 (npm 1.0.20 준비)
+
+### 배경
+
+- 1.0.19(#184)의 사후 적대적 리뷰에서 확정 회귀 2건을 찾았다. (1) AWAITING_* 탈출
+  신호였던 parser `spinner_start`/`idle_detected`를 Claude/Codex 어댑터에서 제거하면서
+  hook 기반 탈출 전이를 추가하지 않아, **키보드로 프롬프트에 답한 managed 세션이 영구
+  amber awaiting**에 고착됐다 (`stop`은 `PROCESSING→IDLE`뿐, Stop 핸들러가 전이 전에
+  question을 비워 "질문 없는 awaiting" 스냅샷까지 방송). (2) Claude Stop hook 유실 시
+  복구(스피너+링버퍼 3경로)가 대체 없이 삭제돼 상태 5분 고착·타임라인 미폐쇄·APME 응답
+  유실이 남았고, 1.0.19 노트에 Codex 쪽 감쇠만 명시됐다. 기존 테스트는
+  `handleParserEvent('spinner_start')`를 직접 호출해 **도달 불가 경로를 green으로
+  인증**하고 있었다.
+
+### 변경
+
+- `shared/src/states.ts`에 hook 탈출 전이 추가: `AWAITING_* → IDLE (stop)`,
+  `AWAITING_* → PROCESSING (user_prompt_submit)`, `AWAITING_*/IDLE → PROCESSING
+  (tool_activity)`. PreToolUse/PostToolUse(및 codex_tool_*)가 `tool_activity`로
+  프롬프트 해제를 증명하되, **프롬프트 표시 직후 1.5s grace** 동안은 병렬 툴 완료나
+  늦게 도착한 hook curl이 진짜 프롬프트를 지우지 못한다
+  (`AWAITING_TOOL_DISMISS_GRACE_MS`). AWAITING 이탈 시 프롬프트 필드 클리어를
+  `transition()`으로 중앙화 — 이탈 경로마다 수동 클리어가 갈라지던 것을 봉합.
+- **missed-Stop watchdog** (`bridge/src/claude-turn-watchdog.ts`): 턴이 열린 채 hook
+  채널이 10s+ 침묵하면 transcript JSONL tail을 프로브(mtime 게이트, 512KB cap)해
+  마지막 message 레코드가 `assistant`+`stop_reason:"end_turn"`이고 timestamp가 턴
+  시작 이후면 synthetic Stop을 어댑터 이벤트 파이프에 주입 — 상태머신·타임라인·APME가
+  기존 Stop 경로로 일관되게 닫힌다. `tool_use`(권한/AskUserQuestion 대기)는 절대 완료로
+  판정하지 않고, 늦은 실제 Stop은 `ccPendingCompletion`이 dedup. 판정 근거는 실제
+  transcript 실측 (완결 턴의 tail = `end_turn`, `mode` 등 non-message 레코드는 스킵).
+- **Codex hook-silence 경고** (`bridge/src/codex-hook-silence.ts`): hook과 notify가
+  같은 curl/`AGENTDECK_PORT` 경로를 타므로 공동 실패 시 무신호였던 것을, "PTY는
+  활동 중인데 codex_* 이벤트가 한 번도 안 옴"이 2분 지속되면 로그+타임라인 error
+  행으로 1회 경고. `--no-codex-hooks` 옵트아웃은 경고하지 않음
+  (`codexHooksExpected` 배선).
+- `codex_stop`의 `message`→error 매핑 제거: 실측 codex_stop 311건(≤0.146.0)에
+  `message`/`error` 키 모두 0회, `message`는 다른 이벤트에서 콘텐츠 키이므로 향후
+  등장 시 전 턴이 "Error:"로 렌더되는 쪽이 비용이 크다. 명시적 `error`만 매핑.
+- `compatibleCodex`(bridge/package.json)를 런타임이 실제로 읽도록 배선
+  (`getCompatibleCodexRange`) — 하드코딩 리터럴과의 이중화 제거.
+- 문서 잔존 드리프트 5건 정리: `docs/protocol.md` 상태머신 절(감지 표가 spinner/idle을
+  상태 소스로 서술), `docs/apme.md`, `docs/apme-pipeline.md`(삭제된 Path A/B/C를 현행
+  서술), `docs/why-apme.md`, `docs/roadmap.md` — hook-primary 구조와 watchdog 반영.
+  `states.ts`/`state-machine.ts`의 낡은 주석도 함께 수정.
+
+### 검증
+
+- 상태머신 hook-탈출 10케이스는 실경로(`handleHookEvent`)로 구동. watchdog 9케이스,
+  transcript 프로브 6케이스, hook-silence 5케이스, codex_stop 매핑 2케이스 신규.
+- Stop 유실이 현재도 실재함을 실측: 1.0.19 배포 후 Claude 턴 9개 중 2개 open 잔존,
+  닫힌 7개 중 3개 response 없음 (apme.sqlite, Claude Code 2.1.231).
+
+---
+
 ## 2026-08-13 — Apple 1.0.6 build 5101 심사 제출
 
 ### 승인 및 공개

--- a/apple/AgentDeck/Daemon/Core/StateMachine.swift
+++ b/apple/AgentDeck/Daemon/Core/StateMachine.swift
@@ -47,6 +47,22 @@ let stateTransitions: [StateTransition] = [
     .init(from: .awaitingPermission, to: .processing, trigger: "spinner_start", source: .pty),
     .init(from: .awaitingOption, to: .processing, trigger: "spinner_start", source: .pty),
     .init(from: .awaitingDiff, to: .processing, trigger: "spinner_start", source: .pty),
+    // Hook exits from AWAITING_* (mirrors states.ts): a prompt answered at the
+    // keyboard is dismissed by the lifecycle hooks that keep firing. NOTE:
+    // this daemon multiplexes every observed session into one machine, so —
+    // exactly like the Node daemon hub's `toolActivityRecovery: false` — the
+    // driver (DaemonServer) must never EMIT "tool_activity"; the entries exist
+    // to keep the table a faithful mirror of shared/src/states.ts.
+    .init(from: .awaitingPermission, to: .processing, trigger: "tool_activity", source: .hook),
+    .init(from: .awaitingOption, to: .processing, trigger: "tool_activity", source: .hook),
+    .init(from: .awaitingDiff, to: .processing, trigger: "tool_activity", source: .hook),
+    .init(from: .awaitingPermission, to: .idle, trigger: "stop", source: .hook),
+    .init(from: .awaitingOption, to: .idle, trigger: "stop", source: .hook),
+    .init(from: .awaitingDiff, to: .idle, trigger: "stop", source: .hook),
+    .init(from: .awaitingPermission, to: .processing, trigger: "user_prompt_submit", source: .hook),
+    .init(from: .awaitingOption, to: .processing, trigger: "user_prompt_submit", source: .hook),
+    .init(from: .awaitingDiff, to: .processing, trigger: "user_prompt_submit", source: .hook),
+    .init(from: .idle, to: .processing, trigger: "tool_activity", source: .hook),
     .init(from: .processing, to: .idle, trigger: "stuck_timeout", source: .internal),
     .init(from: nil, to: .disconnected, trigger: "session_end", source: .hook),
     .init(from: nil, to: .idle, trigger: "interrupt", source: .user),

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/bridge",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "engines": {
     "node": ">=22"
   },

--- a/bridge/src/__tests__/claude-transcript-reader.test.ts
+++ b/bridge/src/__tests__/claude-transcript-reader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { readLastTurn } from '../apme/claude-transcript-reader.js';
+import { readLastTurn, readTurnEndProbe } from '../apme/claude-transcript-reader.js';
 
 // Picks the most recent user→assistant turn out of a Claude Code JSONL
 // transcript. These fixtures mirror the structure Claude Code writes to
@@ -111,5 +111,81 @@ describe('readLastTurn', () => {
     const out = readLastTurn(path);
     expect(out!.userPrompt).toBe('legacy prompt');
     expect(out!.assistantText).toBe('legacy answer');
+  });
+});
+
+describe('readTurnEndProbe', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'transcript-probe-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  function writeTranscript(content: string): string {
+    const path = join(dir, 'session.jsonl');
+    writeFileSync(path, content);
+    return path;
+  }
+
+  it('reports end_turn with the record timestamp on a finished turn', () => {
+    const path = writeTranscript(fixture([
+      { type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+      { type: 'assistant', timestamp: '2026-08-13T12:00:05.000Z',
+        message: { role: 'assistant', stop_reason: 'end_turn', content: [{ type: 'text', text: 'hello' }] } },
+    ]));
+    const out = readTurnEndProbe(path);
+    expect(out).toEqual({
+      role: 'assistant',
+      stopReason: 'end_turn',
+      timestampMs: Date.parse('2026-08-13T12:00:05.000Z'),
+    });
+  });
+
+  it('skips trailing non-message records (mode markers)', () => {
+    // Claude Code appends e.g. {type:"mode"} after the assistant message.
+    const path = writeTranscript(fixture([
+      { type: 'assistant', timestamp: '2026-08-13T12:00:05.000Z',
+        message: { role: 'assistant', stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }] } },
+      { type: 'mode', mode: 'normal', sessionId: 'x' },
+    ]));
+    const out = readTurnEndProbe(path);
+    expect(out!.role).toBe('assistant');
+    expect(out!.stopReason).toBe('end_turn');
+  });
+
+  it('reports tool_use mid-turn (prompt open / tools pending)', () => {
+    const path = writeTranscript(fixture([
+      { type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'run it' }] } },
+      { type: 'assistant', timestamp: '2026-08-13T12:00:01.000Z',
+        message: { role: 'assistant', stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] } },
+    ]));
+    const out = readTurnEndProbe(path);
+    expect(out!.stopReason).toBe('tool_use');
+  });
+
+  it('reports the user role while a tool_result is the tail (assistant pending)', () => {
+    const path = writeTranscript(fixture([
+      { type: 'assistant', timestamp: '2026-08-13T12:00:01.000Z',
+        message: { role: 'assistant', stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] } },
+      { type: 'user', timestamp: '2026-08-13T12:00:02.000Z',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+    ]));
+    const out = readTurnEndProbe(path);
+    expect(out!.role).toBe('user');
+    expect(out!.stopReason).toBeNull();
+  });
+
+  it('returns null timestamp when the record has none, and null on unreadable file', () => {
+    const path = writeTranscript(fixture([
+      { type: 'assistant', message: { role: 'assistant', stop_reason: 'end_turn', content: [] } },
+    ]));
+    expect(readTurnEndProbe(path)!.timestampMs).toBeNull();
+    expect(readTurnEndProbe(join(dir, 'missing.jsonl'))).toBeNull();
+  });
+
+  it('skips a truncated final line (concurrent write)', () => {
+    const good = JSON.stringify({ type: 'assistant', timestamp: '2026-08-13T12:00:05.000Z',
+      message: { role: 'assistant', stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }] } });
+    const path = writeTranscript(good + '\n' + '{"type":"assistant","message":{"role":"assist');
+    const out = readTurnEndProbe(path);
+    expect(out!.stopReason).toBe('end_turn');
   });
 });

--- a/bridge/src/__tests__/claude-turn-watchdog.test.ts
+++ b/bridge/src/__tests__/claude-turn-watchdog.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ClaudeTurnWatchdog, WATCHDOG_QUIET_MS, WATCHDOG_POLL_MS } from '../claude-turn-watchdog.js';
+import type { TurnEndProbe } from '../apme/claude-transcript-reader.js';
+
+const TP = '/tmp/fake-transcript.jsonl';
+
+function makeWatchdog(overrides: {
+  probe?: () => TurnEndProbe | null;
+  mtimeMs?: () => number | null;
+} = {}) {
+  const fired: Array<{ transcript_path: string }> = [];
+  let mtimeCounter = 0;
+  const wd = new ClaudeTurnWatchdog({
+    onMissedStop: (d) => fired.push(d),
+    // Default mtime advances every call so the mtime gate never suppresses
+    // probes unless a test overrides it.
+    mtimeMs: overrides.mtimeMs ?? (() => ++mtimeCounter),
+    probe: overrides.probe ?? (() => null),
+  });
+  return { wd, fired };
+}
+
+function endTurnAt(ts: number): TurnEndProbe {
+  return { role: 'assistant', stopReason: 'end_turn', timestampMs: ts };
+}
+
+describe('ClaudeTurnWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('closes a turn whose Stop was dropped once the transcript shows end_turn', () => {
+    let probeResult: TurnEndProbe | null = null;
+    const { wd, fired } = makeWatchdog({ probe: () => probeResult });
+
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    // Turn finishes in the transcript shortly after, but no Stop arrives.
+    probeResult = endTurnAt(Date.now() + 3_000);
+
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
+    expect(fired).toEqual([{ transcript_path: TP }]);
+  });
+
+  it('fires at most once per turn', () => {
+    const { wd, fired } = makeWatchdog({ probe: () => endTurnAt(Date.now()) });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 10);
+    expect(fired).toHaveLength(1);
+  });
+
+  it('ignores the previous turn\'s end_turn (timestamp before turn open)', () => {
+    const stale = endTurnAt(Date.now() - 60_000);
+    const { wd, fired } = makeWatchdog({ probe: () => stale });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 3);
+    expect(fired).toHaveLength(0);
+  });
+
+  it('never closes a genuine wait (stop_reason tool_use)', () => {
+    const { wd, fired } = makeWatchdog({
+      probe: () => ({ role: 'assistant', stopReason: 'tool_use', timestampMs: Date.now() }),
+    });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 5);
+    expect(fired).toHaveLength(0);
+  });
+
+  it('does not probe while the hook channel is active', () => {
+    const probe = vi.fn(() => endTurnAt(Date.now()));
+    const { wd, fired } = makeWatchdog({ probe });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    // Tool hooks keep arriving every 4s — quieter than quietMs never elapses.
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(4_000);
+      wd.noteHookEvent('PostToolUse', { transcript_path: TP, tool_name: 'Bash' });
+    }
+    expect(probe).not.toHaveBeenCalled();
+    expect(fired).toHaveLength(0);
+  });
+
+  it('disarms when the real Stop arrives', () => {
+    const probe = vi.fn(() => endTurnAt(Date.now()));
+    const { wd, fired } = makeWatchdog({ probe });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    wd.noteHookEvent('Stop', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 5);
+    expect(fired).toHaveLength(0);
+  });
+
+  it('skips the transcript read when mtime has not advanced', () => {
+    const probe = vi.fn(() => null);
+    const { wd } = makeWatchdog({ probe, mtimeMs: () => 42 });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 6);
+    // First eligible poll reads once; identical mtime suppresses the rest.
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops permanently on SessionEnd', () => {
+    const { wd, fired } = makeWatchdog({ probe: () => endTurnAt(Date.now()) });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    wd.noteHookEvent('SessionEnd', {});
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 5);
+    expect(fired).toHaveLength(0);
+  });
+
+  it('waits without a transcript path and recovers once one is learned', () => {
+    const { wd, fired } = makeWatchdog({ probe: () => endTurnAt(Date.now()) });
+    wd.noteHookEvent('UserPromptSubmit', {});
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
+    expect(fired).toHaveLength(0);
+    // A later hook supplies the path (all Claude hook payloads carry it).
+    wd.noteHookEvent('PostToolUse', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
+    expect(fired).toEqual([{ transcript_path: TP }]);
+  });
+});

--- a/bridge/src/__tests__/claude-turn-watchdog.test.ts
+++ b/bridge/src/__tests__/claude-turn-watchdog.test.ts
@@ -100,10 +100,25 @@ describe('ClaudeTurnWatchdog', () => {
     expect(probe).toHaveBeenCalledTimes(1);
   });
 
-  it('stops permanently on SessionEnd', () => {
+  it('disarms on SessionEnd without killing later recovery (/clear fires SessionEnd mid-session)', () => {
     const { wd, fired } = makeWatchdog({ probe: () => endTurnAt(Date.now()) });
     wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
     wd.noteHookEvent('SessionEnd', {});
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 5);
+    expect(fired).toHaveLength(0);
+    // /clear pairs SessionEnd with SessionStart and the bridge session lives
+    // on — the next turn's missed Stop must still be recoverable.
+    wd.noteHookEvent('SessionStart', { transcript_path: TP });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
+    expect(fired).toHaveLength(1);
+  });
+
+  it('stop() (bridge shutdown) disarms permanently', () => {
+    const { wd, fired } = makeWatchdog({ probe: () => endTurnAt(Date.now()) });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    wd.stop();
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
     vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 5);
     expect(fired).toHaveLength(0);
   });

--- a/bridge/src/__tests__/codex-hook-silence.test.ts
+++ b/bridge/src/__tests__/codex-hook-silence.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  CodexHookSilenceWarning,
+  CODEX_HOOK_SILENCE_GRACE_MS,
+  CODEX_HOOK_SILENCE_MIN_ACTIVITY,
+} from '../codex-hook-silence.js';
+
+function activity(w: CodexHookSilenceWarning, n: number) {
+  for (let i = 0; i < n; i++) w.noteActivity();
+}
+
+describe('CodexHookSilenceWarning', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('warns once when the PTY is active but no codex_* event ever arrived', () => {
+    const onSilent = vi.fn();
+    const w = new CodexHookSilenceWarning({ onSilent });
+    activity(w, CODEX_HOOK_SILENCE_MIN_ACTIVITY + 5);
+    vi.advanceTimersByTime(CODEX_HOOK_SILENCE_GRACE_MS + 1_000);
+    expect(onSilent).toHaveBeenCalledTimes(1);
+    // Further activity must not re-warn.
+    activity(w, 50);
+    expect(onSilent).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet when any codex hook event arrives (channel proven)', () => {
+    const onSilent = vi.fn();
+    const w = new CodexHookSilenceWarning({ onSilent });
+    activity(w, 20);
+    w.noteHookEvent();
+    vi.advanceTimersByTime(CODEX_HOOK_SILENCE_GRACE_MS * 2);
+    expect(onSilent).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the terminal was barely used (session may not have started)', () => {
+    const onSilent = vi.fn();
+    const w = new CodexHookSilenceWarning({ onSilent });
+    activity(w, 2);
+    vi.advanceTimersByTime(CODEX_HOOK_SILENCE_GRACE_MS + 1_000);
+    expect(onSilent).not.toHaveBeenCalled();
+  });
+
+  it('warns late when activity only crosses the threshold after the deadline', () => {
+    const onSilent = vi.fn();
+    const w = new CodexHookSilenceWarning({ onSilent });
+    vi.advanceTimersByTime(CODEX_HOOK_SILENCE_GRACE_MS + 1_000);
+    expect(onSilent).not.toHaveBeenCalled();
+    activity(w, CODEX_HOOK_SILENCE_MIN_ACTIVITY);
+    expect(onSilent).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() disarms (session shutdown)', () => {
+    const onSilent = vi.fn();
+    const w = new CodexHookSilenceWarning({ onSilent });
+    activity(w, 20);
+    w.stop();
+    vi.advanceTimersByTime(CODEX_HOOK_SILENCE_GRACE_MS * 2);
+    expect(onSilent).not.toHaveBeenCalled();
+  });
+});

--- a/bridge/src/__tests__/codex-turn-manager.test.ts
+++ b/bridge/src/__tests__/codex-turn-manager.test.ts
@@ -106,6 +106,26 @@ describe('CodexTurnManager (hook-primary path)', () => {
     expect(types).toContain('chat_end');
   });
 
+  it('a benign `message` on codex_stop is never rendered as an error', () => {
+    // Real codex_stop payloads (311 recorded, ≤0.146.0) carry
+    // last_assistant_message and never a bare `message`/`error` key — but
+    // `message` carries CONTENT on every other Codex event, so if a future
+    // build adds it to Stop it must not turn every close row into "Error: …".
+    const { mgr, entries, setTail } = harness;
+    setTail('');
+    mgr.onHookEvent(hookEvt('codex_user_prompt_submit', { message: { content: 'q' } }));
+    mgr.onHookEvent(hookEvt('codex_stop', { message: 'turn finished normally' }));
+    expect(entries.some((e) => (e.raw ?? '').startsWith('Error:'))).toBe(false);
+  });
+
+  it('an explicit `error` on codex_stop renders the error close row', () => {
+    const { mgr, entries, setTail } = harness;
+    setTail('');
+    mgr.onHookEvent(hookEvt('codex_user_prompt_submit', { message: { content: 'q' } }));
+    mgr.onHookEvent(hookEvt('codex_stop', { error: 'sandbox denied' }));
+    expect(entries.some((e) => (e.raw ?? '').startsWith('Error: sandbox denied'))).toBe(true);
+  });
+
   it('codex_stop does not reset subsequent turn_index numbering', () => {
     const { mgr, collector, store, setTail } = harness;
     setTail('first');

--- a/bridge/src/__tests__/state-machine.test.ts
+++ b/bridge/src/__tests__/state-machine.test.ts
@@ -262,7 +262,7 @@ describe('StateMachine', () => {
       expect(sm.getState()).toBe(State.AWAITING_DIFF);
     });
 
-    it('AWAITING leaves only on a real signal — user responds via keyboard → PROCESSING', () => {
+    it('AWAITING leaves only on a real signal — parser spinner (OpenCode/OpenClaw adapters) → PROCESSING', () => {
       const sm = bootToIdle();
       sm.handleHookEvent('UserPromptSubmit', {});
       sm.handleParserEvent('permission_prompt', {
@@ -270,7 +270,9 @@ describe('StateMachine', () => {
       });
       expect(sm.getState()).toBe(State.AWAITING_PERMISSION);
 
-      // Long pause, then the user answers in the terminal — PTY spinner recovers to PROCESSING.
+      // Long pause, then the user answers in the terminal. Only adapters that
+      // still emit parser lifecycle events reach this path; Claude/Codex
+      // keyboard answers recover via the hook exits tested below.
       vi.advanceTimersByTime(20 * 60 * 1000);
       sm.handleParserEvent('spinner_start', {});
       expect(sm.getState()).toBe(State.PROCESSING);
@@ -295,6 +297,127 @@ describe('StateMachine', () => {
       const sm = bootToIdle();
       vi.advanceTimersByTime(10 * 60 * 1000);
       expect(sm.getState()).toBe(State.IDLE);
+    });
+  });
+
+  // === Hook exits from AWAITING (keyboard-answered prompts) ===
+  // Claude/Codex adapters no longer emit parser spinner/idle, so a prompt
+  // answered at the terminal keyboard must be dismissed by lifecycle hooks.
+  // These drive the REAL production route (handleHookEvent), not the parser.
+
+  describe('hook exits from awaiting states', () => {
+    function bootToAwaitingPermission() {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleTerminalUiEvent('permission_prompt', {
+        options: [{ index: 0, label: 'Yes' }, { index: 1, label: 'No' }],
+        question: 'Allow Bash?',
+      });
+      expect(sm.getState()).toBe(State.AWAITING_PERMISSION);
+      return sm;
+    }
+
+    it('Stop from AWAITING_PERMISSION → IDLE with prompt fields cleared', () => {
+      const sm = bootToAwaitingPermission();
+      sm.handleHookEvent('Stop', {});
+      expect(sm.getState()).toBe(State.IDLE);
+      const snap = sm.getSnapshot();
+      expect(snap.options).toEqual([]);
+      expect(snap.question).toBeNull();
+    });
+
+    it('Stop from AWAITING_OPTION → IDLE (keyboard-answered AskUserQuestion ends the turn)', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleTerminalUiEvent('option_prompt', {
+        options: [{ index: 0, label: 'A' }, { index: 1, label: 'B' }],
+        question: 'Pick one',
+      });
+      expect(sm.getState()).toBe(State.AWAITING_OPTION);
+      sm.handleHookEvent('Stop', {});
+      expect(sm.getState()).toBe(State.IDLE);
+      expect(sm.getSnapshot().question).toBeNull();
+    });
+
+    it('Stop from AWAITING_DIFF → IDLE', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleTerminalUiEvent('diff_prompt', {
+        options: [{ index: 0, label: 'Accept' }],
+      });
+      expect(sm.getState()).toBe(State.AWAITING_DIFF);
+      sm.handleHookEvent('Stop', {});
+      expect(sm.getState()).toBe(State.IDLE);
+    });
+
+    it('UserPromptSubmit from AWAITING_PERMISSION → PROCESSING (new turn dismisses the prompt)', () => {
+      const sm = bootToAwaitingPermission();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      expect(sm.getState()).toBe(State.PROCESSING);
+      expect(sm.getSnapshot().options).toEqual([]);
+    });
+
+    it('PostToolUse after the grace period dismisses AWAITING_PERMISSION → PROCESSING', () => {
+      const sm = bootToAwaitingPermission();
+      vi.advanceTimersByTime(5000);
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Bash' });
+      expect(sm.getState()).toBe(State.PROCESSING);
+      expect(sm.getSnapshot().question).toBeNull();
+    });
+
+    it('PreToolUse after the grace period dismisses AWAITING_OPTION → PROCESSING', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleTerminalUiEvent('option_prompt', {
+        options: [{ index: 0, label: 'A' }],
+        question: 'Pick',
+      });
+      vi.advanceTimersByTime(5000);
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Read', tool_input: { file_path: '/tmp/x' } });
+      expect(sm.getState()).toBe(State.PROCESSING);
+      expect(sm.getSnapshot().currentTool).toBe('Read');
+      expect(sm.getSnapshot().question).toBeNull();
+    });
+
+    it('tool activity within the grace period keeps a fresh prompt awaiting', () => {
+      const sm = bootToAwaitingPermission();
+      // A parallel tool finishing (or a late hook curl) right after the prompt
+      // was drawn must not hide the answerable prompt from devices.
+      vi.advanceTimersByTime(500);
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Read' });
+      expect(sm.getState()).toBe(State.AWAITING_PERMISSION);
+      expect(sm.getSnapshot().question).toBe('Allow Bash?');
+    });
+
+    it('PreToolUse from IDLE recovers a dropped user_prompt_submit → PROCESSING', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { command: 'ls' } });
+      expect(sm.getState()).toBe(State.PROCESSING);
+    });
+
+    it('codex_turn_complete from AWAITING_OPTION → IDLE (notify closes a keyboard-answered prompt)', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('codex_user_prompt_submit', {});
+      sm.handleTerminalUiEvent('option_prompt', {
+        options: [{ index: 0, label: 'A' }],
+        question: 'Pick',
+      });
+      expect(sm.getState()).toBe(State.AWAITING_OPTION);
+      sm.handleHookEvent('codex_turn_complete', {});
+      expect(sm.getState()).toBe(State.IDLE);
+      expect(sm.getSnapshot().question).toBeNull();
+    });
+
+    it('codex_tool_end after the grace period dismisses AWAITING_PERMISSION → PROCESSING', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('codex_user_prompt_submit', {});
+      sm.handleTerminalUiEvent('permission_prompt', {
+        options: [{ index: 0, label: 'Yes' }],
+        question: 'Run command?',
+      });
+      vi.advanceTimersByTime(5000);
+      sm.handleHookEvent('codex_tool_end', { tool_name: 'shell' });
+      expect(sm.getState()).toBe(State.PROCESSING);
     });
   });
 

--- a/bridge/src/__tests__/state-machine.test.ts
+++ b/bridge/src/__tests__/state-machine.test.ts
@@ -419,6 +419,79 @@ describe('StateMachine', () => {
       sm.handleHookEvent('codex_tool_end', { tool_name: 'shell' });
       expect(sm.getState()).toBe(State.PROCESSING);
     });
+
+    it('a parallel sibling finishing does not dismiss the prompt while the gated tool is in flight', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      // Batch dispatch: both PreToolUse fire before the prompt is drawn.
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { command: 'make build' } });
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Read', tool_input: { file_path: '/x' } });
+      sm.handleTerminalUiEvent('permission_prompt', {
+        options: [{ index: 0, label: 'Yes' }],
+        question: 'Allow Bash?',
+      });
+      // Sibling Read finishes long after the grace — Bash is still gated.
+      vi.advanceTimersByTime(8000);
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Read' });
+      expect(sm.getState()).toBe(State.AWAITING_PERMISSION);
+      expect(sm.getSnapshot().question).toBe('Allow Bash?');
+      // The gated tool completing (user answered at the keyboard) dismisses.
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Bash' });
+      expect(sm.getState()).toBe(State.PROCESSING);
+    });
+
+    it('a straggler PostToolUse landing after Stop does not reopen a finished session', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { command: 'ls' } });
+      sm.handleHookEvent('Stop', {});
+      expect(sm.getState()).toBe(State.IDLE);
+      // Fire-and-forget hook curls are unordered; the turn's last tool-end
+      // can arrive after Stop. It must not reopen PROCESSING (nothing would
+      // ever re-close it — the watchdog only arms on UserPromptSubmit).
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Bash' });
+      expect(sm.getState()).toBe(State.IDLE);
+    });
+
+    it('a re-detected prompt refreshes the dismissal grace', () => {
+      const sm = bootToIdle();
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleHookEvent('PreToolUse', { tool_name: 'AskUserQuestion', tool_input: {} });
+      sm.handleTerminalUiEvent('option_prompt', {
+        options: [{ index: 0, label: 'A' }],
+        question: 'First?',
+      });
+      vi.advanceTimersByTime(10_000);
+      // A NEW same-kind prompt re-parses while still AWAITING_OPTION — it must
+      // not inherit the first prompt's expired grace.
+      sm.handleTerminalUiEvent('option_prompt', {
+        options: [{ index: 0, label: 'B' }],
+        question: 'Second?',
+      });
+      sm.handleHookEvent('PostToolUse', { tool_name: 'AskUserQuestion' });
+      expect(sm.getState()).toBe(State.AWAITING_OPTION);
+      expect(sm.getSnapshot().question).toBe('Second?');
+    });
+
+    it('the daemon hub machine never dismisses prompts or reopens IDLE on tool activity', () => {
+      const tracker = new UsageTracker();
+      const sm = new StateMachine(tracker, { toolActivityRecovery: false });
+      sm.handleHookEvent('SessionStart', {});
+      // An unrelated observed session's tool hook must not reopen IDLE…
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { command: 'ls' } });
+      expect(sm.getState()).toBe(State.IDLE);
+      // …nor dismiss a held prompt (e.g. an OpenClaw approval).
+      sm.handleHookEvent('UserPromptSubmit', {});
+      sm.handleParserEvent('permission_prompt', {
+        options: [{ index: 0, label: 'Allow' }],
+        question: 'OpenClaw approval',
+      });
+      vi.advanceTimersByTime(60_000);
+      sm.handleHookEvent('PostToolUse', { tool_name: 'Bash' });
+      sm.handleHookEvent('PreToolUse', { tool_name: 'Read', tool_input: { file_path: '/y' } });
+      expect(sm.getState()).toBe(State.AWAITING_PERMISSION);
+      expect(sm.getSnapshot().question).toBe('OpenClaw approval');
+    });
   });
 
   // === Parser Events ===

--- a/bridge/src/apme/adapters/codex-turn-manager.ts
+++ b/bridge/src/apme/adapters/codex-turn-manager.ts
@@ -227,7 +227,12 @@ function outcomeFromHook(data: Record<string, unknown>): CodexTurnOutcome {
     const text = nonEmptyString(data[key]);
     if (text) return { text };
   }
-  const error = nonEmptyString(data.error) ?? nonEmptyString(data.message);
+  // Only an explicit `error` key maps to an error. `message` must NOT: on
+  // every other Codex event it carries content, and across 311 recorded real
+  // codex_stop payloads (≤0.146.0) neither key ever appeared — so a future
+  // benign `message` rendering every turn as "Error: …" is the costly
+  // misread, while a hypothetical message-shaped error only loses a label.
+  const error = nonEmptyString(data.error);
   return { text: '', ...(error ? { error } : {}) };
 }
 

--- a/bridge/src/apme/claude-transcript-reader.ts
+++ b/bridge/src/apme/claude-transcript-reader.ts
@@ -136,6 +136,62 @@ export function readModelFromTranscript(transcriptPath: string): string | null {
   return null;
 }
 
+export interface TurnEndProbe {
+  /** Role of the last message-bearing JSONL record. */
+  role: string;
+  /** `message.stop_reason` on that record (null when absent). */
+  stopReason: string | null;
+  /** Record `timestamp` in epoch ms (null when absent/unparseable). */
+  timestampMs: number | null;
+}
+
+/**
+ * Probe whether the transcript's most recent turn has finished. A completed
+ * turn's last message-bearing record is `role: "assistant"` with
+ * `stop_reason: "end_turn"`; mid-turn tails end in `stop_reason: "tool_use"`
+ * or a `user` tool_result record. Non-message records (`type: "mode"` etc.)
+ * can trail the assistant message, so the walk skips records without a
+ * `message.role`. Never throws; returns null when unreadable/empty.
+ *
+ * Used by the turn watchdog to close a turn whose Stop hook was dropped —
+ * the caller must additionally check `timestampMs` against its own turn-open
+ * time, because at turn start the tail still shows the PREVIOUS turn's
+ * `end_turn`.
+ */
+export function readTurnEndProbe(transcriptPath: string): TurnEndProbe | null {
+  let raw: string;
+  try {
+    raw = readFileSync(transcriptPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  const MAX_TAIL = 512 * 1024;
+  const tail = raw.length > MAX_TAIL ? raw.slice(raw.length - MAX_TAIL) : raw;
+  const lines = tail.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    let rec: {
+      timestamp?: string;
+      message?: { role?: string; stop_reason?: string | null };
+    };
+    try {
+      rec = JSON.parse(line);
+    } catch {
+      continue; // skip malformed (possibly truncated) line
+    }
+    const role = rec?.message?.role;
+    if (!role) continue;
+    const ts = rec.timestamp ? Date.parse(rec.timestamp) : NaN;
+    return {
+      role,
+      stopReason: rec.message?.stop_reason ?? null,
+      timestampMs: Number.isFinite(ts) ? ts : null,
+    };
+  }
+  return null;
+}
+
 function contentToString(content: unknown): string {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';

--- a/bridge/src/apme/claude-transcript-reader.ts
+++ b/bridge/src/apme/claude-transcript-reader.ts
@@ -16,7 +16,7 @@
  * `tool_only`) is the fallback.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, openSync, readSync, fstatSync, closeSync } from 'fs';
 import { debug } from '../logger.js';
 
 export interface LastTurnExcerpt {
@@ -159,14 +159,15 @@ export interface TurnEndProbe {
  * `end_turn`.
  */
 export function readTurnEndProbe(transcriptPath: string): TurnEndProbe | null {
-  let raw: string;
-  try {
-    raw = readFileSync(transcriptPath, 'utf-8');
-  } catch {
-    return null;
-  }
-  const MAX_TAIL = 512 * 1024;
-  const tail = raw.length > MAX_TAIL ? raw.slice(raw.length - MAX_TAIL) : raw;
+  // Unlike the per-Stop readers above, this runs on a POLL (the missed-Stop
+  // watchdog, every few seconds while a turn is quiet), and real transcripts
+  // reach tens of MB — so read only the trailing bytes through a file
+  // descriptor instead of slurping the whole file. Reading from a byte offset
+  // can start mid-line; the backward walk already skips lines that fail to
+  // parse, which covers the truncated head line.
+  const PROBE_TAIL_BYTES = 256 * 1024;
+  const tail = readTailString(transcriptPath, PROBE_TAIL_BYTES);
+  if (tail == null) return null;
   const lines = tail.split('\n');
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
@@ -190,6 +191,27 @@ export function readTurnEndProbe(transcriptPath: string): TurnEndProbe | null {
     };
   }
   return null;
+}
+
+/** Read at most `maxBytes` from the end of a file without loading the rest.
+ *  Returns null when the file is unreadable. */
+function readTailString(path: string, maxBytes: number): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, 'r');
+    const size = fstatSync(fd).size;
+    const len = Math.min(size, maxBytes);
+    if (len === 0) return '';
+    const buf = Buffer.allocUnsafe(len);
+    readSync(fd, buf, 0, len, size - len);
+    return buf.toString('utf-8');
+  } catch {
+    return null;
+  } finally {
+    if (fd != null) {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
+  }
 }
 
 function contentToString(content: unknown): string {

--- a/bridge/src/bridge-core.ts
+++ b/bridge/src/bridge-core.ts
@@ -206,7 +206,12 @@ export class BridgeCore {
 
     // Core components
     this.usageTracker = new UsageTracker();
-    this.stateMachine = new StateMachine(this.usageTracker);
+    // The daemon hub's machine multiplexes EVERY observed session's hooks, so
+    // one session's tool activity must never dismiss another's AWAITING
+    // prompt (e.g. a held OpenClaw approval) or reopen IDLE.
+    this.stateMachine = new StateMachine(this.usageTracker, {
+      toolActivityRecovery: !this.isDaemon,
+    });
     this.ollamaProbe = new OllamaProbe();
     this.displayMonitor = new DisplayMonitor();
     this.bridgeTimeline = new BridgeTimelineStore();

--- a/bridge/src/claude-turn-watchdog.ts
+++ b/bridge/src/claude-turn-watchdog.ts
@@ -1,0 +1,154 @@
+/**
+ * Claude turn watchdog — closes a managed turn whose Stop hook was dropped.
+ *
+ * The Stop hook is the sole authority that closes a Claude turn (state → IDLE,
+ * timeline chat_response/chat_end, APME turn response), but its delivery is
+ * not guaranteed: the hook curl is fire-and-forget with a tight budget, and
+ * historically it has been observed to drop at a meaningful rate. Since the
+ * PTY spinner/ring-buffer fallbacks were removed (1.0.19), a dropped Stop left
+ * the session stuck PROCESSING for STUCK_TIMEOUT_MS and the timeline/APME turn
+ * open until the next prompt.
+ *
+ * Doctrine: recovery reads the durable log, not the screen. While a turn is
+ * open and the hook channel has been quiet, the watchdog probes the
+ * transcript JSONL tail (the same authority the Stop branch itself reads).
+ * A tail whose last message-bearing record is `assistant` + `end_turn`,
+ * stamped after this turn opened, proves the turn finished — the watchdog
+ * then injects a synthetic Stop through the normal adapter event pipe so
+ * state machine, timeline, and APME all close through their existing paths.
+ *
+ * False-positive guards:
+ *  - `stop_reason: "tool_use"` (permission prompt / AskUserQuestion open,
+ *    tools running) never matches, so a genuine wait is never force-closed.
+ *  - The end_turn record must be newer than this turn's open time, so the
+ *    previous turn's end_turn cannot close a freshly opened turn.
+ *  - A transcript mtime older than the last probe skips the read entirely,
+ *    so an idle prompt does not re-read 512 KB every poll.
+ *  - If a real Stop (or SessionEnd) arrives first, the watchdog disarms; a
+ *    synthetic Stop after a real one is deduped downstream
+ *    (ccPendingCompletion / transition-table guards).
+ */
+
+import { statSync } from 'fs';
+import { readTurnEndProbe, type TurnEndProbe } from './apme/claude-transcript-reader.js';
+import { debug } from './logger.js';
+
+/** Hook-channel silence required before the transcript is consulted. */
+export const WATCHDOG_QUIET_MS = 10_000;
+/** Poll cadence while a turn is open. */
+export const WATCHDOG_POLL_MS = 5_000;
+/** Clock slack when comparing a record timestamp to the turn-open time. */
+const TURN_OPEN_SLACK_MS = 2_000;
+
+export interface ClaudeTurnWatchdogOptions {
+  /** Called when the transcript proves the open turn ended without a Stop. */
+  onMissedStop: (data: { transcript_path: string }) => void;
+  quietMs?: number;
+  pollMs?: number;
+  /** Injectable for tests. */
+  now?: () => number;
+  probe?: (transcriptPath: string) => TurnEndProbe | null;
+  mtimeMs?: (transcriptPath: string) => number | null;
+}
+
+export class ClaudeTurnWatchdog {
+  private readonly onMissedStop: (data: { transcript_path: string }) => void;
+  private readonly quietMs: number;
+  private readonly pollMs: number;
+  private readonly now: () => number;
+  private readonly probe: (transcriptPath: string) => TurnEndProbe | null;
+  private readonly mtimeMs: (transcriptPath: string) => number | null;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private turnOpenedAt: number | null = null;
+  private lastHookAt = 0;
+  private transcriptPath = '';
+  private lastProbedMtimeMs = -1;
+  private stopped = false;
+
+  constructor(opts: ClaudeTurnWatchdogOptions) {
+    this.onMissedStop = opts.onMissedStop;
+    this.quietMs = opts.quietMs ?? WATCHDOG_QUIET_MS;
+    this.pollMs = opts.pollMs ?? WATCHDOG_POLL_MS;
+    this.now = opts.now ?? Date.now;
+    this.probe = opts.probe ?? readTurnEndProbe;
+    this.mtimeMs = opts.mtimeMs ?? defaultMtimeMs;
+  }
+
+  /** Feed every hook-sourced adapter event through here (synthetic ones too —
+   *  the synthetic Stop closes the turn like a real one). */
+  noteHookEvent(eventName: string, data: Record<string, unknown> | undefined): void {
+    if (this.stopped) return;
+    this.lastHookAt = this.now();
+    const tp = data?.transcript_path;
+    if (typeof tp === 'string' && tp) this.transcriptPath = tp;
+
+    switch (eventName) {
+      case 'UserPromptSubmit':
+        this.turnOpenedAt = this.now();
+        this.lastProbedMtimeMs = -1;
+        this.arm();
+        break;
+      case 'Stop':
+        this.turnOpenedAt = null;
+        this.disarm();
+        break;
+      case 'SessionEnd':
+        this.stop();
+        break;
+      default:
+        break;
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.turnOpenedAt = null;
+    this.disarm();
+  }
+
+  private arm(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.check(), this.pollMs);
+    // Never hold the process open for the watchdog alone.
+    this.timer.unref?.();
+  }
+
+  private disarm(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private check(): void {
+    if (this.stopped || this.turnOpenedAt == null || !this.transcriptPath) return;
+    if (this.now() - this.lastHookAt < this.quietMs) return;
+
+    // Cheap gate: nothing appended since the last probe means the verdict
+    // cannot have changed (a genuinely-awaiting prompt writes nothing).
+    const mtime = this.mtimeMs(this.transcriptPath);
+    if (mtime != null && mtime === this.lastProbedMtimeMs) return;
+    if (mtime != null) this.lastProbedMtimeMs = mtime;
+
+    const probe = this.probe(this.transcriptPath);
+    if (!probe) return;
+    if (probe.role !== 'assistant' || probe.stopReason !== 'end_turn') return;
+    if (probe.timestampMs == null) return;
+    if (probe.timestampMs < this.turnOpenedAt - TURN_OPEN_SLACK_MS) return;
+
+    debug('watchdog', `missed Stop recovered from transcript (end_turn @ ${probe.timestampMs})`);
+    const transcriptPath = this.transcriptPath;
+    this.turnOpenedAt = null;
+    this.disarm();
+    this.onMissedStop({ transcript_path: transcriptPath });
+  }
+}
+
+function defaultMtimeMs(transcriptPath: string): number | null {
+  try {
+    return statSync(transcriptPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}

--- a/bridge/src/claude-turn-watchdog.ts
+++ b/bridge/src/claude-turn-watchdog.ts
@@ -94,7 +94,13 @@ export class ClaudeTurnWatchdog {
         this.disarm();
         break;
       case 'SessionEnd':
-        this.stop();
+        // Disarm, but do NOT latch `stopped`: Claude Code fires SessionEnd on
+        // /clear too (paired with a SessionStart), and the bridge session
+        // lives on. A permanent latch here would disable missed-Stop recovery
+        // for the rest of the session after the first /clear. Permanent stop
+        // is the bridge shutdown path (core.onShutdown → stop()).
+        this.turnOpenedAt = null;
+        this.disarm();
         break;
       default:
         break;

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -521,6 +521,7 @@ program
       daemonHost: opts.daemonHost,
       daemonToken: opts.daemonToken,
       weight: opts.weight,
+      codexHooksExpected: opts.codexHooks !== false,
       modules: opts.local ? { mdns: false, adb: false, serial: false, pixoo: false, timebox: false } : {
         mdns: false,   // daemon-only
         adb: opts.adb !== false ? 'auto' : false,

--- a/bridge/src/codex-hook-silence.ts
+++ b/bridge/src/codex-hook-silence.ts
@@ -1,0 +1,89 @@
+/**
+ * Codex hook-silence warning — detects the "lifecycle channel dead on
+ * arrival" failure with zero signal today.
+ *
+ * Codex lifecycle hooks AND the notify turn-complete fallback ride the same
+ * mechanism (a curl POST to this bridge's AGENTDECK_PORT, installed in
+ * ~/.codex/config.toml), so they share failure modes: a stale port in the
+ * config, a hooks.json/inline-[hooks] layer conflict, or a broken curl kills
+ * both at once. Since the PTY fallback state machine was removed (1.0.19), a
+ * managed Codex session in that condition is lifecycle-blind silently —
+ * no state changes, no timeline, no APME — while the terminal itself works.
+ *
+ * Detection is deliberately modest: if the PTY has produced real activity but
+ * NO codex_* hook or notify event has EVER arrived by the grace deadline, the
+ * install is broken — warn once (log + timeline row). The first hook event
+ * proves the channel and disarms permanently; mid-session hook death is out
+ * of scope (it cannot be distinguished from an idle session without parsing
+ * the screen, which lifecycle correctness must not do).
+ *
+ * `--no-codex-hooks` opted out of lifecycle monitoring explicitly; callers
+ * must not arm this warning in that case (cli.ts already prints the
+ * degradation notice at startup).
+ */
+
+import { debug } from './logger.js';
+
+/** How long after session start to expect the first codex_* event.
+ *  codex_session_start fires immediately on launch, so one grace period
+ *  covers slow starts without a turn ever being submitted. */
+export const CODEX_HOOK_SILENCE_GRACE_MS = 120_000;
+/** Minimum PTY activity events before silence is judged — a session that
+ *  never rendered anything may simply not have started. */
+export const CODEX_HOOK_SILENCE_MIN_ACTIVITY = 10;
+
+export interface CodexHookSilenceOptions {
+  onSilent: () => void;
+  graceMs?: number;
+  minActivity?: number;
+}
+
+export class CodexHookSilenceWarning {
+  private readonly onSilent: () => void;
+  private readonly minActivity: number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private activityCount = 0;
+  private hookSeen = false;
+  private deadlinePassed = false;
+
+  constructor(opts: CodexHookSilenceOptions) {
+    this.onSilent = opts.onSilent;
+    this.minActivity = opts.minActivity ?? CODEX_HOOK_SILENCE_MIN_ACTIVITY;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.deadlinePassed = true;
+      this.judge();
+    }, opts.graceMs ?? CODEX_HOOK_SILENCE_GRACE_MS);
+    this.timer.unref?.();
+  }
+
+  /** Any codex_* hook or notify event proves the channel; disarms forever. */
+  noteHookEvent(): void {
+    if (this.hookSeen) return;
+    this.hookSeen = true;
+    this.stop();
+  }
+
+  /** PTY activity — the terminal is being used. If the grace deadline already
+   *  passed with too little activity, late activity re-judges once. */
+  noteActivity(): void {
+    this.activityCount++;
+    if (this.deadlinePassed) this.judge();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.deadlinePassed = false;
+  }
+
+  private judge(): void {
+    if (this.hookSeen) return;
+    if (this.activityCount < this.minActivity) return;
+    this.deadlinePassed = false; // fire once
+    debug('codex', `hook silence: ${this.activityCount} PTY activity events, zero codex_* hooks`);
+    this.onSilent();
+  }
+}

--- a/bridge/src/daemon.ts
+++ b/bridge/src/daemon.ts
@@ -22,7 +22,7 @@ const program = new Command();
 program
   .name('agentdeck')
   .description('AgentDeck daemon (legacy entry point — use `agentdeck daemon` instead)')
-  .version('1.0.19');
+  .version('1.0.20');
 
 program
   .command('start', { isDefault: true })

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -251,6 +251,15 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     adapter.seedProjectName(projectName);
   }
 
+  // Codex fires codex_session_start within seconds of the PTY spawning —
+  // before the main wiring below registers its listeners — so capture the
+  // fact early or the hook-silence warning would misread a healthy install
+  // as lifecycle-blind.
+  let codexHookSeenEarly = false;
+  adapter.on('event', (evt: AdapterEvent) => {
+    if (evt.source === 'hook' && evt.event.startsWith('codex_')) codexHookSeenEarly = true;
+  });
+
   // ===== Start adapter (creates HTTP server, spawns process) =====
   try {
     await adapter.start({ port, command: opts.command, gatewayUrl: opts.gatewayUrl });
@@ -577,6 +586,7 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     adapter.on('event', (evt: AdapterEvent) => {
       if (evt.source === 'hook') turnWatchdog.noteHookEvent(evt.event, evt.data ?? {});
     });
+    core.onShutdown(() => turnWatchdog.stop());
   }
   // Codex lifecycle-channel dead-on-arrival warning: hooks and notify share
   // the same curl/port mechanism, so when both are silent the session is
@@ -596,6 +606,7 @@ export async function startSession(opts: SessionOptions): Promise<void> {
         });
       },
     });
+    if (codexHookSeenEarly) hookSilence.noteHookEvent();
     adapter.on('event', (evt: AdapterEvent) => {
       if (evt.source === 'hook' && evt.event.startsWith('codex_')) hookSilence.noteHookEvent();
       else if (evt.source === 'activity') hookSilence.noteActivity();

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -24,6 +24,8 @@ import { enableDebugLog, log, debug, setPtyMode } from './logger.js';
 import { EventJournal } from './event-journal.js';
 import { PtyRingBuffer } from './pty-ringbuffer.js';
 import { isSubagentOnlyHook, SubagentTimelineTracker } from './subagent-timeline.js';
+import { ClaudeTurnWatchdog } from './claude-turn-watchdog.js';
+import { CodexHookSilenceWarning } from './codex-hook-silence.js';
 import { createDiagDump } from './diag-analyzer.js';
 import { createAdapter, ClaudeCodeAdapter, CodexCliAdapter, OpenCodeAdapter } from './adapters/index.js';
 import { MonitorAdapter } from './adapters/monitor.js';
@@ -163,6 +165,9 @@ export interface SessionOptions {
   /** Explicit deck/tab sort override (default 0); lower sorts first. Lets a user
    *  pin terminal-tab order onto the Stream Deck via `--weight <n>`. */
   weight?: number;
+  /** False only under `--no-codex-hooks`: the user opted out of lifecycle
+   *  monitoring, so the hook-silence warning must not arm. */
+  codexHooksExpected?: boolean;
 }
 
 // ===== startSession =====
@@ -182,9 +187,10 @@ export async function startSession(opts: SessionOptions): Promise<void> {
     for (const w of deps.warnings) log(`WARNING: ${w}`);
 
     if (agentType === 'codex-cli' && deps.agentVersion) {
-      const { satisfiesRange } = await import('./version-check.js');
-      if (!satisfiesRange(deps.agentVersion, '>=0.141.0')) {
-        log(`WARNING: Codex ${deps.agentVersion} predates the lifecycle-hook baseline (>=0.141.0). ` +
+      const { satisfiesRange, getCompatibleCodexRange } = await import('./version-check.js');
+      const codexRange = getCompatibleCodexRange() ?? '>=0.141.0';
+      if (!satisfiesRange(deps.agentVersion, codexRange)) {
+        log(`WARNING: Codex ${deps.agentVersion} predates the lifecycle-hook baseline (${codexRange}). ` +
           'The terminal can start, but AgentDeck lifecycle monitoring requires a newer Codex CLI.');
       }
     }
@@ -554,6 +560,47 @@ export async function startSession(opts: SessionOptions): Promise<void> {
   // Claude Code hook events → timeline entries
   if (agentType === 'claude-code') {
     wireClaudeCodeTimeline(adapter, core);
+    // Missed-Stop recovery: when the hook channel goes quiet mid-turn, the
+    // transcript JSONL tail (the Stop branch's own authority) is probed and a
+    // proven-finished turn is closed by injecting a synthetic Stop through
+    // this same event pipe — state machine, timeline, and APME all close via
+    // their existing Stop paths, and a late real Stop dedups downstream.
+    const turnWatchdog = new ClaudeTurnWatchdog({
+      onMissedStop: ({ transcript_path }) => {
+        adapter.emit('event', {
+          source: 'hook',
+          event: 'Stop',
+          data: { transcript_path, synthetic_stop: true },
+        } as AdapterEvent);
+      },
+    });
+    adapter.on('event', (evt: AdapterEvent) => {
+      if (evt.source === 'hook') turnWatchdog.noteHookEvent(evt.event, evt.data ?? {});
+    });
+  }
+  // Codex lifecycle-channel dead-on-arrival warning: hooks and notify share
+  // the same curl/port mechanism, so when both are silent the session is
+  // lifecycle-blind with no signal at all. Warn once if the PTY is clearly in
+  // use but no codex_* event ever arrived. `--no-codex-hooks` opted out.
+  if (agentType === 'codex-cli' && opts.codexHooksExpected !== false) {
+    const hookSilence = new CodexHookSilenceWarning({
+      onSilent: () => {
+        log('WARNING: no Codex lifecycle event has reached this bridge — state/timeline/eval are blind for this session.');
+        log('Repair: rerun `agentdeck codex` (reinstalls hooks) or `agentdeck daemon install`, and check [hooks]/notify in ~/.codex/config.toml.');
+        core.bridgeTimeline.addEntry({
+          ts: Date.now(),
+          type: 'error',
+          raw: 'Codex lifecycle hooks silent — session is lifecycle-blind',
+          detail: 'The terminal is active but no codex_* hook or notify event arrived. Hooks and the notify fallback share one curl/port path in ~/.codex/config.toml, so a stale port or config-layer conflict kills both. Rerun `agentdeck codex` or `agentdeck daemon install` to repair.',
+          agentType: 'codex-cli',
+        });
+      },
+    });
+    adapter.on('event', (evt: AdapterEvent) => {
+      if (evt.source === 'hook' && evt.event.startsWith('codex_')) hookSilence.noteHookEvent();
+      else if (evt.source === 'activity') hookSilence.noteActivity();
+    });
+    core.onShutdown(() => hookSilence.stop());
   }
   // APME wiring for non-Claude-Code agents (OpenCode, Codex, OpenClaw)
   if (apme && agentType !== 'claude-code' && agentType !== 'monitor') {

--- a/bridge/src/state-machine.ts
+++ b/bridge/src/state-machine.ts
@@ -88,10 +88,21 @@ export class StateMachine extends EventEmitter {
   private usageTracker: UsageTracker;
   private stuckTimer: ReturnType<typeof setTimeout> | null = null;
   private awaitingEnteredAt = 0;
+  /** Best-effort count of tool calls started but not yet finished this turn
+   *  (PreToolUse++ / PostToolUse--). Used to tell "the gated tool ran" from
+   *  "a parallel sibling finished while the prompt is still open". Reset at
+   *  turn boundaries so a dropped hook cannot skew it forever. */
+  private inFlightTools = 0;
+  /** False for the daemon hub's global machine: it multiplexes EVERY observed
+   *  session's hooks, so an unrelated session's tool activity must never
+   *  dismiss an AWAITING prompt (e.g. a held OpenClaw approval) or reopen
+   *  IDLE. Session bridges own exactly one agent and keep this true. */
+  private readonly toolActivityRecovery: boolean;
 
-  constructor(usageTracker: UsageTracker) {
+  constructor(usageTracker: UsageTracker, opts?: { toolActivityRecovery?: boolean }) {
     super();
     this.usageTracker = usageTracker;
+    this.toolActivityRecovery = opts?.toolActivityRecovery ?? true;
   }
 
   handleHookEvent(eventName: string, data: Record<string, unknown>): void {
@@ -105,6 +116,7 @@ export class StateMachine extends EventEmitter {
       case 'UserPromptSubmit':
         this.suggestedPrompt = null;
         this.lastValidSuggestedPrompt = null;
+        this.inFlightTools = 0;
         this.transition(State.PROCESSING, 'user_prompt_submit', 'hook');
         break;
 
@@ -114,10 +126,11 @@ export class StateMachine extends EventEmitter {
         this.currentTool = toolName;
         this.toolInput = formatToolInput(toolName, toolInputData);
         this.toolProgress = `Using ${toolName}`;
+        this.inFlightTools++;
         // Tool activity proves the turn is running: recovers AWAITING_* after a
         // keyboard-answered prompt and IDLE after a dropped user_prompt_submit.
         // A no-op from PROCESSING (transition table rejects it).
-        this.recoverProcessingFromToolActivity();
+        this.recoverProcessingFromToolActivity('start');
         this.emitSnapshot();
         break;
       }
@@ -127,7 +140,8 @@ export class StateMachine extends EventEmitter {
         this.currentTool = null;
         this.toolInput = null;
         this.toolProgress = null;
-        this.recoverProcessingFromToolActivity();
+        this.inFlightTools = Math.max(0, this.inFlightTools - 1);
+        this.recoverProcessingFromToolActivity('end');
         this.emitSnapshot();
         break;
       }
@@ -140,6 +154,7 @@ export class StateMachine extends EventEmitter {
         this.question = null;
         this.navigable = false;
         this.cursorIndex = 0;
+        this.inFlightTools = 0;
         this.transition(State.IDLE, 'stop', 'hook');
         break;
 
@@ -176,6 +191,7 @@ export class StateMachine extends EventEmitter {
       case 'codex_user_prompt_submit':
         this.suggestedPrompt = null;
         this.lastValidSuggestedPrompt = null;
+        this.inFlightTools = 0;
         this.transition(State.PROCESSING, 'user_prompt_submit', 'hook');
         break;
 
@@ -185,8 +201,9 @@ export class StateMachine extends EventEmitter {
         this.currentTool = toolName;
         this.toolInput = formatToolInput(toolName, toolInputData);
         this.toolProgress = toolName ? `Using ${toolName}` : null;
+        this.inFlightTools++;
         // Same recovery contract as Claude PreToolUse (see above).
-        this.recoverProcessingFromToolActivity();
+        this.recoverProcessingFromToolActivity('start');
         this.emitSnapshot();
         break;
       }
@@ -196,7 +213,8 @@ export class StateMachine extends EventEmitter {
         this.currentTool = null;
         this.toolInput = null;
         this.toolProgress = null;
-        this.recoverProcessingFromToolActivity();
+        this.inFlightTools = Math.max(0, this.inFlightTools - 1);
+        this.recoverProcessingFromToolActivity('end');
         this.emitSnapshot();
         break;
       }
@@ -209,6 +227,7 @@ export class StateMachine extends EventEmitter {
         this.question = null;
         this.navigable = false;
         this.cursorIndex = 0;
+        this.inFlightTools = 0;
         this.transition(State.IDLE, 'stop', 'hook');
         break;
 
@@ -223,6 +242,7 @@ export class StateMachine extends EventEmitter {
         this.question = null;
         this.navigable = false;
         this.cursorIndex = 0;
+        this.inFlightTools = 0;
         this.transition(State.IDLE, 'stop', 'hook');
         break;
 
@@ -239,7 +259,15 @@ export class StateMachine extends EventEmitter {
         this.question = (data?.question as string) || null;
         this.navigable = (data?.navigable as boolean) ?? false;
         this.cursorIndex = (data?.cursorIndex as number) ?? 0;
-        this.transition(State.AWAITING_PERMISSION, 'permission_prompt', 'pty');
+        if (this.state === State.AWAITING_PERMISSION) {
+          // Re-detected (redraw or a NEW same-kind prompt): refresh the
+          // dismissal grace so a follow-up prompt never inherits an expired
+          // window, and rebroadcast the updated fields.
+          this.awaitingEnteredAt = Date.now();
+          this.emitSnapshot();
+        } else {
+          this.transition(State.AWAITING_PERMISSION, 'permission_prompt', 'pty');
+        }
         break;
       }
 
@@ -250,8 +278,10 @@ export class StateMachine extends EventEmitter {
         this.cursorIndex = (data?.cursorIndex as number) ?? 0;
         if (this.state === State.AWAITING_OPTION) {
           // Already in AWAITING_OPTION — just update options and re-emit snapshot
-          // (debounced chunks may re-parse with more complete data)
+          // (debounced chunks may re-parse with more complete data). Refresh the
+          // dismissal grace: this may be a NEW prompt of the same kind.
           debug('SM', `option_prompt update: ${this.options.length} options, nav=${this.navigable}, cursor=${this.cursorIndex}`);
+          this.awaitingEnteredAt = Date.now();
           this.emitSnapshot();
         } else {
           this.transition(State.AWAITING_OPTION, 'option_ui_detected', 'pty');
@@ -261,7 +291,12 @@ export class StateMachine extends EventEmitter {
 
       case 'diff_prompt': {
         this.options = (data?.options as PromptOption[]) || [];
-        this.transition(State.AWAITING_DIFF, 'diff_ui_detected', 'pty');
+        if (this.state === State.AWAITING_DIFF) {
+          this.awaitingEnteredAt = Date.now();
+          this.emitSnapshot();
+        } else {
+          this.transition(State.AWAITING_DIFF, 'diff_ui_detected', 'pty');
+        }
         break;
       }
 
@@ -505,21 +540,41 @@ export class StateMachine extends EventEmitter {
   }
 
   /** Tool activity (PreToolUse/PostToolUse and Codex equivalents) is dismissal
-   *  evidence for AWAITING_* only after a short grace period: a parallel tool
-   *  finishing — or a hook curl landing late — can arrive while a just-drawn
-   *  prompt is genuinely open, and dismissing it would hide an answerable
-   *  prompt from every device. A keyboard-answered prompt always produces
-   *  later tool activity or a stop, so a dismissal skipped here is retried by
-   *  the next hook. From IDLE (dropped user_prompt_submit) there is no prompt
-   *  to protect, so recovery is immediate. */
-  private recoverProcessingFromToolActivity(): void {
+   *  evidence for AWAITING_* / recovery evidence for IDLE, with three guards:
+   *
+   *  - Disabled entirely on the daemon hub's global machine
+   *    (`toolActivityRecovery: false`) — it multiplexes every observed
+   *    session, so "some session used a tool" proves nothing about the prompt
+   *    or turn this machine is displaying.
+   *  - AWAITING_*: a short grace after the prompt was drawn (a parallel tool
+   *    or a late hook curl can land while a fresh prompt is genuinely open),
+   *    and a tool END only counts when no other tool is still in flight —
+   *    while the gated tool's own PreToolUse is outstanding, a sibling
+   *    finishing is not evidence the prompt was answered. A tool START from
+   *    awaiting is always evidence (batch PreToolUse all fire before the
+   *    prompt is drawn, so a new start means the turn resumed).
+   *  - IDLE: only a tool START recovers a dropped user_prompt_submit. A
+   *    straggler tool-END curl landing after Stop must not reopen a finished
+   *    session (nothing would ever re-close it).
+   *
+   *  A dismissal skipped by any guard is retried by the next hook — a
+   *  keyboard-answered prompt always produces later tool activity or a stop. */
+  private recoverProcessingFromToolActivity(kind: 'start' | 'end'): void {
+    if (!this.toolActivityRecovery) return;
     const inAwaiting =
       this.state === State.AWAITING_PERMISSION ||
       this.state === State.AWAITING_OPTION ||
       this.state === State.AWAITING_DIFF;
-    if (inAwaiting && Date.now() - this.awaitingEnteredAt < AWAITING_TOOL_DISMISS_GRACE_MS) {
-      debug('SM', 'tool_activity within awaiting grace — keeping prompt');
-      return;
+    if (this.state === State.IDLE && kind !== 'start') return;
+    if (inAwaiting) {
+      if (Date.now() - this.awaitingEnteredAt < AWAITING_TOOL_DISMISS_GRACE_MS) {
+        debug('SM', 'tool_activity within awaiting grace — keeping prompt');
+        return;
+      }
+      if (kind === 'end' && this.inFlightTools > 0) {
+        debug('SM', `sibling tool ended with ${this.inFlightTools} still in flight — keeping prompt`);
+        return;
+      }
     }
     this.transition(State.PROCESSING, 'tool_activity', 'hook');
   }

--- a/bridge/src/state-machine.ts
+++ b/bridge/src/state-machine.ts
@@ -49,6 +49,10 @@ function truncateToolInput(s: string): string {
   return line.length > 120 ? line.slice(0, 119) + '\u2026' : line;
 }
 
+/** Grace period during which hook tool activity may not dismiss a freshly
+ *  drawn AWAITING_* prompt — see recoverProcessingFromToolActivity(). */
+export const AWAITING_TOOL_DISMISS_GRACE_MS = 1500;
+
 const TERMINAL_UI_EVENTS = new Set([
   'permission_prompt',
   'option_prompt',
@@ -83,6 +87,7 @@ export class StateMachine extends EventEmitter {
   private lastValidSuggestedPrompt: string | null = null;
   private usageTracker: UsageTracker;
   private stuckTimer: ReturnType<typeof setTimeout> | null = null;
+  private awaitingEnteredAt = 0;
 
   constructor(usageTracker: UsageTracker) {
     super();
@@ -109,6 +114,10 @@ export class StateMachine extends EventEmitter {
         this.currentTool = toolName;
         this.toolInput = formatToolInput(toolName, toolInputData);
         this.toolProgress = `Using ${toolName}`;
+        // Tool activity proves the turn is running: recovers AWAITING_* after a
+        // keyboard-answered prompt and IDLE after a dropped user_prompt_submit.
+        // A no-op from PROCESSING (transition table rejects it).
+        this.recoverProcessingFromToolActivity();
         this.emitSnapshot();
         break;
       }
@@ -118,6 +127,7 @@ export class StateMachine extends EventEmitter {
         this.currentTool = null;
         this.toolInput = null;
         this.toolProgress = null;
+        this.recoverProcessingFromToolActivity();
         this.emitSnapshot();
         break;
       }
@@ -175,6 +185,8 @@ export class StateMachine extends EventEmitter {
         this.currentTool = toolName;
         this.toolInput = formatToolInput(toolName, toolInputData);
         this.toolProgress = toolName ? `Using ${toolName}` : null;
+        // Same recovery contract as Claude PreToolUse (see above).
+        this.recoverProcessingFromToolActivity();
         this.emitSnapshot();
         break;
       }
@@ -184,6 +196,7 @@ export class StateMachine extends EventEmitter {
         this.currentTool = null;
         this.toolInput = null;
         this.toolProgress = null;
+        this.recoverProcessingFromToolActivity();
         this.emitSnapshot();
         break;
       }
@@ -491,6 +504,26 @@ export class StateMachine extends EventEmitter {
     }
   }
 
+  /** Tool activity (PreToolUse/PostToolUse and Codex equivalents) is dismissal
+   *  evidence for AWAITING_* only after a short grace period: a parallel tool
+   *  finishing — or a hook curl landing late — can arrive while a just-drawn
+   *  prompt is genuinely open, and dismissing it would hide an answerable
+   *  prompt from every device. A keyboard-answered prompt always produces
+   *  later tool activity or a stop, so a dismissal skipped here is retried by
+   *  the next hook. From IDLE (dropped user_prompt_submit) there is no prompt
+   *  to protect, so recovery is immediate. */
+  private recoverProcessingFromToolActivity(): void {
+    const inAwaiting =
+      this.state === State.AWAITING_PERMISSION ||
+      this.state === State.AWAITING_OPTION ||
+      this.state === State.AWAITING_DIFF;
+    if (inAwaiting && Date.now() - this.awaitingEnteredAt < AWAITING_TOOL_DISMISS_GRACE_MS) {
+      debug('SM', 'tool_activity within awaiting grace — keeping prompt');
+      return;
+    }
+    this.transition(State.PROCESSING, 'tool_activity', 'hook');
+  }
+
   transition(to: State, trigger: string, source: string): void {
     const valid = transitions.some(
       (t: StateTransition) =>
@@ -507,13 +540,29 @@ export class StateMachine extends EventEmitter {
     const prev = this.state;
     this.state = to;
 
-    // Reset cursor authority when leaving AWAITING states
+    // Leaving AWAITING_*: the prompt on screen is gone, so the prompt fields
+    // must not outlive it — a stale answerable question on a device would
+    // inject keystrokes into a running turn. Cleared here (not per-caller) so
+    // every exit path agrees.
     if (
-      prev === State.AWAITING_OPTION ||
-      prev === State.AWAITING_PERMISSION ||
-      prev === State.AWAITING_DIFF
+      (prev === State.AWAITING_OPTION ||
+        prev === State.AWAITING_PERMISSION ||
+        prev === State.AWAITING_DIFF) &&
+      to !== prev
     ) {
+      this.options = [];
+      this.question = null;
+      this.navigable = false;
+      this.cursorIndex = 0;
       this.cursorAuthority = 'pty';
+    }
+    if (
+      to !== prev &&
+      (to === State.AWAITING_OPTION ||
+        to === State.AWAITING_PERMISSION ||
+        to === State.AWAITING_DIFF)
+    ) {
+      this.awaitingEnteredAt = Date.now();
     }
 
     // Manage stuck-state timer. PROCESSING recovers after STUCK_TIMEOUT_MS
@@ -522,7 +571,8 @@ export class StateMachine extends EventEmitter {
     // user may be away for hours. A blind timer can't tell "away" from "parser
     // missed the recovery", so it wrongly forced a real prompt to IDLE and made
     // the session's creature vanish from the dashboard. Awaiting only leaves via
-    // a real signal (spinner_start / idle_detected / user response / stop), and
+    // a real signal (hook tool_activity / stop / user_prompt_submit, parser
+    // spinner_start / idle_detected where still emitted, or a user response);
     // a truly-dead session is reaped by liveness (PID death / /health grace),
     // not by this timer.
     this.resetStuckTimer();

--- a/bridge/src/version-check.ts
+++ b/bridge/src/version-check.ts
@@ -58,6 +58,18 @@ export function getAgentDeckVersion(): string {
   }
 }
 
+/** Codex CLI lifecycle-hook baseline, from this package's `compatibleCodex`
+ *  field — the one place the floor is stated (docs/cli.md quotes it). */
+export function getCompatibleCodexRange(): string | null {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+    return typeof pkg.compatibleCodex === 'string' ? pkg.compatibleCodex : null;
+  } catch {
+    return null;
+  }
+}
+
 function loadCompatState(): CompatState {
   try {
     if (existsSync(COMPAT_PATH)) {

--- a/bridge/src/version-check.ts
+++ b/bridge/src/version-check.ts
@@ -9,6 +9,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { debug } from './logger.js';
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -59,12 +60,25 @@ export function getAgentDeckVersion(): string {
 }
 
 /** Codex CLI lifecycle-hook baseline, from this package's `compatibleCodex`
- *  field — the one place the floor is stated (docs/cli.md quotes it). */
+ *  field — the one place the floor is stated (docs/cli.md quotes it).
+ *
+ *  The shape is validated because `satisfiesRange` SKIPS any constraint it
+ *  cannot parse and falls through to `true`: an npm-idiomatic edit like
+ *  `^0.150.0` would otherwise silently disable the version warning. An
+ *  invalid field returns null and the caller falls back to its literal. */
 export function getCompatibleCodexRange(): string | null {
   try {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
-    return typeof pkg.compatibleCodex === 'string' ? pkg.compatibleCodex : null;
+    const range = typeof pkg.compatibleCodex === 'string' ? pkg.compatibleCodex.trim() : null;
+    if (!range) return null;
+    const constraint = /^(>=|<=|>|<)?\d+\.\d+\.\d+$/;
+    const parts = range.split(/\s+/);
+    if (!parts.every((p: string) => constraint.test(p))) {
+      debug('version', `compatibleCodex "${range}" is not a supported range shape — ignoring`);
+      return null;
+    }
+    return range;
   } catch {
     return null;
   }

--- a/docs/apme-pipeline.md
+++ b/docs/apme-pipeline.md
@@ -12,17 +12,20 @@
 │                                                                              │
 │  ┌──────────────┐    ┌──────────────────┐    ┌────────────────────────────┐  │
 │  │ claude-code  │    │ openclaw/opencode│    │ codex-cli                  │  │
-│  │ (PTY + hook) │    │ (timeline events)│    │ (PTY parser only)          │  │
+│  │ (lifecycle   │    │ (timeline events)│    │ (lifecycle hooks + notify  │  │
+│  │  hooks +     │    │                  │    │  turn-complete + rollout   │  │
+│  │  transcript) │    │                  │    │  JSONL)                    │  │
 │  └──────┬───────┘    └────────┬─────────┘    └────────────┬───────────────┘  │
 │         │                     │                           │                  │
-│         │ HTTP POST           │ adapter.on('event')       │ parser events    │
-│         │ /hook/:event        │ source:'timeline'         │ spinner_stop+⏺   │
+│         │ HTTP POST           │ adapter.on('event')       │ HTTP POST        │
+│         │ /hooks/:event       │ source:'timeline'         │ /hooks/codex_*   │
 └─────────┼─────────────────────┼───────────────────────────┼──────────────────┘
           │                     │                           │
           ▼                     ▼                           ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ L1  INGESTION              │  wireAgentApme() + PTY tail parser              │
-│                            │  bridge/src/index.ts:440, 505, 1169             │
+│ L1  INGESTION              │  claudeHookToSpans / wireAgentApme()            │
+│                            │  bridge/src/index.ts (hook switch + codex      │
+│                            │  turn manager)                                  │
 └──────────────────────────────┬───────────────────────────────────────────────┘
                                ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
@@ -93,42 +96,48 @@ PTY가 없거나 구조화된 이벤트 스트림이 있는 에이전트는 time
 
 - **앵커**: `bridge/src/index.ts:1169` (`wireAgentApme`), `:1181` (timeline 분기)
 
-### 1C. Codex CLI — PTY Parser Only
+### 1C. Codex CLI — Lifecycle Hooks + Notify + Rollout
 
-Codex는 hook도 timeline도 없어서 PTY 파서 + 터미널 tail 파싱이 유일한 경로다.
+Codex 수집은 `~/.codex/config.toml` 의 lifecycle hook (`codex_session_start` /
+`codex_user_prompt_submit` / `codex_tool_start` / `codex_tool_end` /
+`codex_stop`) 이 1차 경로다. 초기 구현이 쓰던 PTY 파서 turn 추적은 1.0.19 에서
+제거됐다 (화면 파싱은 lifecycle 정본이 아니다).
 
-- **소스**: `adapter.on('event', { source: 'parser', event: 'user_prompt' | 'spinner_stop' })`
-- **프롬프트 수집**: `user_prompt` 이벤트에서 직접 추출 (`index.ts:1213-1219`)
-- **응답 수집**: `spinner_stop` 이벤트 → 500ms 지연 후 링버퍼 tail 파싱 (`index.ts:1220-1233`)
-- **필터링**: spinner 문자 (`✢✳✶✻✽`), 모드 인디케이터 (`⏸⏵`), 프롬프트 (`❯`), separator, plan/accept-edit 패턴, `? for shortcuts` 등을 제거
+- **소스**: `adapter.on('event', { source: 'hook', event: 'codex_*' })` →
+  `CodexTurnManager.onHookEvent()` (`bridge/src/apme/adapters/codex-turn-manager.ts`)
+- **턴 경계**: `codex_user_prompt_submit` 이 열고 `codex_stop` 이 닫는다.
+  `codex_stop` 이 유실되면 notify `codex_turn_complete` 가 같은 턴을 닫고
+  StateMachine 도 IDLE 로 복구한다 (hook 과 notify 는 둘 다 curl/`AGENTDECK_PORT`
+  경로를 타므로, 세션 내내 양쪽 모두 침묵하면 `codex-hook-silence.ts` 가 경고를
+  타임라인에 남긴다)
+- **응답 수집**: inline payload (`last_assistant_message` 등) 우선, 없으면
+  rollout JSONL tail (`bridge/src/codex-rollout-response.ts`)
+- **오류 표기**: 명시적 `error` 키만 오류로 매핑한다 — `message` 는 다른 Codex
+  이벤트에서 콘텐츠를 담는 키라 오류로 해석하지 않는다 (실측 codex_stop 311건
+  기준 두 키 모두 등장 0회)
 
-### 1D. Claude Code PTY Response Capture (Hook 보조)
+### 1D. Claude Code Response Capture (transcript 정본)
 
-Claude Code의 `Stop` 훅은 v2.1.104 기준 **발화율 ~18%** (매우 불안정). 이를 보완하기 위해 PTY tail 파싱을 **1차 경로**로 사용한다.
+Claude Code 의 응답 본문은 `Stop` hook payload 의 `transcript_path` JSONL tail
+에서 읽는다 (`readClaudeTranscriptLastTurn` — `last_assistant_message` 필드는
+불안정해 transcript 가 닿지 않을 때의 보조로만 쓴다).
 
-- **트리거**: `spinner_stop` 이벤트 + 500ms 지연 (`index.ts:505-546`)
-- **추출 방식**: 링버퍼 tail 5000 bytes에서 **마지막 `⏺` 마커** 위치 찾기 → 그 이후 텍스트를 라인 단위 필터링
-- **필터** (`index.ts:517-527`):
-  ```
-  - spinner chars /^[✢✳✶✻✽⏸⏵❯─>]/
-  - /planmode|plan\s*mode|shift\+tab|accept\s*edits/i
-  - 상태 텍스트 "Whirring…", "Finagling…" + 토큰/시간
-  - /\?\s*for\s*shortcuts/
-  ```
-
-#### pendingPtyResponse — 3경로 race 해결
-
-`UserPromptSubmit` 훅과 `spinner_stop` 이벤트의 도착 순서가 **프롬프트 길이에 따라 역전**되는 race condition 때문에, 세 경로의 fallback 체인을 둔다:
+`Stop` hook 자체가 유실되는 경우가 실측으로 존재하므로 (v2.1.104 에서 발화율
+~18% 를 기록한 적이 있고, 2.1.231 에서도 유실이 관측된다) **transcript
+watchdog** (`bridge/src/claude-turn-watchdog.ts`) 이 구조적 fallback 이다:
 
 ```
-Path A: spinner_stop 도착 시점에 활성 turn 존재 → 바로 setTurnResponse
-Path B: spinner_stop이 먼저, turn이 아직 없음 → pendingPtyResponse에 버퍼링
-Path C: 이후 UserPromptSubmit이 도착하면 직전에 닫힌 turn에
-        setLastClosedTurnResponse로 적용 (bridge/src/index.ts:470-480)
-Stop 훅이 오면: 더 깨끗한 last_assistant_message로 덮어쓰고 버퍼 클리어
+턴 열림(UserPromptSubmit) 상태에서 hook 채널이 10s+ 침묵
+  → transcript tail 프로브 (mtime 게이트, 512KB cap)
+  → 마지막 message 레코드가 assistant + stop_reason "end_turn"
+    이고 timestamp 가 턴 시작 이후면 턴이 끝났다는 증거
+  → synthetic Stop 을 어댑터 이벤트 파이프에 주입
+  → 상태머신·타임라인·APME 가 기존 Stop 경로로 일관되게 닫힘
 ```
 
-- **앵커**: `index.ts:450` (`pendingPtyResponse` 선언), `:470-482`
+`stop_reason: "tool_use"` (권한 프롬프트/AskUserQuestion 대기) 는 절대 완료로
+판정하지 않으므로 진짜 대기를 강제로 닫는 일은 없다. 늦게 도착한 실제 Stop 은
+`ccPendingCompletion` 가드가 dedup 한다. 어느 단계에도 화면(PTY) 파싱은 없다.
 
 ---
 
@@ -472,7 +481,7 @@ ApmeConfig {
 
 | 레이어 | 파일 | 핵심 라인 |
 |---|---|---|
-| L1 — Ingestion | `bridge/src/index.ts` | `:440` (wireAgentApme 호출) · `:505-546` (PTY ⏺ 파싱) · `:470-482` (pendingPtyResponse 3경로) · `:1169` (wireAgentApme 정의) · `:1181-1209` (timeline 분기) · `:1213-1233` (Codex parser 분기) |
+| L1 — Ingestion | `bridge/src/index.ts` + `bridge/src/apme/adapters/` | index.ts hook switch (`claudeHookToSpans`/`codexHookToSpans` 분기) · `wireAgentApme` 정의 (timeline 분기 + CodexTurnManager 배선) · `claude-hook.ts` / `codex-hook.ts` / `codex-turn-manager.ts` · missed-Stop watchdog `bridge/src/claude-turn-watchdog.ts` |
 | L2 — Collector | `bridge/src/apme/collector.ts` | `:60` openRun · `:86` ingestHook · `:149` closeTurn · `:183` setTurnResponse · `:196` setLastClosedTurnResponse · `:239` splitRun · `:268` closeRun |
 | L2 — Store | `bridge/src/apme/store.ts` | `:32-57` runs · `:68-85` turns · `:98-109` evals · `:111-119` rubrics · `:137-174` 집계 뷰 · `:178-299` DEFAULT_RUBRIC_V1 + CATEGORY_RUBRICS · `:406-439` seedDefaultRubric |
 | L3 — Classifier | `bridge/src/apme/classifier.ts` | `:64` computeSignals · `:159` RULES · `:203` classify · `:239` classifyWithLlm · `:299` classifyRunSmart |

--- a/docs/apme.md
+++ b/docs/apme.md
@@ -29,12 +29,13 @@ validators: [pnpm test]
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
 │                        Agent Sessions                                │
-│  claude-code (PTY+hook) │ openclaw/opencode (GW) │ codex-cli (PTY)   │
-└───────┬─────────────────┴────────┬────────────────┴──────┬───────────┘
-        │ hook POST                │ timeline events       │ parser events
-        ▼                          ▼                       ▼
+│  claude-code (hooks)  │ openclaw/opencode (GW)  │ codex-cli (hooks)  │
+└───────┬───────────────┴────────┬─────────────────┴──────┬────────────┘
+        │ hook POST              │ timeline events        │ hook POST +
+        │ + transcript JSONL     │                        │ notify + rollout
+        ▼                        ▼                        ▼
 ┌──────────────────────────────────────────────────────────────────────┐
-│  wireAgentApme() + PTY tail parser  (bridge/src/index.ts)            │
+│  wireAgentApme() / claudeHookToSpans  (bridge/src/index.ts)          │
 │  3경로 수렴 → ApmeCollector 공통 API                                   │
 └──────────────────────────────┬───────────────────────────────────────┘
                                ▼
@@ -83,7 +84,7 @@ daemon 없이 session bridge 단독 사용 시 데이터만 축적되고 coding 
 | `bridge/src/apme/types.ts` | DB row TS types (Run, Turn, Step, Eval, Rubric, Vibe, Scorecard, TaskSignals) |
 | `bridge/src/apme/store.ts` | SQLite DAO — DDL, CRUD, 집계 뷰 3종, 기본 + 카테고리별 루브릭 seed |
 | `bridge/src/apme/settings.ts` | `~/.agentdeck/settings.json` 병합 로더 + `shouldJudge()` gate |
-| `bridge/src/apme/collector.ts` | 수집 경계 — session/turn lifecycle, hook → steps, PTY response → turns |
+| `bridge/src/apme/collector.ts` | 수집 경계 — session/turn lifecycle, hook → steps, transcript/rollout response → turns |
 | `bridge/src/apme/classifier.ts` | Task signals 계산 + rule-based + MLX fallback 분류 |
 | `bridge/src/apme/runner.ts` | Run-level (coding) + turn-level (non-coding) 평가 파이프라인 |
 | `bridge/src/foundation-models-helper.ts` | CLI-only Foundation Models Swift helper resolver / JSONL process manager |
@@ -195,11 +196,11 @@ v_category_scorecard    -- (task_category, model_id) 그룹: runs, avg_overall,
 ### Session bridge (`bridge/src/index.ts`)
 
 1. `startSession()` 진입 시 `await initApme()` → `core.setApme(apme, cwd)`
-2. **Claude Code**: `adapter.on('event', 'hook')` → `apme.collector.ingestHook(sessionId, event, data)`
-3. **Non-Claude 에이전트** (OpenClaw/OpenCode/Codex): `wireAgentApme(adapter, agentType, apme, core, ptyRingBuffer)` — timeline 이벤트 + PTY parser 이벤트를 collector로 변환
-4. **Claude Code PTY 응답 캡처**: `spinner_stop` 이벤트 + 500ms 지연 → 링버퍼 tail에서 `⏺` 마커 기반 파싱 → `setTurnResponse()`. `pendingPtyResponse` 3-path race 해결
+2. **Claude Code**: `adapter.on('event', 'hook')` → `claudeHookToSpans` → `apme.collector.ingestSpan(sessionId, span)`
+3. **Non-Claude 에이전트** (OpenClaw/OpenCode/Codex): `wireAgentApme(adapter, agentType, apme, core)` — timeline 이벤트(OpenClaw/OpenCode)와 Codex lifecycle hook + notify를 collector로 변환
+4. **Claude Code 응답 캡처**: Stop hook의 `transcript_path` JSONL tail 을 읽어 `setTurnResponse()` (`readClaudeTranscriptLastTurn`). Stop 자체가 유실되면 `claude-turn-watchdog.ts` 가 hook 침묵 + transcript `end_turn` 레코드를 근거로 synthetic Stop 을 주입해 같은 경로로 닫는다 — 화면(PTY) 파싱은 어느 단계에도 없다
 
-> **관측(observed) 세션의 응답 캡처는 데몬 쪽에 따로 있다.** 위 PTY 경로는 `agentdeck claude` 로 띄운 managed 세션 전용이라, 직접 실행한 `claude`/`codex`/`opencode` 는 이 경로를 타지 않는다. 그 결과 hook 으로만 관측되는 세션은 프롬프트와 툴 궤적만 아카이빙되고 **응답은 통째로 유실**됐다 (claude-code turn 1589개 중 response 219개, 마지막이 2026-07-11; `assistant_message` 궤적 이벤트는 전 기간 15개뿐이고 그중 12개가 OpenClaw). 대시보드가 TIMELINE 이 온전히 보여주는 대화를 재현할 수 없었고, judge 는 침묵을 채점하고 있었다. 지금은 `daemon-server.ts` 의 stop 훅 핸들러가 타임라인 행을 결정하는 **같은 분기에서** `setTurnResponse()` 를 호출한다. Swift 데몬도 같은 증상이었지만 원인이 달랐다 — `getLastEntry(type:"chat_end")` 를 읽었는데 `chat_end` 는 응답이 **없을 때만** 나오는 행이라 구조적으로 응답을 볼 수 없었다(`DaemonServer.appendClaudeCodeChatEnd` 로 이동).
+> **관측(observed) 세션의 응답 캡처는 데몬 쪽에 따로 있다.** 위 세션 브리지 경로는 `agentdeck claude` 로 띄운 managed 세션 전용이라, 직접 실행한 `claude`/`codex`/`opencode` 는 이 경로를 타지 않는다. 그 결과 hook 으로만 관측되는 세션은 프롬프트와 툴 궤적만 아카이빙되고 **응답은 통째로 유실**됐다 (claude-code turn 1589개 중 response 219개, 마지막이 2026-07-11; `assistant_message` 궤적 이벤트는 전 기간 15개뿐이고 그중 12개가 OpenClaw). 대시보드가 TIMELINE 이 온전히 보여주는 대화를 재현할 수 없었고, judge 는 침묵을 채점하고 있었다. 지금은 `daemon-server.ts` 의 stop 훅 핸들러가 타임라인 행을 결정하는 **같은 분기에서** `setTurnResponse()` 를 호출한다. Swift 데몬도 같은 증상이었지만 원인이 달랐다 — `getLastEntry(type:"chat_end")` 를 읽었는데 `chat_end` 는 응답이 **없을 때만** 나오는 행이라 구조적으로 응답을 볼 수 없었다(`DaemonServer.appendClaudeCodeChatEnd` 로 이동).
 5. `usage_info` 메타데이터 → `apme.collector.updateUsage(sessionId, snapshot)`
 6. `state_changed` → `apme.collector.updateModel(sessionId, modelName)`
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -77,49 +77,58 @@ Same-socket is the **only** reverse path (no inbound reachability required — w
 
 ## State Machine
 
-The bridge combines hook events and PTY output parsing to maintain 6 states:
+Lifecycle hooks own the 6 states; the managed terminal contributes only
+prompt-affordance observations (`terminal_ui` events) that hooks cannot see
+yet. The transition table is the SSOT in `shared/src/states.ts`.
 
 ```
                     +----------------+
          +---------|  DISCONNECTED  |<---- SessionEnd hook / PTY closed
          |         +----------------+
-         | agentdeck claude
+         | SessionStart hook
          v
-    +-----------+  Stop hook / idle detected
+    +-----------+  Stop hook (or transcript watchdog)
     |   IDLE    |<----------------------------------+
     +-----+-----+                                   |
-          | UserPromptSubmit hook / spinner          |
+          | UserPromptSubmit hook                    |
           v                                         |
-    +---------------+  permission prompt detected   |
+    +---------------+  permission prompt observed   |
     |  PROCESSING   |---------------------+         |
     +---+-------+---+                     |         |
         |       |                         v         |
         |       |                +--------------+   |
         |       |                |  AWAITING    |   |
-        |       |                |  PERMISSION  |---+ user responds (y/n/a)
-        |       |                +--------------+
-        |       | diff prompt detected
-        |       v
+        |       |                |  PERMISSION  |---+ user/device answers,
+        |       |                +--------------+     or hooks resume
+        |       | diff prompt observed                (tool activity / Stop /
+        |       v                                      next prompt)
         |  +--------------+
         |  |  AWAITING    |
-        |  |  DIFF        |-----------------------------+ user responds (v/a/d)
+        |  |  DIFF        |-----------------------------+ same exits
         |  +--------------+
-        | option UI detected
+        | option UI observed
         v
     +--------------+
     |  AWAITING    |
-    |  OPTION      |--------------------------------+ user selects option
+    |  OPTION      |--------------------------------+ same exits
     +--------------+
 ```
 
-| State | Description | Detection |
+| State | Description | Driven by |
 |-------|-------------|-----------|
 | `DISCONNECTED` | No session | `SessionEnd` hook, PTY exit |
-| `IDLE` | Waiting for prompt | `Stop` hook, `>` idle pattern |
-| `PROCESSING` | Agent working | `UserPromptSubmit` hook, spinner |
-| `AWAITING_PERMISSION` | Yes/No response needed | `Yes, allow once` / `(y/n)` pattern |
-| `AWAITING_OPTION` | Selection needed | Numbered list / navigable cursor |
-| `AWAITING_DIFF` | Diff review | `(V)iew/(A)pply/(D)eny` pattern |
+| `IDLE` | Waiting for prompt | `Stop` hook; missed-Stop transcript watchdog (Claude); notify `codex_turn_complete` (Codex) |
+| `PROCESSING` | Agent working | `UserPromptSubmit` hook; tool-activity hooks recover a dropped prompt-submit |
+| `AWAITING_PERMISSION` | Yes/No response needed | `terminal_ui` permission-prompt observation (managed sessions) |
+| `AWAITING_OPTION` | Selection needed | `terminal_ui` option-prompt observation (numbered list / navigable cursor) |
+| `AWAITING_DIFF` | Diff review | `terminal_ui` diff-prompt observation |
+
+`AWAITING_*` exits are hook-driven for Claude/Codex (tool activity after a
+short grace, `Stop`, or the next `UserPromptSubmit` — a prompt answered at the
+keyboard produces no device action, so the hooks that keep firing are the
+dismissal evidence). Adapters that still normalize their native event streams
+into parser signals (OpenCode, OpenClaw) additionally exit on
+`spinner_start`/`idle_detected`.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ AgentDeck is actively working on the next Apple companion release and on persona
 
 ## 2. Personalized Agent Evaluation System (APME)
 
-Building a data-driven answer to "which of my 6+ LLMs should I route this task to?" — replacing gut-feel model selection with measurement on my actual work. All three ingestion paths (Claude Code hooks + PTY, OpenClaw/OpenCode timeline events, Codex PTY parser) converge on a unified `ApmeCollector` → local SQLite. **Category-aware evaluation:**
+Building a data-driven answer to "which of my 6+ LLMs should I route this task to?" — replacing gut-feel model selection with measurement on my actual work. All three ingestion paths (Claude Code hooks + transcript JSONL, OpenClaw/OpenCode timeline events, Codex lifecycle hooks + notify + rollout JSONL) converge on a unified `ApmeCollector` → local SQLite. **Category-aware evaluation:**
 - **Coding (coding/refactoring/debugging)** — run-level eval after session ends, deterministic layer (lint/build/test) + LLM judge with category-specific rubrics
 - **Non-coding (conversation/planning/research/review)** — turn-level mid-session eval, fires immediately after each turn completes, no git diff needed
 - **Composite score** — 4-dimensional weighted sum (0.40 outcome + 0.40 judge + 0.15 efficiency + 0.05 vibe) so a single noisy signal can't poison the run

--- a/docs/why-apme.md
+++ b/docs/why-apme.md
@@ -102,7 +102,7 @@ Stage 4 — LLM Judge 튜닝 (사람과 일치하는 자동 평가)
 | 수집 대상 | 출처 |
 |---|---|
 | 프롬프트 | `UserPromptSubmit` hook / chat_start timeline |
-| 응답 | PTY `⏺` 마커 tail / chat_response / Stop hook |
+| 응답 | Stop hook `transcript_path` JSONL / chat_response / Codex rollout JSONL |
 | 툴 호출 히스토리 | `PreToolUse`/`PostToolUse` hooks |
 | 파일 변경 | git diff (before/after) |
 | 토큰 사용량 / 비용 | `/usage` 명령, Codex bash 로그 |
@@ -114,17 +114,18 @@ Stage 4 — LLM Judge 튜닝 (사람과 일치하는 자동 평가)
 ┌───────────────┬────────────────────────┬─────────────────────────────┐
 │   에이전트     │      수집 경로          │         특이사항             │
 ├───────────────┼────────────────────────┼─────────────────────────────┤
-│ Claude Code   │ hook HTTP POST         │ Stop 훅 발화율 ~18% (불안정)  │
-│               │ /hook/:event           │ → PTY ⏺ tail 파싱이 1차 경로  │
-│               │                        │ → pendingPtyResponse 3경로    │
-│               │                        │   race 해결                   │
+│ Claude Code   │ hook HTTP POST         │ Stop 훅 유실 시              │
+│               │ /hooks/:event          │ → transcript JSONL tail 이   │
+│               │ + transcript JSONL     │   정본, watchdog 이 synthetic │
+│               │                        │   Stop 으로 턴을 닫음         │
 ├───────────────┼────────────────────────┼─────────────────────────────┤
 │ OpenClaw      │ adapter timeline       │ chat_start/response/end      │
 │ OpenCode      │ events                 │ → collector 이벤트 매핑       │
 │               │ (source:'timeline')    │                              │
 ├───────────────┼────────────────────────┼─────────────────────────────┤
-│ Codex CLI     │ PTY parser             │ hook/timeline 없음           │
-│               │ (spinner_stop + ⏺)     │ → PTY tail 파싱 유일 경로     │
+│ Codex CLI     │ lifecycle hooks        │ codex_stop 유실 시 notify    │
+│               │ + notify + rollout     │ turn-complete 가 닫고,       │
+│               │ JSONL                  │ 응답은 rollout tail 로 보완   │
 └───────────────┴────────────────────────┴─────────────────────────────┘
                                 │
                                 ▼

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/hooks",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "engines": {
     "node": ">=22"
   },

--- a/setup/package.json
+++ b/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/setup",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "engines": {
     "node": ">=22"
   },

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdeck/shared",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "engines": {
     "node": ">=22"
   },

--- a/shared/src/states.ts
+++ b/shared/src/states.ts
@@ -44,14 +44,36 @@ export const transitions: StateTransition[] = [
   { from: State.AWAITING_OPTION, to: State.PROCESSING, trigger: 'user_selection', source: 'user' },
   { from: State.AWAITING_DIFF, to: State.PROCESSING, trigger: 'user_response', source: 'user' },
   { from: State.AWAITING_DIFF, to: State.PROCESSING, trigger: 'user_selection', source: 'user' },
-  // Recovery: spinner_start from awaiting states (user responded via keyboard, not Stream Deck)
+  // Recovery: spinner_start from awaiting states (user responded via keyboard,
+  // not a device). Only adapters that still emit parser lifecycle events
+  // (OpenCode, OpenClaw) can drive these; Claude/Codex adapters forward
+  // terminal_ui prompts only, so their keyboard-answer recovery is hook-based.
   { from: State.AWAITING_PERMISSION, to: State.PROCESSING, trigger: 'spinner_start', source: 'pty' },
   { from: State.AWAITING_OPTION, to: State.PROCESSING, trigger: 'spinner_start', source: 'pty' },
   { from: State.AWAITING_DIFF, to: State.PROCESSING, trigger: 'spinner_start', source: 'pty' },
+  // Hook exits from AWAITING_*: a prompt answered at the keyboard produces no
+  // user/device action and (for Claude/Codex) no parser signal, so the
+  // lifecycle hooks that keep firing are the only truthful dismissal evidence:
+  // tool activity means the turn is running again, stop means the turn ended,
+  // and a new user_prompt_submit means a new turn started. Without these the
+  // session wedges in AWAITING_* forever once the user touches the terminal.
+  { from: State.AWAITING_PERMISSION, to: State.PROCESSING, trigger: 'tool_activity', source: 'hook' },
+  { from: State.AWAITING_OPTION, to: State.PROCESSING, trigger: 'tool_activity', source: 'hook' },
+  { from: State.AWAITING_DIFF, to: State.PROCESSING, trigger: 'tool_activity', source: 'hook' },
+  { from: State.AWAITING_PERMISSION, to: State.IDLE, trigger: 'stop', source: 'hook' },
+  { from: State.AWAITING_OPTION, to: State.IDLE, trigger: 'stop', source: 'hook' },
+  { from: State.AWAITING_DIFF, to: State.IDLE, trigger: 'stop', source: 'hook' },
+  { from: State.AWAITING_PERMISSION, to: State.PROCESSING, trigger: 'user_prompt_submit', source: 'hook' },
+  { from: State.AWAITING_OPTION, to: State.PROCESSING, trigger: 'user_prompt_submit', source: 'hook' },
+  { from: State.AWAITING_DIFF, to: State.PROCESSING, trigger: 'user_prompt_submit', source: 'hook' },
+  // Hook-miss recovery: tool activity arriving while IDLE proves a turn is
+  // running even when its user_prompt_submit was dropped.
+  { from: State.IDLE, to: State.PROCESSING, trigger: 'tool_activity', source: 'hook' },
   // stuck_timeout: only PROCESSING recovers after STUCK_TIMEOUT_MS (Claude hung).
   // AWAITING_* intentionally have NO wall-clock backstop — an unanswered prompt
   // is a genuine, indefinitely-valid wait (the user may be away); it only leaves
-  // via a real signal (spinner_start / idle_detected / user response / stop), and
+  // via a real signal (hook tool_activity/stop/user_prompt_submit, parser
+  // spinner_start/idle_detected where still emitted, or a user response), and
   // a truly-dead session is reaped by liveness, not a timer. A blind awaiting
   // timer wrongly forced real prompts to IDLE and vanished them from dashboards.
   { from: State.PROCESSING, to: State.IDLE, trigger: 'stuck_timeout', source: 'internal' },


### PR DESCRIPTION
## Summary

Post-release adversarial review of #184 (npm 1.0.19) found two confirmed regressions; this PR fixes both plus follow-up hardening, and prepares npm 1.0.20.

**Regression 1 (critical): AWAITING_* wedge.** 1.0.19 removed the parser exit signals (`spinner_start`/`idle_detected`) from the Claude/Codex adapters without adding hook-based replacements — the transition table had no `AWAITING_* → IDLE` on `stop` and no `AWAITING_* → PROCESSING` on `user_prompt_submit`, so a managed session whose prompt was answered **at the keyboard** stayed amber-awaiting forever (and the Stop handler cleared `question` before the blocked transition, broadcasting question-less awaiting snapshots).

**Regression 2 (high): missed-Stop blackout.** The spinner/ring-buffer recovery was deleted with no substitute: a dropped Claude Stop hook left state stuck PROCESSING (5-min stuck timer, re-armed by PTY output), no timeline close row, and an open APME turn with no response. Measured post-1.0.19: of 9 Claude turns, 2 still open, 3 of 7 closed without a response (Claude Code 2.1.231).

## Changes

- `shared/src/states.ts`: hook exits from AWAITING_* — `tool_activity` (PreToolUse/PostToolUse/codex_tool_*, gated by a 1.5s grace so a parallel tool or late hook curl can't dismiss a freshly drawn prompt), `stop`, `user_prompt_submit`; plus `IDLE → PROCESSING` on tool activity (dropped prompt-submit recovery). Prompt-field clearing centralized in `transition()`.
- `bridge/src/claude-turn-watchdog.ts` (new): when a turn is open and the hook channel is quiet 10s+, probe the transcript JSONL tail (mtime-gated, 512KB cap). Last message-bearing record `assistant` + `stop_reason:"end_turn"` stamped after turn-open ⇒ inject a synthetic Stop through the adapter event pipe — state machine, timeline, and APME close via their existing Stop paths. `tool_use` (genuine prompt wait) is never force-closed; a late real Stop dedups.
- `bridge/src/codex-hook-silence.ts` (new): one-shot warning (log + timeline error row) when a managed Codex terminal is active but no `codex_*` hook/notify event ever arrives — both ride one curl/port path and previously failed silently. Skipped under `--no-codex-hooks`.
- `codex_stop` mapping: only explicit `error` maps to an error row; the speculative `message`→error probe is removed (0/311 recorded real Stop payloads carry either key; `message` is a content key on every other Codex event).
- `compatibleCodex` in bridge/package.json is now read at runtime (`getCompatibleCodexRange`) instead of duplicating the literal.
- Docs: protocol.md state-machine section, apme.md, apme-pipeline.md, why-apme.md, roadmap.md rewritten to the hook-primary architecture (they still described the deleted Path A/B/C ring-buffer capture as current); stale comments in states.ts/state-machine.ts fixed.
- Versions: four npm packages → 1.0.20; CHANGELOG names both 1.0.19 regressions including the previously unacknowledged Claude one.

## Verification

- 182 test files, 2,940 tests pass. New real-path tests: 10 hook-exit cases driven through `handleHookEvent` (replacing reliance on parser-path tests that certified an unreachable route), 9 watchdog, 6 transcript-probe, 5 hook-silence, 2 codex_stop mapping.
- Transcript end_turn/tool_use judgment validated against real `~/.claude/projects` JSONL; codex_stop shape validated against 311 recorded real payloads (≤0.146.0).
- `pnpm build`, `pnpm verify-version`, `pnpm docs:check`, targeted ESLint (0 errors), `git diff --check` all pass.

Wire protocol unchanged — no device redeploys needed; same 1.0 compatibility line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)