### PR TITLE
Prepare Android 1.0.9 for Google Play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ repository baseline, not a patch ceiling: any numeric `A.B.C` and `A.B.D` are
 mutually compatible. `pnpm verify-version` gates the shared `A.B` line and
 target-internal version consistency. See [RELEASING.md](RELEASING.md).
 
+## 1.0.9
+
+### Android dashboard
+
+- State the computer prerequisite on every disconnected screen, including the
+  high-contrast e-ink layout: open AgentDeck Dashboard on a Mac or run
+  `npx @agentdeck/setup` on macOS, Windows, or Linux
+- Publish the unified first-connection path from 1.0.8 to Google Play: prefer
+  USB when present, discover a daemon over Wi-Fi, allow code-based pairing on
+  camera-less readers, and stop retry storms after an unpaired device is
+  rejected
+- Keep the 1.0.8 e-ink usage-limit clipping fix in the Play release
+
 ## 1.0.20
 
 ### CLI and daemon — npm

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: required
 owner: Release maintainers
-reviewed: 2026-08-13
-revision: 2026-08-13
+reviewed: 2026-08-15
+revision: 2026-08-15
 source_of_truth: RELEASING.md
 validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-version]
 ---
@@ -17,7 +17,7 @@ validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-ve
 
 AgentDeck uses one `major.minor` compatibility line across every maintained surface. Two numeric `X.Y.Z` product versions are mutually compatible if and only if their first two components match. Patch values are ignored in both directions: for example, `1.0.1` and `1.0.9` are compatible regardless of which side is newer.
 
-Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI is at `1.0.19`; Stream Deck is at `1.0.5`; Android is at `1.0.8`; Apple is at `1.0.6`; ESP32 is at `1.0.4`; Ulanzi is at `1.0.3`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. **This sentence is a mirror, not a source** — take the declared values from `pnpm verify-version`, which reads each target's own manifest, and distinguish them from delivered state. Apple `1.0.6` build 5101 is live on macOS and iPhone/iPad, Stream Deck `1.0.5` is published, Ulanzi `1.0.3` is under review, Android Play `1.0.6` (versionCode 8) remains in review while Android `1.0.8` is available through GitHub Releases, and npm `1.0.19` is published (all last verified 2026-08-13 unless noted otherwise).
+Root [`VERSION`](VERSION) is the repository baseline and compatibility-line anchor, not a patch ceiling and not a runtime negotiation value. It currently reads **1.0.2**, so every maintained target must remain on compatibility line **1.0**. npm/CLI is at `1.0.20`; Stream Deck is at `1.0.5`; Android is at `1.0.9`; Apple is at `1.0.6`; ESP32 is at `1.0.4`; Ulanzi is at `1.0.3`. A target may also advance beyond root's patch without forcing unrelated targets or root to ship. **This sentence is a mirror, not a source** — take the declared values from `pnpm verify-version`, which reads each target's own manifest, and distinguish them from delivered state. Apple `1.0.6` build 5101 is live on macOS and iPhone/iPad, Stream Deck `1.0.5` is published, Ulanzi `1.0.3` is under review, Android Play `1.0.6` (versionCode 8) is live while Android `1.0.9` is prepared for Play and GitHub delivery, and npm `1.0.20` is published (all last verified 2026-08-15 unless noted otherwise).
 
 Run `pnpm verify-version` before every build or release. CI rejects a `major.minor` compatibility split or a target-internal mismatch. Release CI additionally requires a channel tag's full `X.Y.Z` to equal that target's own declared version; it does not compare the tag's patch with root `VERSION`.
 
@@ -54,7 +54,7 @@ On 2026-08-09 an agent with those tools loaded from the first turn never invoked
 | Surface                                                   | Target version                               | Independent monotonic value                                                | Tag / delivery                             |
 | --------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------ |
 | **Apple** (iOS+macOS)                                     | `apple/project.yml` `MARKETING_VERSION`      | `CURRENT_PROJECT_VERSION` (CI-owned)                                       | `apple-v*` → TestFlight / App Store        |
