### PR TITLE
Improve Android setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://apps.apple.com/app/id6784822497"><img src="https://img.shields.io/badge/App%20Store-Mac%20%C2%B7%20iPhone%20%C2%B7%20iPad-1f6157.svg?logo=apple" alt="App Store — Mac, iPhone, and iPad"></a>
+  <a href="https://play.google.com/store/apps/details?id=dev.agentdeck"><img src="https://img.shields.io/badge/Google%20Play-Android-1f6157.svg?logo=googleplay" alt="Google Play — Android"></a>
   <a href="https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464"><img src="https://img.shields.io/badge/Elgato%20Marketplace-Stream%20Deck%20plugin-1f6157.svg" alt="Elgato Marketplace"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://www.npmjs.com/package/@agentdeck/setup"><img src="https://img.shields.io/npm/v/@agentdeck/setup.svg" alt="npm version"></a>
@@ -127,13 +128,14 @@ Any of these attach to the same daemon, and you can add them in any order:
 | **Ulanzi D200H** | Install the plugin in Ulanzi Studio — see [plugin-ulanzi/VERIFY.md](plugin-ulanzi/VERIFY.md) |
 | **macOS app** | [Download on the App Store](https://apps.apple.com/app/id6784822497) — the SwiftUI dashboard carries its own daemon, so it needs no Node.js |
 | **iPhone / iPad companion** | Same [App Store listing](https://apps.apple.com/app/id6784822497) — pairs with a daemon on your Mac over the LAN (QR pairing) |
-| **Android tablet / e-ink** | Signed APK from [Releases](https://github.com/puritysb/AgentDeck/releases) — see [docs/android.md](docs/android.md) |
+| **Android tablet / e-ink** | [Install from Google Play](https://play.google.com/store/apps/details?id=dev.agentdeck) (recommended), or use the signed APK from [Releases](https://github.com/puritysb/AgentDeck/releases). Android is a companion dashboard: keep the AgentDeck daemon running on a Mac/PC on the same network. See the [3-step setup guide](docs/android.md#quick-start-google-play-or-github-apk). |
 | **ESP32 panels · InkDeck e-ink** | Flash firmware, then Wi-Fi OTA — see [docs/esp32.md](docs/esp32.md) |
 | **Pixoo64 · TC001 · Timebox · iDotMatrix** | `agentdeck pixoo scan` / `agentdeck timebox scan` — see [docs/devices.md](docs/devices.md) |
 
-> **The Stream Deck and Ulanzi plugins are thin clients.** They talk to the
-> AgentDeck daemon the way an OBS plugin talks to OBS, and never embed it. With no
-> daemon running they show an OFFLINE state pointing at the install command.
+> **Android, Stream Deck, and Ulanzi are companion surfaces.** They talk to the
+> AgentDeck daemon the way an OBS plugin talks to OBS, and never embed it. Keep the
+> daemon running on the same computer/network; without it these surfaces show an
+> offline or searching state.
 
 Full build-from-source and manual steps: **[docs/install.md](docs/install.md)**.
 
@@ -270,7 +272,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.3 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.3); submitted, review in progress ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.8](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.8) |
 | **GitHub Release** — ESP32 firmware | `esp32-v*` | [1.0.4](https://github.com/puritysb/AgentDeck/releases/tag/esp32-v1.0.4) — one binary per Shipping board |
-| **Google Play** — Android AAB | `android-v*` | 1.0.6 (versionCode 8) in review for full production rollout since 2026-08-07; the public listing is not live yet. Listing copy, assets and the console runbook are in [marketplace/play/](marketplace/play/LISTING.md) |
+| **Google Play** — Android AAB | `android-v*` | [1.0.6 live](https://play.google.com/store/apps/details?id=dev.agentdeck) (versionCode 8, published 2026-08-14). Listing copy, assets and the console runbook are in [marketplace/play/](marketplace/play/LISTING.md) |
 
 ---
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -7,14 +7,41 @@ locale: en
 canonical: true
 status: stable
 owner: Android maintainers
-reviewed: 2026-07-30
-revision: 2026-07-30
+reviewed: 2026-08-14
+revision: 2026-08-14
 source_of_truth: docs/android.md
 validators: [pnpm test:android]
 ---
 # Android Dashboard
 
 Detailed reference for the AgentDeck Android app — build, device support, and creature behavior.
+
+---
+
+## Quick Start (Google Play or GitHub APK)
+
+AgentDeck for Android is a **companion dashboard**, not the daemon itself. It
+shows the coding-agent sessions reported by AgentDeck on your computer, so the
+Android device and computer must be on the same local network.
+
+1. **Install the Android app.** Use [Google Play](https://play.google.com/store/apps/details?id=dev.agentdeck)
+   (recommended), or download the signed APK from [GitHub Releases](https://github.com/puritysb/AgentDeck/releases).
+2. **Start AgentDeck on the computer running your agents.** On a Mac, open
+   [AgentDeck Dashboard from the Mac App Store](https://apps.apple.com/app/id6784822497).
+   On macOS, Windows, or Linux, install and start the local daemon with:
+
+   ```bash
+   npx @agentdeck/setup
+   ```
+
+3. **Open the Android app.** It discovers the daemon automatically over the
+   local network. Start Claude Code, Codex, or OpenCode normally; their sessions
+   then appear on the dashboard.
+
+If the app stays on **Searching for AgentDeck**, confirm that the computer app
+or daemon is still running and both devices are on the same Wi-Fi/LAN. Then use
+the app's **Manual URL** or **USB Connect** fallback described in
+[Connection ladder](#connection-ladder-ssot).
 
 ---
 

--- a/docs/hardware/index.html
+++ b/docs/hardware/index.html
@@ -197,6 +197,10 @@
   .periph { margin:0 0 var(--s-4); color:var(--ink-500); font-size:var(--t-caption); }
   .periph span { display:block; font-family:var(--font-mono); font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:var(--ink-500); margin-bottom:2px; }
   .spec-note { margin:var(--s-6) 0 0; color:var(--ink-500); font-size:var(--t-caption); }
+  .android-setup { display:flex; align-items:center; justify-content:space-between; gap:var(--s-6); margin:0 0 var(--s-6); padding:var(--s-5) var(--s-6); border:1px solid var(--tide-200); border-radius:var(--r-2xl); background:var(--tide-100); }
+  .android-setup h3 { margin:0 0 var(--s-1); font-size:19px; }
+  .android-setup p { margin:0; color:var(--ink-500); font-size:var(--t-caption); max-width:68ch; }
+  .android-setup .actions { display:flex; flex:0 0 auto; gap:var(--s-2); flex-wrap:wrap; }
   .detail-link { margin-top:var(--s-12); padding:var(--s-6); border-radius:var(--r-2xl); background:var(--ink-900); color:var(--tide-300); display:flex; align-items:center; justify-content:space-between; gap:var(--s-6); }
   .detail-link h2 { color:var(--tide-50); font-size:24px; }
   .detail-link p { margin:4px 0 0; }
@@ -216,6 +220,7 @@
     .grid { grid-template-columns:1fr; }
     .spec-grid { grid-template-columns:1fr; }
     .device.wide { grid-column:auto; }
+    .android-setup { align-items:flex-start; flex-direction:column; }
     .detail-link { align-items:flex-start; flex-direction:column; }
   }
 </style>
@@ -281,6 +286,16 @@
 
   <section id="apps">
     <div class="section-head"><h2 data-i18n="s.apps.h">Apps &amp; terminal</h2><p data-i18n="s.apps.p">Each app is a separately designed UI — macOS and iOS/iPadOS are similar but distinct, while Android tablet and Android e-ink are entirely different layouts. The dependency-free TUI keeps the same sessions visible inside a terminal.</p></div>
+    <aside class="android-setup" aria-label="Android setup">
+      <div>
+        <h3 data-i18n="android.h">Android app + computer daemon</h3>
+        <p data-i18n="android.p">Install the app from Google Play, then run AgentDeck on a Mac, Windows, or Linux computer on the same network. The Android app is the dashboard; the computer daemon supplies the live sessions.</p>
+      </div>
+      <div class="actions">
+        <a class="btn primary" href="https://play.google.com/store/apps/details?id=dev.agentdeck" data-i18n="android.install">Get it on Google Play</a>
+        <a class="btn secondary" href="https://github.com/puritysb/AgentDeck/blob/master/docs/android.md#quick-start-google-play-or-github-apk" data-i18n="android.guide">Setup guide</a>
+      </div>
+    </aside>
     <div class="grid">
       <article class="device">
         <figure class="shot" style="margin:0 0 var(--s-4)"><img src="../media/macos-dashboard.png" alt="AgentDeck macOS dashboard screenshot" loading="lazy" onerror="this.parentNode.classList.add('missing')"></figure>
@@ -298,13 +313,13 @@
         <figure class="shot" style="margin:0 0 var(--s-4)"><img src="../media/android-tablet.jpg" alt="Android tablet running the AgentDeck Compose dashboard" loading="lazy" onerror="this.parentNode.classList.add('missing')"></figure>
         <div class="device-top"><h3>Android Tablet</h3><span class="badge native" data-i18n="b.native">Native</span></div>
         <p class="sub" data-i18n="d.android.tablet">Compose color dashboard — 60fps terrarium + HUD overlay.</p>
-        <div class="specs"><div class="spec"><span>Canvas</span><strong>Color LCD</strong></div><div class="spec"><span>Discovery</span><strong>mDNS · Wi-Fi WS</strong></div></div>
+        <div class="specs"><div class="spec"><span>Canvas</span><strong>Color LCD</strong></div><div class="spec"><span>Discovery</span><strong>mDNS · Wi-Fi WS</strong></div><div class="spec"><span>Install</span><strong><a href="https://play.google.com/store/apps/details?id=dev.agentdeck">Google Play</a></strong></div><div class="spec"><span>Needs</span><strong>Computer daemon</strong></div></div>
       </article>
       <article class="device">
         <figure class="shot" style="margin:0 0 var(--s-4)"><img src="../media/android-eink.jpg" alt="AgentDeck Android e-ink reader photography" loading="lazy" onerror="this.parentNode.classList.add('missing')"></figure>
         <div class="device-top"><h3>Android E-ink</h3><span class="badge native" data-i18n="b.native">Native</span></div>
         <p class="sub" data-i18n="d.android.eink">Reader-tuned Compose layouts for Crema, Onyx, Kobo, and Bigme — B&amp;W and Kaleido 3 color.</p>
-        <div class="specs"><div class="spec"><span>Refresh</span><strong>GC16 · DU · A2</strong></div><div class="spec"><span>Color</span><strong>B&amp;W + Kaleido 3</strong></div></div>
+        <div class="specs"><div class="spec"><span>Refresh</span><strong>GC16 · DU · A2</strong></div><div class="spec"><span>Color</span><strong>B&amp;W + Kaleido 3</strong></div><div class="spec"><span>Install</span><strong><a href="https://play.google.com/store/apps/details?id=dev.agentdeck">Google Play</a></strong></div><div class="spec"><span>Needs</span><strong>Computer daemon</strong></div></div>
       </article>
       <article class="device">
         <figure class="shot" style="margin:0 0 var(--s-4)"><img src="../media/tui-dashboard.png" alt="AgentDeck TUI dashboard in a terminal" loading="lazy" onerror="this.parentNode.classList.add('missing')"></figure>
@@ -523,6 +538,10 @@
         's.controls.p': '양방향 서피스입니다. 세션 상태를 보여주면서 터미널로 돌아가지 않고도 포커스·승인·중지·응답을 할 수 있습니다.',
         's.apps.h': '앱 & 터미널',
         's.apps.p': '각 앱은 따로 설계된 UI입니다 — macOS와 iOS/iPadOS는 비슷하지만 별개이고, Android 태블릿과 Android e-ink는 완전히 다른 레이아웃입니다. 의존성 없는 TUI는 같은 세션을 터미널 안에서 보여줍니다.',
+        'android.h': 'Android 앱 + 컴퓨터 데몬',
+        'android.p': 'Google Play에서 앱을 설치한 뒤, 같은 네트워크의 Mac·Windows·Linux 컴퓨터에서 AgentDeck을 실행하세요. Android 앱은 대시보드이고 컴퓨터 데몬이 라이브 세션을 제공합니다.',
+        'android.install': 'Google Play에서 받기',
+        'android.guide': '설정 가이드',
         's.esp32.h': 'ESP32 디스플레이',
         's.esp32.p': '네이티브 픽셀 그리드 위의 전용 펌웨어를 실제 세션 구동 중에 촬영했습니다. 픽셀 단위 펌웨어 프레임은 라이브 프리뷰에 있습니다.',
         's.pixel.h': '픽셀 디스플레이',
@@ -571,6 +590,10 @@
         's.controls.p': '双方向サーフェスです。セッション状態を表示しながら、ターミナルに戻らずにフォーカス・承認・停止・応答ができます。',
         's.apps.h': 'アプリ & ターミナル',
         's.apps.p': '各アプリは別設計のUIです — macOSとiOS/iPadOSは似ていて別物、AndroidタブレットとAndroid e-inkは完全に異なるレイアウトです。依存なしのTUIは同じセッションをターミナル内に表示します。',
+        'android.h': 'Androidアプリ + パソコンのdaemon',
+        'android.p': 'Google Playからアプリをインストールし、同じネットワークのMac・Windows・LinuxパソコンでAgentDeckを起動してください。Androidアプリはダッシュボードで、パソコンのdaemonがライブセッションを提供します。',
+        'android.install': 'Google Playで入手',
+        'android.guide': 'セットアップガイド',
         's.esp32.h': 'ESP32ディスプレイ',
         's.esp32.p': 'ネイティブピクセルグリッド上の専用ファームウェアを、実際のセッション動作中に撮影しました。ピクセル単位のファームウェアフレームはライブプレビューにあります。',
         's.pixel.h': 'ピクセルディスプレイ',

--- a/marketplace/play/LISTING.md
+++ b/marketplace/play/LISTING.md
@@ -8,9 +8,10 @@ created after 2023-11-13 does not apply — production is reachable directly.
 The APK on GitHub Releases stays; Play is an additional channel, not a
 replacement. Nothing in the app changes between them.
 
-## Account state — verified, app record created (2026-08-07)
+## Account state — published to production (2026-08-14)
 
-Both account verification steps are **done** and the app record now exists:
+Both account verification steps are **done**, and AgentDeck 1.0.6 (versionCode
+8) is live on the public [Google Play listing](https://play.google.com/store/apps/details?id=dev.agentdeck):
 
 | Field | Value |
 |---|---|
@@ -182,14 +183,15 @@ declarations.
 
 **3. Store listing** — *Grow → Store presence → Main store listing*. Short and
 full description are in this file, already inside Play's limits (74/80 and
-2,076/4,000). Assets from `marketplace/play/1.0.5/`:
+2,076/4,000). Current assets are in `marketplace/play/1.0.6/`:
 
 | Field | File |
 |---|---|
 | App icon | `icon-512.png` |
 | Feature graphic | `feature-graphic-1024x500.png` |
-| Phone screenshots | `phone-01-dashboard.png`, `phone-02-attention.png` |
-| Tablet (10") screenshots | `tablet-01-dashboard.png` |
+| Phone screenshots | `phone-01-dashboard.png` through `phone-04-calm.png` |
+| Tablet (7") screenshots | `tablet7-01-attention.png`, `tablet7-02-dashboard.png` |
+| Tablet (10") screenshots | `tablet10-01-dashboard.png`, `tablet10-02-timeline.png` |
 
 **4. App content** — privacy policy `https://puritysb.github.io/AgentDeck/#privacy`,
 data safety per the table above (no data collected; microphone is push-to-talk

--- a/scripts/pages-index.html
+++ b/scripts/pages-index.html
@@ -177,6 +177,15 @@
   .btn-primary:hover { background: var(--kelp-500); }
   .btn-ghost { background: var(--tide-100); color: var(--ink-800); border-color: var(--tide-200); }
   .btn-ghost:hover { background: var(--tide-200); }
+  .android-callout {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--s-6);
+    margin: var(--s-8) auto 0; max-width: 920px; padding: var(--s-5) var(--s-6);
+    text-align: left; background: var(--tide-100); border: 1px solid var(--tide-200);
+    border-radius: var(--r-2xl); box-shadow: var(--sh-card);
+  }
+  .android-callout strong { display: block; margin-bottom: var(--s-1); font-size: 17px; color: var(--ink-900); }
+  .android-callout p { margin: 0; color: var(--ink-500); font-size: 14px; }
+  .android-callout .actions { display: flex; gap: var(--s-2); flex: 0 0 auto; flex-wrap: wrap; }
 
   /* ── Stat strip ── */
   .stats { display: flex; justify-content: center; gap: var(--s-10); flex-wrap: wrap; margin: var(--s-8) 0 0; }
@@ -233,6 +242,7 @@
   @media (max-width: 720px) {
     /* GNB responsive rules live in the canonical GNB-CSS block above. */
     .wrap { padding: var(--s-12) var(--s-4) var(--s-16); }
+    .android-callout { align-items: flex-start; flex-direction: column; }
   }
 </style>
 </head>
@@ -270,11 +280,22 @@
     </p>
     <div class="cta">
       <a class="btn btn-primary" href="https://apps.apple.com/us/app/agentdeck-dashboard/id6784822497" data-i18n="cta.appstore">Get the Mac app</a>
+      <a class="btn btn-primary" href="https://play.google.com/store/apps/details?id=dev.agentdeck" data-i18n="cta.play">Get it on Google Play</a>
       <a class="btn btn-ghost" href="https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464" data-i18n="cta.streamdeck">Get the Stream Deck plugin</a>
       <a class="btn btn-ghost" href="https://www.npmjs.com/package/@agentdeck/setup" data-i18n="cta.npm">Install the CLI (npm)</a>
       <a class="btn btn-ghost" href="hardware/" data-i18n="cta.devices">Explore the devices</a>
       <a class="btn btn-ghost" href="demo/" data-i18n="cta.demo">Try the live preview</a>
     </div>
+    <aside class="android-callout" aria-label="Android setup">
+      <div>
+        <strong data-i18n="android.h">Android needs AgentDeck on your computer</strong>
+        <p data-i18n="android.p">The Android app is a companion dashboard. Start the Mac app or run <code>npx @agentdeck/setup</code> on macOS, Windows, or Linux, then keep both devices on the same network.</p>
+      </div>
+      <div class="actions">
+        <a class="btn btn-ghost" href="https://play.google.com/store/apps/details?id=dev.agentdeck" data-i18n="android.install">Install Android app</a>
+        <a class="btn btn-ghost" href="https://github.com/puritysb/AgentDeck/blob/master/docs/android.md#quick-start-google-play-or-github-apk" data-i18n="android.guide">3-step setup guide</a>
+      </div>
+    </aside>
     <div class="stats">
       <div class="stat"><div class="n">26</div><div class="l" data-i18n="stat.surfaces">display surfaces</div></div>
       <div class="stat"><div class="n">4</div><div class="l" data-i18n="stat.agents">coding agents</div></div>
@@ -402,10 +423,15 @@
         'hero.kicker': 'AI 코딩 에이전트를 위한 피지컬 컨트롤 서피스',
         'hero.lede': 'AgentDeck은 코딩 에이전트를 책상 위로 꺼내 놓습니다. 하나의 데몬 허브가 모든 세션을 26개 서피스에 라이브로 렌더링하고 — 키보드를 떠나지 않고 조종하게 해줍니다.',
         'cta.appstore': 'Mac 앱 받기',
+        'cta.play': 'Google Play에서 받기',
         'cta.streamdeck': 'Stream Deck 플러그인 받기',
         'cta.npm': 'CLI 설치 (npm)',
         'cta.devices': '디바이스 살펴보기',
         'cta.demo': '라이브 프리뷰 열기',
+        'android.h': 'Android에서는 컴퓨터의 AgentDeck이 필요합니다',
+        'android.p': 'Android 앱은 컴패니언 대시보드입니다. Mac 앱을 실행하거나 macOS·Windows·Linux에서 <code>npx @agentdeck/setup</code>을 실행한 뒤, 두 기기를 같은 네트워크에 두세요.',
+        'android.install': 'Android 앱 설치',
+        'android.guide': '3단계 설정 가이드',
         'stat.surfaces': '디스플레이 서피스',
         'stat.agents': '코딩 에이전트',
         'stat.local': '로컬 — 클라우드 없음',
@@ -430,10 +456,15 @@
         'hero.kicker': 'AIコーディングエージェントのためのフィジカルコントロールサーフェス',
         'hero.lede': 'AgentDeckはコーディングエージェントを机の上に連れ出します。ひとつのdaemonハブがすべてのセッションを26のサーフェスにライブ描画し — キーボードを離れずに操縦させてくれます。',
         'cta.appstore': 'Macアプリを入手',
+        'cta.play': 'Google Playで入手',
         'cta.streamdeck': 'Stream Deckプラグインを入手',
         'cta.npm': 'CLIをインストール (npm)',
         'cta.devices': 'デバイスを見る',
         'cta.demo': 'ライブプレビューを試す',
+        'android.h': 'Androidにはパソコン側のAgentDeckが必要です',
+        'android.p': 'Androidアプリはコンパニオンダッシュボードです。Macアプリを起動するか、macOS・Windows・Linuxで<code>npx @agentdeck/setup</code>を実行し、両方の端末を同じネットワークに接続してください。',
+        'android.install': 'Androidアプリをインストール',
+        'android.guide': '3ステップ設定ガイド',
         'stat.surfaces': 'ディスプレイサーフェス',
         'stat.agents': 'コーディングエージェント',
         'stat.local': 'ローカル — クラウドなし',


### PR DESCRIPTION
## What changed

- add Google Play discovery and live release status to the README
- add a three-step Android quick start explaining the required computer daemon
- add prominent Android setup callouts to the GitHub Pages landing and Devices pages
- localize the new Pages copy in Korean and Japanese
- update the Play listing runbook to reflect the production release and current assets

## Why

The Android app is a companion dashboard, but the public GitHub and Pages surfaces did not clearly explain that an AgentDeck daemon must be running on a computer on the same network. Google Play was also missing from the main install paths and the release status was stale.

## Validation

- `pnpm docs:check`
- `pnpm check-surface-mirrors`
- `node scripts/sync-pages-nav.mjs --check`
- `node scripts/sync-hardware-spec-cards.mjs --check`
- browser-verified desktop and 390px mobile layouts, including Korean localization