### PR TITLE
Record provenance for all six agent marks, not just Kiro

### DIFF
--- a/design/RESOURCES.md
+++ b/design/RESOURCES.md
@@ -50,9 +50,35 @@ Agent marks identify compatible third-party tools; they do not imply sponsorship
 or endorsement. Preserve the exact upstream geometry and the source record below
 when regenerating constrained-device masks.
 
-| Mark | Upstream source | Source license | Pinned artifact |
-|---|---|---|---|
-| Kiro ghost | `@lobehub/icons-static-svg@1.94.0`, `icons/kiro.svg` | MIT (Lobe Icons package); Kiro is a mark of Amazon.com, Inc. or its affiliates | npm integrity `sha512-Inx1TYkjLH6YeHOIHeVW9+OM/xxRnk8TmcQVKquFUDBmE3X9sUuRGt7kALrrDBNNAbrWz7Qq6fAiFj9E9Mmw9Q==` |
+**Every** mark in `design/brand/` comes from one upstream package —
+`@lobehub/icons-static-svg@1.94.0` (MIT), npm integrity
+`sha512-Inx1TYkjLH6YeHOIHeVW9+OM/xxRnk8TmcQVKquFUDBmE3X9sUuRGt7kALrrDBNNAbrWz7Qq6fAiFj9E9Mmw9Q==`.
+This table used to hold Kiro alone, which read as though Kiro were the one mark
+with a licensing question; the other five were simply undocumented. They stand
+or fall together, and they stand: the path geometry of all six is byte-identical
+to upstream (verified 2026-08-16 against the packed tarball; `kiro.svg` differs
+only by a trailing newline and `antigravity.svg` only by a self-closing `<path/>`).
+
+The trademark column is a *statement of whose mark it is*, not an open question
+per row. Nominative use — naming a tool AgentDeck interoperates with — is the
+posture for all of them equally, and none of the holders has granted or been
+asked for anything beyond that.
+
+| Mark | Upstream file | Trademark holder |
+|---|---|---|
+| Claude Code | `icons/claudecode.svg` | Anthropic |
+| Codex | `icons/codex.svg` | OpenAI |
+| Antigravity | `icons/antigravity.svg` | Google |
+| Kiro ghost | `icons/kiro.svg` | Amazon.com, Inc. or its affiliates |
+| opencode | `icons/opencode.svg` | the opencode project |
+| OpenClaw | `icons/openclaw.svg` | the OpenClaw project |
+
+Re-verify a mark against upstream with:
+
+```bash
+npm pack @lobehub/icons-static-svg@1.94.0 && tar xzf lobehub-icons-static-svg-1.94.0.tgz
+diff package/icons/<name>.svg design/brand/<name>.svg   # path data must match
+```
 
 ## Derived / consumer surfaces (safe to regenerate, never edit)
 

--- a/shared/src/__tests__/brand-assets-contract.test.ts
+++ b/shared/src/__tests__/brand-assets-contract.test.ts
@@ -64,10 +64,27 @@ describe('canonical agent brand assets', () => {
     }
   });
 
-  it('records the pinned Kiro source and trademark boundary', () => {
+  // Pinned per mark rather than for Kiro alone. The table used to carry one row
+  // and this test enforced exactly that row, which is how five marks shipped for
+  // months with no recorded source while the sixth read as the one with a
+  // licensing question. They come from one MIT package; the contract is that
+  // none of them may ship without its source and holder written down.
+  it('records the upstream source and trademark holder for every agent mark', () => {
     const resources = read('design/RESOURCES.md');
     expect(resources).toContain('@lobehub/icons-static-svg@1.94.0');
-    expect(resources).toContain('Kiro is a mark of Amazon.com, Inc. or its affiliates');
+    // The integrity hash is what makes "upstream geometry" checkable later.
+    expect(resources).toContain('sha512-Inx1TYkjLH6YeHOIHeVW9+OM/xxRnk8TmcQVKquFUDBmE3X9sUuRGt7kALrrDBNNAbrWz7Qq6fAiFj9E9Mmw9Q==');
+    for (const [stem, holder] of [
+      ['claudecode', 'Anthropic'],
+      ['codex', 'OpenAI'],
+      ['antigravity', 'Google'],
+      ['kiro', 'Amazon.com, Inc. or its affiliates'],
+      ['opencode', 'the opencode project'],
+      ['openclaw', 'the OpenClaw project'],
+    ] as const) {
+      expect(resources).toContain(`icons/${stem}.svg`);
+      expect(resources).toContain(holder);
+    }
   });
 
   it('does not retain alternate logo-source dumps', () => {


### PR DESCRIPTION
Follow-up to #198, prompted by a fair question: *"we already use the Claude and Codex creatures — is Kiro different?"*

It isn't. The third-party provenance table held exactly one row — Kiro — which read as though Kiro were the mark carrying a licensing question. It was the opposite: **Kiro was the only mark whose source, license and npm integrity had ever been written down.** The other five had no record at all.

## They come from the same place

Verified against the packed tarball (`npm pack @lobehub/icons-static-svg@1.94.0`):

| Mark | vs upstream 1.94.0 |
|---|---|
| claudecode | byte-identical |
| codex | byte-identical |
| opencode | byte-identical |
| openclaw | byte-identical |
| kiro | trailing newline only — path data identical |
| antigravity | `<path></path>` → `<path/>` only — path data identical |

One MIT package, one integrity hash (confirmed against the registry and recomputed from the tarball), six marks, **no redrawing anywhere** — which is what `CLAUDE.md` design rule 6 requires.

## What changes

The trademark column becomes a statement of *whose mark it is*, not a per-row open question. Nominative use — naming a tool AgentDeck interoperates with — applies to the Anthropic, OpenAI, Google and Amazon marks identically. Singling out one holder implied a distinction that does not exist, and I was the one who implied it.

Adds the re-verification command so the claim stays checkable rather than becoming another undocumented assumption.

Gates: `docs:check`, `design-system:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)