-| **Android**                                               | `android/app/build.gradle.kts` `versionName` | `versionCode` (currently 7)                                                | `android-v*` → APK Release / optional Play |
+| **Android**                                               | `android/app/build.gradle.kts` `versionName` | `versionCode` (currently 11)                                               | `android-v*` → APK Release / optional Play |
 | **npm** (`@agentdeck/hooks`, `shared`, `bridge`, `setup`) | public `package.json` files                  | npm registry version floor                                                 | `npm-v*` → manual publish                  |
 | **ESP32**                                                 | `esp32/src/config.h` `FIRMWARE_VERSION`      | build hash / epoch in firmware metadata                                    | `esp32-v*` → firmware Release              |
 | **Stream Deck**                                           | plugin manifest `Version` as `X.Y.Z.0`       | fourth component if a same-product-version plugin rebuild is ever required | `streamdeck-v*` → Elgato Maker portal      |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "dev.agentdeck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.0.8"
+        versionCode = 11
+        versionName = "1.0.9"
     }
 
     buildTypes {

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/common/ConnectionComponents.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/common/ConnectionComponents.kt
@@ -56,6 +56,13 @@ object ConnectionLexicon {
     const val RECONNECTING = "Reconnecting..."
 }
 
+/** First-run prerequisite shown anywhere a device has not found a daemon yet. */
+object ConnectionSetupGuide {
+    const val REQUIRED = "AgentDeck must be running on your computer."
+    const val MAC = "Mac: open AgentDeck Dashboard"
+    const val CLI = "macOS / Windows / Linux: npx @agentdeck/setup"
+}
+
 // ── Status Badge ──────────────────────────────────────────────────────
 
 @Composable
@@ -519,6 +526,17 @@ fun ConnectionPanel(
         }
 
         if (connectionStatus == ConnectionStatus.DISCONNECTED) {
+            Text(
+                text = ConnectionSetupGuide.REQUIRED,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "${ConnectionSetupGuide.MAC}\n${ConnectionSetupGuide.CLI}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
             UsbConnectButton(onClick = onConnectLocalhost)
 
             DiscoveredBridgeList(

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -2,6 +2,7 @@ package dev.agentdeck.ui.monitor
 
 import android.content.res.Configuration
 import dev.agentdeck.ui.common.ConnectionLexicon
+import dev.agentdeck.ui.common.ConnectionSetupGuide
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -413,6 +414,21 @@ private fun ConnectionOverlay(
                 color = AgentDeckColors.SlateText,
                 textAlign = TextAlign.Center,
             )
+
+            if (connectionStatus == ConnectionStatus.DISCONNECTED && !isReconnecting) {
+                Text(
+                    text = ConnectionSetupGuide.REQUIRED,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                    color = AgentDeckColors.WhiteText,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "${ConnectionSetupGuide.MAC}\n${ConnectionSetupGuide.CLI}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = AgentDeckColors.SlateText,
+                    textAlign = TextAlign.Center,
+                )
+            }
 
             if (isReconnecting) {
                 // Stop reconnecting button

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/screen/EinkMonitorScreen.kt
@@ -2,6 +2,7 @@ package dev.agentdeck.ui.screen
 
 import android.content.res.Configuration
 import dev.agentdeck.ui.common.ConnectionLexicon
+import dev.agentdeck.ui.common.ConnectionSetupGuide
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -738,6 +739,23 @@ private fun EinkNotConnectedScreen(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        if (connectionStatus == ConnectionStatus.DISCONNECTED) {
+            Text(
+                text = ConnectionSetupGuide.REQUIRED,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "${ConnectionSetupGuide.MAC}\n${ConnectionSetupGuide.CLI}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
 
         // Error message from last connection attempt
         if (lastError != null && connectionStatus == ConnectionStatus.DISCONNECTED) {

--- a/android/app/src/test/kotlin/dev/agentdeck/ui/common/ConnectionSetupGuideTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/ui/common/ConnectionSetupGuideTest.kt
@@ -1,0 +1,15 @@
+package dev.agentdeck.ui.common
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConnectionSetupGuideTest {
+    @Test
+    fun `disconnected guidance states the host prerequisite and both setup paths`() {
+        assertTrue(ConnectionSetupGuide.REQUIRED.contains("computer"))
+        assertTrue(ConnectionSetupGuide.MAC.contains("AgentDeck Dashboard"))
+        assertTrue(ConnectionSetupGuide.CLI.contains("npx @agentdeck/setup"))
+        assertTrue(ConnectionSetupGuide.CLI.contains("Windows"))
+        assertTrue(ConnectionSetupGuide.CLI.contains("Linux"))
+    }
+}

--- a/marketplace/play/LISTING.md
+++ b/marketplace/play/LISTING.md
@@ -102,13 +102,15 @@ unreadable, and the app's own header would collide with the wordmark.
 ## Short description (≤80 chars)
 
 ```
-Every coding agent session on one calm screen — running, waiting, or idle.
+Coding-agent dashboard — requires AgentDeck running on your computer.
 ```
 
 ## Full description (≤4000 chars)
 
 ```
-AgentDeck turns your Android tablet, phone, or e-ink reader into a live status surface for the AI coding agents running on your computer.
+AgentDeck is a companion dashboard. Before opening this app, run AgentDeck on a Mac, Windows, or Linux computer on the same network. On Mac, open the free AgentDeck Dashboard app. On any supported computer, you can instead run: npx @agentdeck/setup
+
+Your Android tablet, phone, or e-ink reader then becomes a live status surface for the AI coding agents running on that computer.
 
 Every session gets a row: which agent it is, which project it is in, which model it is using, and whether it is working, waiting on you, or idle. The screen repaints itself as that changes, so you can tell at a glance which of five sessions actually needs you.
 
@@ -149,6 +151,35 @@ AgentDeck is an independent project and is not affiliated with or endorsed by An
 
 Privacy policy: <https://puritysb.github.io/AgentDeck/#privacy>
 
+## Release notes — 1.0.9
+
+### English (US)
+
+```
+• Makes the required computer setup clear on the first connection screen.
+• Adds a unified USB, Wi-Fi discovery, and manual pairing path.
+• Prevents repeated connection attempts after a daemon rejects an unpaired device.
+• Fixes clipped usage-limit cards on e-ink screens.
+```
+
+### Korean
+
+```
+• 첫 연결 화면에서 컴퓨터에 AgentDeck을 실행해야 한다는 안내를 명확히 표시합니다.
+• USB, Wi-Fi 자동 검색, 수동 페어링 연결 경로를 하나로 통합했습니다.
+• 페어링되지 않은 기기가 거절된 뒤 반복해서 재접속하던 문제를 수정했습니다.
+• 전자책 단말기에서 사용량 제한 카드가 잘리던 문제를 수정했습니다.
+```
+
+### Japanese
+
+```
+• 初回接続画面で、パソコン側でAgentDeckの実行が必要なことを明確に表示します。
+• USB、Wi-Fi自動検出、手動ペアリングを一つの接続フローに統合しました。
+• 未ペアリング端末が拒否された後の繰り返し接続を防ぎます。
+• E Ink画面で利用上限カードが切れる問題を修正しました。
+```
+
 ## Declared permissions worth a note
 
 - `RECORD_AUDIO` — push-to-talk dictation to the user's own daemon.
@@ -172,10 +203,10 @@ cd android && ./gradlew bundleRelease     # → app/build/outputs/bundle/release
 ```
 
 Signing comes from `android/signing.properties` + `agentdeck-release.jks`
-(both gitignored, both local). The last verified build was **1.0.5 /
-versionCode 7**, 5.2 MB, `targetSdkVersion 36`. Play requires a strictly higher
-`versionCode` on every subsequent upload, so bump it before rebuilding if 7 has
-already been consumed.
+(both gitignored, both local). The current release target is **1.0.9 /
+versionCode 11**, `targetSdkVersion 36`. Play requires a strictly higher
+`versionCode` on every subsequent upload; production currently serves 1.0.6 /
+versionCode 8.
 
 **2. Create the app.** Console home → *앱 만들기 / Create app*. App name
 `AgentDeck`, default language, **App** (not game), **Free**. Accept the


### PR DESCRIPTION
## Summary
- make the required computer-side AgentDeck setup explicit on Android disconnected screens, including e-ink
- bump Android to 1.0.9 (versionCode 11)
- strengthen the Google Play short/full descriptions and add localized release notes
- refresh Android delivery documentation

## Verification
- `./gradlew :app:testDebugUnitTest --no-daemon`
- `pnpm verify-version`
- `node scripts/build-design-system-viewer.mjs --check`
- `bash scripts/build-android-release.sh`
- `./gradlew bundleRelease --no-daemon`
- signed APK: package `dev.agentdeck`, versionCode 11, versionName 1.0.9, targetSdk 36
- signed AAB: `jarsigner -verify`