### PR TITLE
Give Kiro sessions their name, mark and colour in the dashboard

### DIFF
--- a/apple/AgentDeck/Model/Protocol.swift
+++ b/apple/AgentDeck/Model/Protocol.swift
@@ -74,7 +74,14 @@ enum DashboardDataRules {
         case "codex-app": 3
         case "opencode": 4
         case "antigravity": 5
-        default: 6
+        // Kiro's own slots, and `others` moved off 6 to make room. This mirror
+        // had gone stale against shared/src/session-utils.ts (and against the
+        // D200H mirror, which was updated): every unknown agent shared rank 6
+        // with kiro-cli, so the dashboard and the D200H preview ordered the
+        // same session list differently.
+        case "kiro-cli": 6
+        case "kiro-ide": 7
+        default: 8
         }
     }
 

--- a/apple/AgentDeck/Rendering/StateColors.swift
+++ b/apple/AgentDeck/Rendering/StateColors.swift
@@ -29,6 +29,7 @@ enum StateColors {
         static let codexCli   = "#6366f1"  // indigo-500
         static let opencode   = "#F1ECEC"  // cream
         static let antigravity = "#5F6368"  // Google gray
+        static let kiro       = "#7C3AED"  // Kiro violet
         static let monitor    = "#94a3b8"  // slate-400
     }
 
@@ -77,6 +78,7 @@ enum StateColors {
         case "codex-app":   return Color(hex: Hex.codexCli)
         case "opencode":    return Color(hex: Hex.opencode)
         case "antigravity": return Color(hex: Hex.antigravity)
+        case "kiro-cli", "kiro-ide": return Color(hex: Hex.kiro)
         case "monitor":     return Color(hex: Hex.monitor)
         default:            return Color(hex: Hex.monitor)  // slate fallback
         }

--- a/apple/AgentDeck/UI/Common/SessionBrand.swift
+++ b/apple/AgentDeck/UI/Common/SessionBrand.swift
@@ -26,6 +26,17 @@ enum SessionBrand {
         default:            return Color.secondary
         }
     }
+
+    /// Whether a drawn brand mark exists for this agent.
+    ///
+    /// Surfaces that need to fall back to a placeholder must ask this instead
+    /// of restating which agents have a mark. A hand-kept list in
+    /// `SessionListPanel` fell behind the icon table the moment Kiro shipped —
+    /// the spec, the color and the accessibility label all knew `kiro-cli`
+    /// while that one switch did not, so every Kiro row drew the grey bullet.
+    static func hasBrandMark(for agentType: String?) -> Bool {
+        AgentBrandIconSpec.fromAgentType(agentType) != nil
+    }
 }
 
 /// Renders an agent's branded creature in its brand color.

--- a/apple/AgentDeck/UI/Monitor/AttentionTheaterHUD.swift
+++ b/apple/AgentDeck/UI/Monitor/AttentionTheaterHUD.swift
@@ -40,6 +40,8 @@ struct AttentionTheaterHUD: View {
         case "openclaw":    return "OpenClaw"
         case "opencode":    return "OpenCode"
         case "antigravity": return "Antigravity"
+        case "kiro-cli":    return "Kiro CLI"
+        case "kiro-ide":    return "Kiro IDE"
         default:            return session.agentType?.capitalized ?? "Agent"
         }
     }

--- a/apple/AgentDeck/UI/Monitor/SessionListPanel.swift
+++ b/apple/AgentDeck/UI/Monitor/SessionListPanel.swift
@@ -264,6 +264,8 @@ struct SessionListPanel: View {
             case "openclaw": return "OpenClaw"
             case "opencode": return "OpenCode"
             case "antigravity": return "Antigravity"
+            case "kiro-cli": return "Kiro CLI"
+            case "kiro-ide": return "Kiro IDE"
             default: break
             }
         }
