### PR TITLE
Capture Kiro's spoken reply instead of its redacted Reasoning placeholder

### DIFF
--- a/bridge/src/__tests__/kiro-diagnostics.test.ts
+++ b/bridge/src/__tests__/kiro-diagnostics.test.ts
@@ -208,6 +208,43 @@ describe('Kiro privacy-safe diagnostics', () => {
     expect(JSON.stringify(report)).not.toContain('secret response');
   });
 
+  // A real v3 turn ends with a SECOND `assistant` record — `operationType:
+  // "Reasoning"`, content already redacted by Kiro to a literal "..." — and the
+  // newest assistant record wins. The fixture above has a single unqualified
+  // assistant record, which is why it passed while every real session came out
+  // with response === "...". Measured against 6 live transcripts on 2026-08-16.
+  it('takes the spoken reply, not the trailing redacted Reasoning block', () => {
+    const raw = [
+      JSON.stringify({ id: '1', timestamp: '2026-08-15T00:00:00Z', payload: { type: 'user', content: 'secret prompt' } }),
+      JSON.stringify({ id: '2', timestamp: '2026-08-15T00:00:01Z', payload: { type: 'turn_start', executionId: 'secret' } }),
+      JSON.stringify({
+        id: '3',
+        timestamp: '2026-08-15T00:00:02Z',
+        payload: { type: 'assistant', operationType: 'Say', content: 'the actual answer', executionId: 'secret' },
+      }),
+      JSON.stringify({
+        id: '4',
+        timestamp: '2026-08-15T00:00:03Z',
+        payload: {
+          type: 'assistant',
+          operationType: 'Reasoning',
+          content: '...',
+          reasoningSignature: 'secret-signature',
+          reasoningModelId: 'qdev::auto',
+        },
+      }),
+      JSON.stringify({ id: '5', timestamp: '2026-08-15T00:00:04Z', payload: { type: 'turn_end', executionId: 'secret' } }),
+    ].join('\n');
+
+    const summary = parseKiroTranscript(raw);
+    expect(summary.response).toBe('the actual answer');
+    expect(summary.state).toBe('idle');
+    // The reasoning block contributes nothing — neither its placeholder nor,
+    // should Kiro ever stop redacting it, its content.
+    expect(summary.response).not.toContain('...');
+    expect(JSON.stringify(summary)).not.toContain('secret-signature');
+  });
+
   it('discovers the measured v3 workspace/session directory layout', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agentdeck-kiro-v3-'));
     const sessionDir = join(root, 'workspace-hash', 'sess_test-v3');

--- a/bridge/src/kiro-session.ts
+++ b/bridge/src/kiro-session.ts
@@ -213,7 +213,21 @@ export function parseKiroTranscript(raw: string): KiroTranscriptSummary {
       continue;
     }
     if (kind === 'assistant') {
-      noteAssistant(contentText(data));
+      // Kiro writes one `assistant` record per operation, and the LAST one in a
+      // v3 turn is routinely `operationType: "Reasoning"` — a chain-of-thought
+      // block whose content Kiro has already redacted to a literal "...". Since
+      // the newest assistant record wins, taking it unconditionally captured
+      // that placeholder as the reply for every v3 session (measured against 6
+      // real transcripts: all six came out with response === "...", discarding
+      // the `operationType: "Say"` record that held the actual answer).
+      //
+      // Excluded by operation name, not by matching the "..." text: that string
+      // is a display artifact free to change, while the operation is the
+      // structural fact. Reasoning content must stay out of the timeline and
+      // APME on its own merits anyway.
+      if (firstString(envelope, ['operationType']) !== 'Reasoning') {
+        noteAssistant(contentText(data));
+      }
       turnOpen = true;
       continue;
     }


### PR DESCRIPTION
Found by running `agentdeck diag kiro` on real data and following through: **every v3 Kiro session came out of the parser with `response === "..."`.**

## What happens

A real v3 turn writes one `assistant` record per operation and ends with a second one:

| record | `operationType` | content |
|---|---|---|
| #3 | `Say` | the actual answer |
| #4 | `Reasoning` | `"..."` — Kiro has already redacted it |

`noteAssistant` overwrites `response` on each record, so the newest wins — and the newest is always that placeholder. The `Say` record holding the reply was read and thrown away.

Measured against the 6 v3 transcripts on this machine:

```
before:  6/6 sessions → response "..." (3 chars)
after:   real replies, longest 311 chars
```

## Why by operation name, not by the string

Matching `"..."` would pin a display artifact that is free to change. `operationType` is the structural fact. And reasoning is model chain-of-thought — it has no business in the timeline or in APME regardless of how Kiro renders it, so the exclusion is right on its own merits.

## Why the tests were green

The existing fixture had a **single unqualified `assistant` record** — a shape real Kiro never emits. It asserted `response: 'secret response'` and passed throughout. The regression test now carries both records in the order Kiro actually writes them, and also pins that the reasoning signature never reaches the summary.

Gates: vitest 3054/3054, typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)