@@ -389,10 +391,15 @@ struct SessionListPanel: View {
 
     // MARK: - Brand Icons (SVG path data, viewBox 0 0 24 24)
 
+    /// Ask the icon table whether it has a mark, rather than restating which
+    /// agents have one. The literal list here fell behind `AgentBrandIconSpec`
+    /// the moment Kiro shipped: the spec, the brand color, the creature and the
+    /// accessibility label all knew `kiro-cli`, and this switch did not, so
+    /// every Kiro row in the dashboard rendered as the grey bullet below —
+    /// the fallback for an agent nobody has drawn yet.
     @ViewBuilder
     private func agentIconView(for agentType: String?) -> some View {
-        switch agentType {
-        case "claude-code", "codex-cli", "codex-app", "openclaw", "opencode", "antigravity":
+        if SessionBrand.hasBrandMark(for: agentType) {
             AgentBrandIcon(
                 agentType: agentType,
                 tint: SessionBrand.color(for: agentType),
@@ -400,7 +407,7 @@ struct SessionListPanel: View {
                 contentInset: sessionListIconInset(for: agentType)
             )
             .frame(width: 16, height: 16)
-        default:
+        } else {
             Text("●")
                 .font(.system(size: 8))
                 .foregroundStyle(TerrariumHUD.subtext)
@@ -432,6 +439,8 @@ struct SessionListPanel: View {
         case "openclaw": return "OpenClaw"
         case "opencode": return "OpenCode"
         case "antigravity": return "Antigravity"
+        case "kiro-cli": return "Kiro CLI"
+        case "kiro-ide": return "Kiro IDE"
         default: return "Agent"
         }
     }

--- a/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
+++ b/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
@@ -1184,6 +1184,8 @@ struct TimelineStripView: View {
         case "openclaw": "OpenClaw"
         case "opencode": "OpenCode"
         case "antigravity": "Antigravity"
+        case "kiro-cli": "Kiro CLI"
+        case "kiro-ide": "Kiro IDE"
         case "daemon": "Daemon"
         case nil: ""
         default: "Agent"
@@ -1979,6 +1981,8 @@ struct TimelineSessionFilter: Equatable {
         case "codex-app": return "Codex App"
         case "opencode": return "OpenCode"
         case "antigravity": return "Antigravity"
+        case "kiro-cli": return "Kiro CLI"
+        case "kiro-ide": return "Kiro IDE"
         default: return sessionId
         }
     }


### PR DESCRIPTION
Reported from the running app: Kiro rows showed a grey bullet and no agent name.

Checked the producer first — the daemon broadcasts `agentType: "kiro-cli"` correctly (read live off its WebSocket) — so the gap was entirely on the Swift side, in surfaces that spell the agent roster out again instead of asking.

## The icon

`SessionListPanel.agentIconView` carried its own literal list:

```swift
case "claude-code", "codex-cli", "codex-app", "openclaw", "opencode", "antigravity":
    AgentBrandIcon(...)
default:
    Text("●")          // ← what every Kiro row rendered
```

`AgentBrandIconSpec`, `SessionBrand.color`, the accessibility label and `CreatureGeometry` all knew `kiro-cli`. That one switch didn't, so Kiro fell to the placeholder meant for agents nobody has drawn yet. It now asks `SessionBrand.hasBrandMark(for:)`, so the next agent cannot reintroduce this.

## The names

Five more switches had no kiro case, falling back to `"Agent"`, `"Kiro-cli"`, or the raw session id: the session row, the group header, the attention HUD, and both timeline label paths. Added directly — their long/short label styles differ on purpose, so folding them into one helper would change existing agents' text.

## A stale SSOT mirror

`Model/Protocol.swift agentTypeRank` had no kiro cases and `default: 6`, colliding with kiro-cli's intended rank 6 in `shared/src/session-utils.ts`. The **D200H mirror of the same rule had been updated**, so the dashboard and the D200H preview ordered one session list two different ways.

## Verified

Built and ran the app against the live daemon.

| | before | after |
|---|---|---|
| mark | grey `●` | violet Kiro ghost |
| name | project name / "Agent" | **Kiro CLI** |

## Not fixed here — the terrarium

Visible in the same screenshot: **the dashboard terrarium has no Kiro creature.** Its octopus bucket is defined by *exclusion* —

```swift
let primaryIsOctopus = agentType != "daemon" && agentType != "openclaw"
    && agentType != "codex-cli" && … && agentType != "antigravity"
```

— so an unlisted agent is silently a Claude octopus. Kiro sessions currently swim as Claude.

The two available edits are both wrong on their own: adding kiro to the deny-lists makes live Kiro sessions *vanish* from the tank, and drawing a creature is a design task with an Android mirror (~230–300 lines each, cf. `OpenCodeCreature` / `AntigravityCreature`) plus idle/working/asking behaviour I shouldn't invent. Same gap in the Pixoo/Timebox/iDotMatrix `creatureAgents` sets, `TUITerrariumRenderer`'s glyph and short-label tables, and `SessionSlotRenderer`'s palette.

Worth noting the two polarities that produced one bug each: the icon list defaults to *exclude* (unknown agent → placeholder), the terrarium bucket defaults to *include* (unknown agent → Claude).

Gates: macOS `xcodebuild` BUILD SUCCEEDED; verified visually in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)