### PR TITLE
Give Kiro a terrarium creature of its own, on every surface

### DIFF
--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
@@ -102,6 +102,25 @@ fun layoutAntigravityCreatures(count: Int): List<CreatureSlot> {
     )
 }
 
+/** Kiro ghosts — top-left band, INSIDE the visible tank. Above the octopuses
+ * and left of the Codex clouds (0.30+). The x floor is 0.21, not the tank edge:
+ * the session-list HUD covers roughly the left 0.19, and a band starting at
+ * 0.08 put the ghosts behind it. The right side is the upstream HUD plus the
+ * Antigravity strip and crayfish floor. */
+fun layoutKiroCreatures(count: Int): List<CreatureSlot> {
+    return layoutBand(
+        count = count,
+        xMin = 0.21f,
+        xMax = 0.32f,
+        frontY = 0.10f,
+        backY = 0.20f,
+        singleRowLimit = 3,
+        baseScale = 0.96f,
+        minScale = 0.56f,
+        creatureWidth = 0.086f,
+    )
+}
+
 /**
  * Hard floor for the crowd-driven shrink. Below the per-band [minScale] so
  * tightly packed bands can still shrink enough to honor the overlap cap before
@@ -204,5 +223,38 @@ fun layoutWorkerCrayfish(
             mainY + sin(angle) * arcRadius,
             0.5f,
         )
+    }
+}
+
+/**
+ * Per-entry slots for the vector-mark creature list, which holds OpenCode rings
+ * and Kiro ghosts together (they share a class, not a band). Each entry is
+ * placed from ITS OWN band so the two platforms agree on where a session is
+ * drawn — the layout mirrors are only a single source of truth if both sides
+ * ask the same function for the same agent.
+ */
+/** Single spelling of "is this a Kiro session", shared by the layout split
+ * and the state builder. Two copies of this predicate is how one surface
+ * ends up placing a ghost in a band the other does not. */
+internal fun isKiroAgentType(type: String?): Boolean =
+    type == "kiro-cli" || type == "kiro-ide"
+
+internal fun vectorMarkSlots(creatures: List<AgentCreatureState>): List<CreatureSlot> {
+    val kiroCount = creatures.count { isKiroAgentType(it.agentType) }
+    val openCodeSlots = layoutOpenCodeCreatures(creatures.size - kiroCount)
+    val kiroSlots = layoutKiroCreatures(kiroCount)
+    val fallback = CreatureSlot(0.55f, 0.40f, 1.0f)
+    var openCodeIndex = 0
+    var kiroIndex = 0
+    return creatures.map { creature ->
+        if (isKiroAgentType(creature.agentType)) {
+            val slot = kiroSlots.getOrElse(kiroIndex) { kiroSlots.lastOrNull() ?: fallback }
+            kiroIndex++
+            slot
+        } else {
+            val slot = openCodeSlots.getOrElse(openCodeIndex) { openCodeSlots.lastOrNull() ?: fallback }
+            openCodeIndex++
+            slot
+        }
     }
 }

--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/CreatureLayout.kt
@@ -239,6 +239,11 @@ fun layoutWorkerCrayfish(
 internal fun isKiroAgentType(type: String?): Boolean =
     type == "kiro-cli" || type == "kiro-ide"
 
+/** Agent types drawn as the octopus. SSOT-mirrored from CODING_AGENTS in
+ * bridge/src/pixoo/pixoo-renderer.ts. Kept an allow-list so an unknown agent
+ * renders as nothing rather than as Claude. */
+internal fun isOctopusAgentType(type: String?): Boolean = type == "claude-code"
+
 internal fun vectorMarkSlots(creatures: List<AgentCreatureState>): List<CreatureSlot> {
     val kiroCount = creatures.count { isKiroAgentType(it.agentType) }
     val openCodeSlots = layoutOpenCodeCreatures(creatures.size - kiroCount)

--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
@@ -199,7 +199,11 @@ fun DashboardState.toTerrariumState(
     fun isKiroAgent(type: String?): Boolean = isKiroAgentType(type)
 
     // Primary agent — brand-mark creatures are routed to their dedicated render lists below.
-    if (agentState != AgentState.DISCONNECTED && !isDaemonLike && agentType != "openclaw" && !isCodexAgent(agentType) && agentType != "opencode" && agentType != "antigravity" && !isKiroAgent(agentType)) {
+    // ALLOW-list, not a deny-list: an agentType this build has never heard of
+    // must render as nothing, never as a Claude octopus wearing another
+    // agent's identity. Daemon and dashboard ship separately, so unknown
+    // types WILL arrive. Mirrors CODING_AGENTS in pixoo-renderer.ts.
+    if (agentState != AgentState.DISCONNECTED && !isDaemonLike && isOctopusAgentType(agentType)) {
         agents.add(
             AgentCreatureState(
                 sessionId = sessionId ?: "primary",
@@ -221,7 +225,7 @@ fun DashboardState.toTerrariumState(
             continue // skip self (null guard)
         }
         val siblingType = sibling.agentType
-        if (siblingType == "openclaw" || siblingType == "daemon" || isCodexAgent(siblingType) || siblingType == "opencode" || siblingType == "antigravity" || isKiroAgent(siblingType)) {
+        if (!isOctopusAgentType(siblingType)) {
             continue // not octopus
         }
         agents.add(

--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/TerrariumState.kt
@@ -196,7 +196,7 @@ fun DashboardState.toTerrariumState(
     val agents = mutableListOf<AgentCreatureState>()
 
     fun isCodexAgent(type: String?): Boolean = type == "codex-cli" || type == "codex-app"
-    fun isKiroAgent(type: String?): Boolean = type == "kiro-cli" || type == "kiro-ide"
+    fun isKiroAgent(type: String?): Boolean = isKiroAgentType(type)
 
     // Primary agent — brand-mark creatures are routed to their dedicated render lists below.
     if (agentState != AgentState.DISCONNECTED && !isDaemonLike && agentType != "openclaw" && !isCodexAgent(agentType) && agentType != "opencode" && agentType != "antigravity" && !isKiroAgent(agentType)) {

--- a/android/app/src/main/kotlin/dev/agentdeck/terrarium/renderer/EinkRenderer.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/terrarium/renderer/EinkRenderer.kt
@@ -358,7 +358,7 @@ private fun renderEinkFrame(
 
     // OpenCode creatures (nested-square logo agents)
     if (state.openCodeCreatures.isNotEmpty()) {
-        val openCodeSlots = dev.agentdeck.terrarium.layoutOpenCodeCreatures(state.openCodeCreatures.size)
+        val openCodeSlots = dev.agentdeck.terrarium.vectorMarkSlots(state.openCodeCreatures)
         for (i in state.openCodeCreatures.indices) {
             val slot = openCodeSlots.getOrElse(i) { openCodeSlots.last() }
             drawEinkOpenCode(canvas, paint, width, height,

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/MonitorScreen.kt
@@ -101,6 +101,7 @@ import dev.agentdeck.terrarium.layoutOctopuses
 import dev.agentdeck.terrarium.layoutOctopusesByProject
 import dev.agentdeck.terrarium.layoutCloudCreatures
 import dev.agentdeck.terrarium.layoutOpenCodeCreatures
+import dev.agentdeck.terrarium.vectorMarkSlots
 import dev.agentdeck.terrarium.layoutAntigravityCreatures
 import dev.agentdeck.terrarium.layoutWorkerCrayfish
 import dev.agentdeck.terrarium.renderer.ColorTerrariumCanvas
@@ -632,7 +633,7 @@ private fun ColorTerrariumBackground(
     }
 
     // OpenCode creatures (nested-square logo agents)
-    val openCodeSlots = layoutOpenCodeCreatures(state.openCodeCreatures.size)
+    val openCodeSlots = vectorMarkSlots(state.openCodeCreatures)
     val openCodeCreatures = remember { mutableStateListOf<OpenCodeCreature>() }
 
     LaunchedEffect(state.openCodeCreatures) {

--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		1755CE50FB5EBB217B02AED7 /* TimeboxDivoomPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE667561A919A52759C5225E /* TimeboxDivoomPacket.swift */; };
 		1833E28AEE39E209E4AA45B6 /* DaemonOfflineAffordance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F99A265E8C83A287F7DB71 /* DaemonOfflineAffordance.swift */; };
 		189B8DE0AF541394BFDFA664 /* DaemonVoiceAssistant.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF3E9B667BE141F81917F89 /* DaemonVoiceAssistant.swift */; };
+		18B5EB50FB19AB4013D78F74 /* UnknownAgentForwardCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A472C32952DF18A4C77A969A /* UnknownAgentForwardCompatTests.swift */; };
 		19CDAF0B79C1F843366192C0 /* DevicePreviewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */; };
 		1A25F581608D3C282D70FAF5 /* GaugeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE70EEDDCA2199E894D275 /* GaugeBar.swift */; };
 		1BE430CE7A81C3C2B7160250 /* StateColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB2E51F6EFD29341EB6127 /* StateColors.swift */; };
@@ -375,6 +376,7 @@
 		D7E95F09BC44D47D05B4EC06 /* CodexFreshnessRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC487120E810897B3BF0FC4 /* CodexFreshnessRules.generated.swift */; };
 		D80DDBEF3EDB811EFF6B834A /* DaemonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BD296835DE366BFDBB15B9 /* DaemonService.swift */; };
 		D863C121DC06035A0007914B /* WaterSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F134F38758589B5D47652C8 /* WaterSurface.swift */; };
+		D8B0E597FE6FF31AE5F7B0EB /* UnknownAgentForwardCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A472C32952DF18A4C77A969A /* UnknownAgentForwardCompatTests.swift */; };
 		D8EC7333D6CEB08ED84E4BC2 /* ProviderRailEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBA59C83638DB2F6B90C44A /* ProviderRailEvaluatorTests.swift */; };
 		D98FDB40FEA236A6370DE45E /* SessionPushRegisterMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB88D8C2921CB4B93EC8B9 /* SessionPushRegisterMergeTests.swift */; };
 		DAD883DE12AFEE958A79595A /* HookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E0B3C7EBBFFD8C2EB08F11 /* HookInstaller.swift */; };
@@ -612,6 +614,7 @@
 		9E6E252A5DCAC5E298C21473 /* SessionBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionBrand.swift; sourceTree = "<group>"; };
 		9F9B51FC480E3419A6334A20 /* SandDisturbance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandDisturbance.swift; sourceTree = "<group>"; };
 		A0B6AFDC194533BFA388DECA /* AppReviewPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReviewPrompt.swift; sourceTree = "<group>"; };
+		A472C32952DF18A4C77A969A /* UnknownAgentForwardCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownAgentForwardCompatTests.swift; sourceTree = "<group>"; };
 		A4EB2E51F6EFD29341EB6127 /* StateColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateColors.swift; sourceTree = "<group>"; };
 		A5D17A24E0C5B16A097D62E9 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		A70843624A0EEB9E63435EC5 /* PlanktonSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanktonSystem.swift; sourceTree = "<group>"; };
@@ -787,6 +790,7 @@
 				7847FA7381FB8075331B0F12 /* TimelineTests.swift */,
 				7D05CE505E1EC5729C69752E /* TopologyRailHelpersTests.swift */,
 				CAA529E02014523C9AD2CD0E /* UnauthorizedCloseCodeTests.swift */,
+				A472C32952DF18A4C77A969A /* UnknownAgentForwardCompatTests.swift */,
 				B9841FBF8AFC5D5C65809F8B /* UsageAPIClientThreadingTests.swift */,
 			);
 			path = AgentDeckTests;
@@ -1414,6 +1418,7 @@
 				DBE7242898F7F03CB3463B6D /* TimelineTests.swift in Sources */,
 				AFF81F64527A02F26615AB61 /* TopologyRailHelpersTests.swift in Sources */,
 				1326D167890900B50643E129 /* UnauthorizedCloseCodeTests.swift in Sources */,
+				18B5EB50FB19AB4013D78F74 /* UnknownAgentForwardCompatTests.swift in Sources */,
 				CB4DB4586BC5196412C3429C /* UsageAPIClientThreadingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1461,6 +1466,7 @@
 				4F6DEDF8FD3A71AFD059278D /* TimelineTests.swift in Sources */,
 				0E60D3FBC7626624FF7B5A2E /* TopologyRailHelpersTests.swift in Sources */,
 				C15E3EF9660F1EAD28AE33BF /* UnauthorizedCloseCodeTests.swift in Sources */,
+				D8B0E597FE6FF31AE5F7B0EB /* UnknownAgentForwardCompatTests.swift in Sources */,
 				DD57AEBB6F916C984C85F48F /* UsageAPIClientThreadingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		3C2668742A6920AB392BA3EA /* CrayfishCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD30721AD4CBA74DD049A1F /* CrayfishCreature.swift */; };
 		3C58A78598B065AC2EDD44B8 /* BridgeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F34DE9E44936BAC6D96F19 /* BridgeDiscovery.swift */; };
 		3DF6BC8D6B4841A3EF370023 /* ObservedAskUserQuestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767EE1D15C8564C2A5AC5713 /* ObservedAskUserQuestionTests.swift */; };
+		3EF77B464A70587DAF191FFD /* KiroCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF126528728AEF6E07C3C7ED /* KiroCreature.swift */; };
 		3F707E15A1A8E2707F36796D /* TerrariumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BCA057209786EF62993762 /* TerrariumView.swift */; };
 		4063C8A5D6C17B415AA11D2A /* AgentStatusIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F4A4AE7D86132501CA1096 /* AgentStatusIcon.swift */; };
 		42A735D885E2F8A95F75673D /* GatewayProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCC68BE56702DFD637FFE02 /* GatewayProbe.swift */; };
@@ -403,6 +404,7 @@
 		E55963FC1E5C23442A500CE4 /* CodexOtelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE1D983995443760EDE3A4A /* CodexOtelParserTests.swift */; };
 		E59E0351EAA083B954985854 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3B886C1F467A011D242E296E /* PrivacyInfo.xcprivacy */; };
 		E5B1774D921E5B4C508D73A0 /* AgentStateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F84E0AB4261F8308A45186 /* AgentStateHolder.swift */; };
+		E8484D2A78F8F3C35EAD8204 /* KiroCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF126528728AEF6E07C3C7ED /* KiroCreature.swift */; };
 		E940E2714946D07856C8FB37 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5200B4548DFE9F98AEE8D504 /* ContentView.swift */; };
 		E98F3FC6D7134E8E65163D93 /* OnboardingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302810B07A9DC093700A7C31 /* OnboardingSheet.swift */; };
 		EA32929C78C6088451DDF476 /* TimelineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95824B0CF6571507DBAF27C5 /* TimelineStore.swift */; };
@@ -673,6 +675,7 @@
 		E9342D343A701D2BDC92C845 /* PixooModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixooModule.swift; sourceTree = "<group>"; };
 		EB1470AE66304DC838676016 /* ApmeJudgeDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApmeJudgeDetect.swift; sourceTree = "<group>"; };
 		EC83A78EA479592D015AA2F6 /* UtilityProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityProxy.swift; sourceTree = "<group>"; };
+		EF126528728AEF6E07C3C7ED /* KiroCreature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KiroCreature.swift; sourceTree = "<group>"; };
 		F028824993D611B356EA86D3 /* SessionFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionFormatters.swift; sourceTree = "<group>"; };
 		F15F55435772A15B8F0E92C1 /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
 		F2E6BEE1A730418C1EBDC048 /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
@@ -735,6 +738,7 @@
 				3FD30721AD4CBA74DD049A1F /* CrayfishCreature.swift */,
 				05A9A073192C93C1277AE490 /* Creature.swift */,
 				57722317EDF1D567981112DE /* DataParticleSystem.swift */,
+				EF126528728AEF6E07C3C7ED /* KiroCreature.swift */,
 				776467350B975D0CA1A18E84 /* OctopusCreature.swift */,
 				4C2005980598D651492006A3 /* OpenCodeCreature.swift */,
 			);
@@ -1551,6 +1555,7 @@
 				B6674B508C256A29E68E3E12 /* InkDeckPreview.swift in Sources */,
 				CF27ABB66E4B268C31C44E6E /* IntegrationsView.swift in Sources */,
 				54A5C71CB7264DAFC6FF694D /* KelpField.swift in Sources */,
+				3EF77B464A70587DAF191FFD /* KiroCreature.swift in Sources */,
 				ABE80C830C69CB0A2D03A767 /* LightRaySystem.swift in Sources */,
 				5ADCEA267661D3C4934EC6BD /* LocalCodexAppObserver.swift in Sources */,
 				E35D8D73F3FFFCD795B1236A /* LocalSessionDiscovery.swift in Sources */,
@@ -1733,6 +1738,7 @@
 				4578F976C71274F3C7C2620C /* InkDeckPreview.swift in Sources */,
 				8B7311262C05E2B32F563760 /* IntegrationsView.swift in Sources */,
 				0AC3F569F362D121D985EA52 /* KelpField.swift in Sources */,
+				E8484D2A78F8F3C35EAD8204 /* KiroCreature.swift in Sources */,
 				7B25A56536275C7DF023DFEB /* LightRaySystem.swift in Sources */,
 				A0E4BE7512FF07BD0DFDB2E0 /* LocalCodexAppObserver.swift in Sources */,
 				5B1640167CAEBC66B8D0BE35 /* LocalSessionDiscovery.swift in Sources */,

--- a/apple/AgentDeck/Daemon/Modules/IDotMatrixModule.swift
+++ b/apple/AgentDeck/Daemon/Modules/IDotMatrixModule.swift
@@ -357,7 +357,10 @@ actor IDotMatrixModule: DeviceModule {
         switch type {
         case "state_update":
             let eventAgentType = event["agentType"] as? String
-            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity"]
+            // Kiro included: MicroGlyphs already carries its official 24/9/8px
+            // masks and violet, so leaving it out of this gate was the only thing
+            // keeping the ghost off the dot-matrix devices.
+            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity", "kiro-cli", "kiro-ide"]
             if let at = eventAgentType, creatureAgents.contains(at) {
                 cachedState = event["state"] as? String ?? "disconnected"
                 cachedProject = event["projectName"] as? String

--- a/apple/AgentDeck/Daemon/Modules/PixooModule.swift
+++ b/apple/AgentDeck/Daemon/Modules/PixooModule.swift
@@ -407,7 +407,10 @@ actor PixooModule: DeviceModule {
             let eventAgentType = event["agentType"] as? String
             // Only update primary state from creature agents — daemon/openclaw
             // events would otherwise overwrite the coding agent's PROCESSING state
-            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity"]
+            // Kiro included: MicroGlyphs already carries its official 24/9/8px
+            // masks and violet, so leaving it out of this gate was the only thing
+            // keeping the ghost off the dot-matrix devices.
+            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity", "kiro-cli", "kiro-ide"]
             if let at = eventAgentType, creatureAgents.contains(at) {
                 cachedState = event["state"] as? String ?? "disconnected"
                 cachedProject = event["projectName"] as? String

--- a/apple/AgentDeck/Daemon/Modules/TimeboxModule.swift
+++ b/apple/AgentDeck/Daemon/Modules/TimeboxModule.swift
@@ -320,7 +320,10 @@ actor TimeboxModule: DeviceModule {
         switch type {
         case "state_update":
             let eventAgentType = event["agentType"] as? String
-            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity"]
+            // Kiro included: MicroGlyphs already carries its official 24/9/8px
+            // masks and violet, so leaving it out of this gate was the only thing
+            // keeping the ghost off the dot-matrix devices.
+            let creatureAgents: Set<String> = ["claude-code", "codex-cli", "codex-app", "opencode", "antigravity", "kiro-cli", "kiro-ide"]
             if let at = eventAgentType, creatureAgents.contains(at) {
                 cachedState = event["state"] as? String ?? "disconnected"
                 cachedProject = event["projectName"] as? String

--- a/apple/AgentDeck/Rendering/SessionSlotRenderer.swift
+++ b/apple/AgentDeck/Rendering/SessionSlotRenderer.swift
@@ -74,6 +74,8 @@ private struct AgentSlotPalette {
             return .init(primary: Color(hex: "#8BA4FF"), secondary: Color(hex: "#5981FF"))
         case "openclaw":
             return .init(primary: Color(hex: "#FF6B6B"), secondary: Color(hex: "#CC3333"))
+        case "kiro-cli", "kiro-ide":
+            return .init(primary: Color(hex: "#A78BFA"), secondary: Color(hex: "#7C3AED"))
         default: // opencode + unknown
             return .init(primary: Color(hex: "#F1ECEC"), secondary: Color(hex: "#AFAFAF"))
         }

--- a/apple/AgentDeck/Rendering/SessionSlotRenderer.swift
+++ b/apple/AgentDeck/Rendering/SessionSlotRenderer.swift
@@ -76,8 +76,13 @@ private struct AgentSlotPalette {
             return .init(primary: Color(hex: "#FF6B6B"), secondary: Color(hex: "#CC3333"))
         case "kiro-cli", "kiro-ide":
             return .init(primary: Color(hex: "#A78BFA"), secondary: Color(hex: "#7C3AED"))
-        default: // opencode + unknown
+        case "opencode":
             return .init(primary: Color(hex: "#F1ECEC"), secondary: Color(hex: "#AFAFAF"))
+        default:
+            // Unknown agent — a neutral slate, not OpenCode's cream. The
+            // daemon can name an agent this build has never seen, and it
+            // should read as "some agent", not as a specific other one.
+            return .init(primary: Color(hex: "#B8BEC8"), secondary: Color(hex: "#7A828F"))
         }
     }
 }

--- a/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
+++ b/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
@@ -362,7 +362,11 @@ private enum TerrariumGridBuilder {
             return state == "processing" ? ["(", "\u{25D5}", ")"]
                                          : ["(", "\u{25CB}", ")"]
         default:
-            return ["(", "o", ")"]
+            // An agentType this build does not know renders as a neutral
+            // marker, NOT as Claude's "(o)". The daemon ships separately and
+            // will send types added after this build; borrowing another
+            // agent's glyph makes a new agent look like an old one.
+            return ["[", "\u{00B7}", "]"]
         }
     }
 

--- a/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
+++ b/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
@@ -356,6 +356,11 @@ private enum TerrariumGridBuilder {
             // crayfish — pincers
             return state == "processing" ? ["\u{03BB}", "\u{25C9}", "\u{03BB}"]
                                          : ["\u{03BB}", "o", "\u{03BB}"]
+        case "kiro-cli", "kiro-ide":
+            // ghost - domed head between parentheses; the filled disc marks
+            // WORKING, matching how the other creatures signal it here.
+            return state == "processing" ? ["(", "\u{25D5}", ")"]
+                                         : ["(", "\u{25CB}", ")"]
         default:
             return ["(", "o", ")"]
         }
@@ -369,6 +374,8 @@ private enum TerrariumGridBuilder {
         case "opencode":    return "oc"
         case "antigravity": return "ag"
         case "openclaw":    return "ow"
+        case "kiro-cli":    return "kc"
+        case "kiro-ide":    return "ki"
         default:            return "a\(index)"
         }
     }

--- a/apple/AgentDeck/Terrarium/CreatureLayout.swift
+++ b/apple/AgentDeck/Terrarium/CreatureLayout.swift
@@ -69,6 +69,25 @@ enum CreatureLayout {
         )
     }
 
+    /// Kiro ghosts — top-left band, INSIDE the visible tank. Above the
+    /// octopuses and left of the Codex clouds (0.30+). The x floor is 0.21,
+    /// not the tank edge: the session-list HUD covers roughly the left 0.19,
+    /// and a band starting at 0.08 put the ghosts behind it. The right side is
+    /// the upstream HUD plus the Antigravity strip and crayfish floor.
+    static func layoutKiroCreatures(count: Int) -> [CreatureSlot] {
+        layoutBand(
+            count: count,
+            xMin: 0.21,
+            xMax: 0.32,
+            frontY: 0.10,
+            backY: 0.20,
+            singleRowLimit: 3,
+            baseScale: 0.96,
+            minScale: 0.56,
+            creatureWidth: 0.086
+        )
+    }
+
     /// Hard floor for the crowd-driven shrink. Below the per-band `minScale`
     /// so tightly packed bands can still shrink enough to honor the overlap cap
     /// before we give up and accept brief overlap.

--- a/apple/AgentDeck/Terrarium/Creatures/KiroCreature.swift
+++ b/apple/AgentDeck/Terrarium/Creatures/KiroCreature.swift
@@ -1,0 +1,303 @@
+// KiroCreature.swift — Ghost creature for Kiro sessions
+//
+// The creature IS the logo, the same contract AntigravityCreature established:
+// this fills the canonical Kiro ghost silhouette (viewBox 0 0 24 24) rather
+// than drawing a ghost of our own. Two consequences that are easy to get wrong:
+//
+//  - The eyes are HOLES, not shapes. They live in the same path as the body as
+//    reversed subpaths, so the fill must be even-odd. A non-zero fill produces
+//    a blind ghost — recognisably wrong against the mark everyone knows.
+//  - The path data is an SSOT mirror of `design/brand/kiro.svg`
+//    (@lobehub/icons-static-svg@1.94.0, MIT). Do not redraw it, and do not
+//    "clean it up" — `design/RESOURCES.md` records how to verify it byte-wise
+//    against upstream, and the geometry must survive that check.
+//
+// Behaviour: a ghost hovers, so unlike the octopus it never rests on the sand.
+// WORKING rises and gains a sheen, FLOATING breathes and drifts, SLEEPING sinks
+// and fades (a ghost dimming out, not lying down), ASKING shows the shared "?"
+// bubble. Lifecycle/draw structure mirrors AntigravityCreature so it plugs into
+// TerrariumRenderer the same way.
+
+import SwiftUI
+
+// MARK: - Kiro Visual State
+
+enum KiroVisualState {
+    case sleeping   // Disconnected — sinks and fades out
+    case floating   // Idle — hover, gentle breath + drift
+    case working    // Processing — rises, sheen pulse
+    case asking     // Awaiting — "?" bubble
+}
+
+final class KiroCreature: Creature {
+    // MARK: - Properties
+
+    let sessionId: String
+    var displayName: String?
+    var visualState: KiroVisualState = .floating
+    var homeX: Float
+    var homeY: Float
+    var scale: Float
+
+    private var time: Float = 0
+    private(set) var currentX: Float
+    private(set) var currentY: Float
+    private var phaseOffset: Float
+    private var driftPhase: Float
+
+    private var previousState: KiroVisualState?
+    private var transitionProgress: Float = 1.0
+
+    var onAskingExit: (() -> Void)?
+
+    // MARK: - Geometry (canonical 24×24 ghost)
+
+    /// Canonical Kiro ghost — SSOT mirror of `design/brand/kiro.svg`
+    /// (@lobehub/icons-static-svg@1.94.0, MIT; Kiro is a mark of Amazon.com,
+    /// Inc. or its affiliates). Same string as
+    /// `CreatureGeometry.kiroPathData` and `SessionBrand.kiroPath`.
+    private static let pathData =
+        "M4.594 6.677C6.67-2.226 18.746-2.211 21.16 6.632c.353 1.297 1.725 7.582-1.673 13.747-1.545 2.797-5.841 5.49-6.99 1.883C8.6 25.477 3.315 24.1 5.789 18.609l-.318.143c-3.57 1.305-3.863-1.208-3.173-2.513.45-.84.727-1.335.937-1.897.353-.975.458-1.568.593-2.498.27-1.837.277-3.607.765-5.167zm8.37.01a.92.92 0 00-.81.428c-.217.323-.33.825-.33 1.462 0 .705.15 1.89 1.14 1.89h.008c.757 0 1.214-.705 1.214-1.89 0-.622-.127-1.125-.367-1.455a1.014 1.014 0 00-.855-.435zm4.08 0a.92.92 0 00-.81.428c-.217.323-.33.825-.33 1.462 0 .705.15 1.89 1.14 1.89h.008c.757 0 1.215-.705 1.215-1.89 0-.622-.128-1.125-.368-1.455a1.014 1.014 0 00-.855-.435z"
+    private static let viewBox: CGFloat = 24
+    private static let ghostPath: SwiftUI.Path = CrayfishCreature.parseSvgPath(pathData)
+
+    private static let wispCount = 5
+
+    // MARK: - Init
+
+    init(sessionId: String, homeX: Float, homeY: Float, scale: Float) {
+        self.sessionId = sessionId
+        self.homeX = homeX
+        self.homeY = homeY
+        self.scale = scale
+        self.currentX = homeX
+        self.currentY = homeY
+        self.phaseOffset = Float.random(in: 0...Float.pi * 2)
+        self.driftPhase = Float.random(in: 0...Float.pi * 2)
+    }
+
+    // MARK: - Update
+
+    func update(dt: Float, state: TerrariumState) {
+        time += dt
+
+        if let creature = state.kiroCreatures.first(where: { $0.id == sessionId }) {
+            let newState = creature.state
+            if newState != visualState {
+                if visualState == .asking { onAskingExit?() }
+                previousState = visualState
+                transitionProgress = 0
+                visualState = newState
+            }
+        }
+
+        if transitionProgress < 1.0 {
+            transitionProgress = min(1.0, transitionProgress + dt * 2.5)
+        }
+
+        updatePosition(dt: dt)
+    }
+
+    private func updatePosition(dt: Float) {
+        // homeY anchors the upper-left band (~0.18..0.30). A ghost hovers, so
+        // even SLEEPING stops well above the sand — the floor belongs to the
+        // octopuses and the crayfish, and a ghost lying on it reads as a bug.
+        let idleY = min(0.28, max(0.18, homeY + 0.08))
+        let askingY = min(0.26, max(0.16, homeY + 0.06))
+        let workingY = min(0.16, max(0.08, homeY - 0.03))
+        let sleepingY = min(0.40, max(0.30, homeY + 0.18))
+        let targetY: Float = switch visualState {
+        case .sleeping: sleepingY
+        case .floating: idleY
+        case .working: workingY
+        case .asking: askingY
+        }
+
+        let lerpRate: Float = visualState == .working ? 2.0 : 1.4
+        // Slower and wider than the Antigravity bob: a ghost drifts rather than
+        // bobs, and the difference is what tells the two apart at a glance.
+        let pulseSpeed: Float = visualState == .working ? 1.4 : 0.42
+        let pulseAmp: Float = visualState == .working ? 0.013 : 0.008
+        let pulseBob = sin((time + phaseOffset) * pulseSpeed) * pulseAmp
+        currentY += (targetY + pulseBob - currentY) * dt * lerpRate
+
+        let driftAmp: Float = visualState == .working ? min(0.045, 0.018 + scale * 0.025) : 0.009
+        let driftSpeed: Float = visualState == .working ? 0.18 : 0.22
+        let driftX = sin((time + driftPhase) * driftSpeed) * driftAmp
+        currentX += (homeX + driftX - currentX) * dt * lerpRate
+
+        // Stays clear of the session-list HUD on the left and the Codex cloud
+        // band on the right; the vertical cap keeps it out of the octopus band.
+        let minX = max(0.19, homeX - 0.05)
+        let maxX = min(0.36, homeX + 0.05)
+        currentX = min(maxX, max(minX, currentX))
+        currentY = min(0.42, max(0.05, currentY))
+    }
+
+    func currentPosition() -> (x: Float, y: Float) { (currentX, currentY) }
+    func isWorking() -> Bool { visualState == .working }
+
+    // MARK: - Colors
+
+    private static let bodyColor = TerrariumColors.kiroBody
+    private static let lightColor = TerrariumColors.kiroLight
+    private static let dimColor = TerrariumColors.kiroDim
+    static let nameBg = TerrariumColors.kiroNameBg
+
+    // MARK: - Draw
+
+    func draw(context: inout GraphicsContext, size: CGSize) {
+        let w = Float(size.width)
+        let h = Float(size.height)
+        let bodyRadius = w * 0.040 * scale
+
+        let cx = CGFloat(currentX * w)
+        let bobOffset = visualState == .working ? CGFloat(sin(time * 1.8) * h * 0.005) : 0
+        let cy = CGFloat(currentY * h) + bobOffset
+
+        let alpha: CGFloat = visualState == .sleeping ? 0.38 : 1.0
+
+        if visualState == .working {
+            drawWisps(context: &context, cx: cx, cy: cy, radius: CGFloat(bodyRadius), alpha: alpha)
+        }
+
+        drawGhostBody(context: &context, cx: cx, cy: cy, radius: CGFloat(bodyRadius), alpha: alpha)
+
+        if visualState == .asking {
+            drawSpeechBubble(context: &context, cx: cx, cy: cy, bodyW: CGFloat(bodyRadius))
+        }
+
+        if let name = displayName {
+            drawNameTag(
+                context: &context,
+                name: name,
+                cx: cx,
+                cy: cy,
+                bodyW: CGFloat(bodyRadius),
+                canvasWidth: size.width
+            )
+        }
+    }
+
+    // MARK: - Ghost Body (canonical silhouette)
+
+    private func drawGhostBody(context: inout GraphicsContext, cx: CGFloat, cy: CGFloat,
+                               radius: CGFloat, alpha: CGFloat) {
+        let breathScale: CGFloat = switch visualState {
+        case .sleeping: 1.0
+        case .working: 1.0 + CGFloat(sin(time * 1.8) * 0.022)
+        default: 1.0 + CGFloat(sin(time * 0.5) * 0.012)
+        }
+
+        let effScale = (radius * 2.0) / Self.viewBox * breathScale
+        var transform = CGAffineTransform(translationX: cx, y: cy)
+        transform = transform.scaledBy(x: effScale, y: effScale)
+        transform = transform.translatedBy(x: -Self.viewBox / 2, y: -Self.viewBox / 2)
+        let body = Self.ghostPath.applying(transform)
+
+        // Even-odd is load-bearing: the eyes are reversed subpaths inside the
+        // body, so a non-zero fill fills them in and blinds the ghost.
+        let fillStyle = FillStyle(eoFill: true)
+
+        if visualState == .sleeping {
+            context.fill(body, with: .color(Self.dimColor.opacity(alpha * 0.8)), style: fillStyle)
+            return
+        }
+
+        // Soft halo — reads as the ghost's glow, and keeps the violet silhouette
+        // legible against the dark tank without outlining (an outline would
+        // trace the eye holes too and turn them into rings).
+        context.fill(
+            body,
+            with: .color(Self.lightColor.opacity(0.18 * Double(alpha))),
+            style: fillStyle
+        )
+
+        context.fill(
+            body,
+            with: Self.bodyShading(in: body.boundingRect, alpha: bodyAlpha(alpha)),
+            style: fillStyle
+        )
+    }
+
+    private func bodyAlpha(_ baseAlpha: CGFloat) -> Double {
+        guard visualState == .working else { return Double(baseAlpha) }
+        let pulse = max(0, sin(time * TerrariumTiming.thinkingPulseSpeed))
+        return min(1.0, Double(baseAlpha) * 0.9 + Double(pulse) * 0.12)
+    }
+
+    private static func bodyShading(in bounds: CGRect, alpha: Double) -> GraphicsContext.Shading {
+        .linearGradient(
+            Gradient(colors: [
+                lightColor.opacity(alpha),
+                bodyColor.opacity(alpha),
+            ]),
+            startPoint: CGPoint(x: bounds.midX, y: bounds.minY),
+            endPoint: CGPoint(x: bounds.midX, y: bounds.maxY)
+        )
+    }
+
+    // MARK: - Wisps (WORKING trail)
+
+    private func drawWisps(context: inout GraphicsContext, cx: CGFloat, cy: CGFloat,
+                           radius: CGFloat, alpha: CGFloat) {
+        for i in 0..<Self.wispCount {
+            let phase = Float(i) * (2 * Float.pi / Float(Self.wispCount))
+            let fall = (time * 0.35 + Float(i) * 0.31).truncatingRemainder(dividingBy: 1)
+            let sx = cx + CGFloat(sin(phase + time * 0.6)) * radius * 0.5
+            // Wisps trail DOWNWARD off the ghost's fringe — the opposite of
+            // Antigravity's rising sparks, so the two working states never read
+            // as the same effect in a shared tank.
+            let sy = cy + radius * CGFloat(0.5 + fall * 0.9)
+            let wispAlpha = Double((1 - fall) * 0.42) * Double(alpha)
+            let r = radius * 0.10 * CGFloat(1 - fall * 0.5)
+
+            context.fill(
+                SwiftUI.Path(ellipseIn: CGRect(x: sx - r, y: sy - r, width: r * 2, height: r * 2)),
+                with: .color(Self.lightColor.opacity(max(0, min(1, wispAlpha))))
+            )
+        }
+    }
+
+    // MARK: - Speech Bubble
+
+    private func drawSpeechBubble(context: inout GraphicsContext, cx: CGFloat, cy: CGFloat, bodyW: CGFloat) {
+        let bx = cx + bodyW * 0.9
+        let by = cy - bodyW * 0.1
+        let br = bodyW * 0.35
+        let pulse = CGFloat(sin(time * 2.5)) * 0.08 + 1
+        let r = br * pulse
+
+        let rect = CGRect(x: bx - r, y: by - r, width: r * 2, height: r * 2)
+        context.fill(Path(ellipseIn: rect), with: .color(.white.opacity(0.25)))
+        context.stroke(Path(ellipseIn: rect),
+                       with: .color(TerrariumColors.hudText.opacity(0.5)),
+                       lineWidth: bodyW * 0.02)
+
+        var tail = SwiftUI.Path()
+        tail.move(to: CGPoint(x: bx - r * 0.3, y: by + r * 0.3))
+        tail.addLine(to: CGPoint(x: cx + bodyW * 0.45, y: cy))
+        tail.addLine(to: CGPoint(x: bx - r * 0.05, y: by + r * 0.5))
+        tail.closeSubpath()
+        context.fill(tail, with: .color(.white.opacity(0.25)))
+
+        context.draw(
+            Text("?").font(.system(size: r * 1.2, weight: .bold)).foregroundColor(TerrariumColors.hudText.opacity(0.7)),
+            at: CGPoint(x: bx, y: by)
+        )
+    }
+
+    // MARK: - Name Tag
+
+    private func drawNameTag(context: inout GraphicsContext, name: String,
+                             cx: CGFloat, cy: CGFloat, bodyW: CGFloat, canvasWidth: CGFloat) {
+        drawTerrariumNameTag(
+            context: &context,
+            name: name,
+            cx: cx,
+            bodyTopY: cy - bodyW * 0.8,
+            bodyMetric: terrariumNameTagMetric(canvasWidth: canvasWidth, scale: scale),
+            backgroundColor: Self.nameBg
+        )
+    }
+}

--- a/apple/AgentDeck/Terrarium/TerrariumConfig.swift
+++ b/apple/AgentDeck/Terrarium/TerrariumConfig.swift
@@ -61,6 +61,13 @@ enum TerrariumColors {
     static let antigravityDim = Color(red: 0.235, green: 0.251, blue: 0.263)    // #3C4043 sleeping shadow
     static let antigravityNameBg = Color(red: 0.373, green: 0.388, blue: 0.408).opacity(0.6)
 
+    // Kiro — violet #7C3AED (design/brand/kiro.svg is a silhouette, so the
+    // palette is ours; the SHAPE is what must match upstream, not the hue).
+    static let kiroBody = Color(red: 0.486, green: 0.227, blue: 0.929)         // #7C3AED
+    static let kiroLight = Color(red: 0.655, green: 0.545, blue: 0.980)        // #A78BFA working sheen
+    static let kiroDim = Color(red: 0.263, green: 0.145, blue: 0.482)          // #43257B sleeping
+    static let kiroNameBg = Color(red: 0.486, green: 0.227, blue: 0.929).opacity(0.6)
+
     // Environment
     static let bubbleWhite = Color.white.opacity(0.25)      // 0x40FFFFFF
     static let bubbleHighlight = Color.white.opacity(0.5)    // 0x80FFFFFF

--- a/apple/AgentDeck/Terrarium/TerrariumRenderer.swift
+++ b/apple/AgentDeck/Terrarium/TerrariumRenderer.swift
@@ -10,6 +10,7 @@ final class TerrariumRenderer {
     private var clouds: [String: CloudCreature] = [:]
     private var opencodeCreatures: [String: OpenCodeCreature] = [:]
     private var antigravityCreatures: [String: AntigravityCreature] = [:]
+    private var kiroCreatures: [String: KiroCreature] = [:]
     private let crayfish = CrayfishCreature()
     private let tetra = DataParticleSystem()
     private let bubbles = BubbleSystem()
@@ -79,6 +80,7 @@ final class TerrariumRenderer {
         syncClouds(state: state)
         syncOpenCode(state: state)
         syncAntigravity(state: state)
+        syncKiro(state: state)
 
         // Focus halo state
         focusedSessionId = state.focusedSessionId
@@ -91,6 +93,7 @@ final class TerrariumRenderer {
                 clouds[id] != nil ||
                 opencodeCreatures[id] != nil ||
                 antigravityCreatures[id] != nil ||
+                kiroCreatures[id] != nil ||
                 (isCrayfishFocusId(id) && crayfish.visible)
         }()
         let presenceTarget: Float = hasVisibleFocus ? 1.0 : 0.0
@@ -116,6 +119,9 @@ final class TerrariumRenderer {
         }
         for ag in antigravityCreatures.values {
             sand.creaturePositions.append(ag.currentPosition())
+        }
+        for k in kiroCreatures.values {
+            sand.creaturePositions.append(k.currentPosition())
         }
         if crayfish.visible {
             sand.creaturePositions.append(crayfish.currentPosition())
@@ -159,6 +165,10 @@ final class TerrariumRenderer {
                 let pos = ag.currentPosition()
                 bubbles.emitCreatureBubbles(x: pos.x, y: pos.y - 0.02, count: 1)
             }
+            for k in kiroCreatures.values where k.visualState != .sleeping {
+                let pos = k.currentPosition()
+                bubbles.emitCreatureBubbles(x: pos.x, y: pos.y - 0.02, count: 1)
+            }
         }
 
         // Tetra coupling — working octopi + pulsing jellyfish attract fish
@@ -172,6 +182,9 @@ final class TerrariumRenderer {
             .filter { $0.state == .pulsing }
             .map { ($0.homeX, $0.homeY) }
         workingPositions += state.antigravityCreatures
+            .filter { $0.state == .working }
+            .map { ($0.homeX, $0.homeY) }
+        workingPositions += state.kiroCreatures
             .filter { $0.state == .working }
             .map { ($0.homeX, $0.homeY) }
         tetra.octopusPositions = workingPositions
@@ -191,6 +204,9 @@ final class TerrariumRenderer {
         }
         for ag in antigravityCreatures.values {
             ag.update(dt: dt, state: state)
+        }
+        for k in kiroCreatures.values {
+            k.update(dt: dt, state: state)
         }
         crayfish.update(dt: dt, state: state)
 
@@ -261,6 +277,11 @@ final class TerrariumRenderer {
             ag.draw(context: &context, size: size)
         }
 
+        // Layer 9.45: Kiro ghosts
+        for k in kiroCreatures.values {
+            k.draw(context: &context, size: size)
+        }
+
         // Layer 9.5: Front-layer fish
         tetra.drawFrontLayer(context: &context, size: size)
 
@@ -300,6 +321,8 @@ final class TerrariumRenderer {
             pos = (oc.currentX, oc.currentY, oc.scale)
         } else if let ag = antigravityCreatures[id] {
             pos = (ag.currentX, ag.currentY, ag.scale)
+        } else if let k = kiroCreatures[id] {
+            pos = (k.currentX, k.currentY, k.scale)
         } else if isCrayfishFocusId(id), crayfish.visible {
             let cp = crayfish.currentPosition()
             pos = (cp.x, cp.y, 1.1)
@@ -391,6 +414,17 @@ final class TerrariumRenderer {
         }
         for creature in state.antigravityCreatures {
             guard let live = antigravityCreatures[creature.id] else { continue }
+            drawSubagentOrbit(
+                context: &context,
+                size: size,
+                x: live.currentX,
+                y: live.currentY,
+                scale: live.scale,
+                activity: creature.subagentActivity
+            )
+        }
+        for creature in state.kiroCreatures {
+            guard let live = kiroCreatures[creature.id] else { continue }
             drawSubagentOrbit(
                 context: &context,
                 size: size,
@@ -593,6 +627,37 @@ final class TerrariumRenderer {
                 oc.homeY = creature.homeY
                 oc.scale = creature.scale
                 oc.displayName = creature.projectName
+            }
+        }
+    }
+
+    private func syncKiro(state: TerrariumState) {
+        let currentIds = Set(state.kiroCreatures.map(\.id))
+        let existingIds = Set(kiroCreatures.keys)
+
+        for id in existingIds.subtracting(currentIds) {
+            kiroCreatures.removeValue(forKey: id)
+        }
+
+        for creature in state.kiroCreatures {
+            if kiroCreatures[creature.id] == nil {
+                let k = KiroCreature(
+                    sessionId: creature.id,
+                    homeX: creature.homeX,
+                    homeY: creature.homeY,
+                    scale: creature.scale
+                )
+                k.displayName = creature.projectName
+                k.onAskingExit = { [weak self] in
+                    self?.bubbles.emitPopBurst(x: creature.homeX, y: creature.homeY)
+                }
+                kiroCreatures[creature.id] = k
+            } else {
+                let k = kiroCreatures[creature.id]!
+                k.homeX = creature.homeX
+                k.homeY = creature.homeY
+                k.scale = creature.scale
+                k.displayName = creature.projectName
             }
         }
     }

--- a/apple/AgentDeck/Terrarium/TerrariumState.swift
+++ b/apple/AgentDeck/Terrarium/TerrariumState.swift
@@ -139,26 +139,21 @@ extension DashboardState {
         var result = TerrariumState()
 
         // Primary session creature (skip daemon/openclaw/codex-cli/opencode/antigravity — they're not octopuses)
-        let primaryIsOctopus = state != .disconnected
-            && agentType != "daemon"
-            && agentType != "openclaw"
-            && agentType != "codex-cli"
-            && agentType != "codex-app"
-            && agentType != "opencode"
-            && agentType != "antigravity"
-            // Kiro ghosts have their own band. Note this bucket is defined by
-            // EXCLUSION, so an agent nobody lists here silently becomes a
-            // Claude octopus — which is exactly what Kiro sessions did until
-            // this line existed.
-            && agentType != "kiro-cli"
-            && agentType != "kiro-ide"
+        // ALLOW-list, not a deny-list. This bucket used to be spelled as
+        // "everything except the agents we happen to know about", which meant an
+        // agentType this build has never heard of was drawn as a Claude octopus
+        // — a session wearing another agent's identity. Daemon and dashboard
+        // ship separately, so the daemon WILL send types an older dashboard does
+        // not know; the correct answer for those is no creature, never someone
+        // else's. Mirrors `CODING_AGENTS` in bridge/src/pixoo/pixoo-renderer.ts,
+        // which has always been an allow-list.
+        let primaryIsOctopus = state != .disconnected && Self.isOctopusAgent(agentType)
 
         // Octopus siblings (exclude daemon/openclaw/codex-cli/opencode/antigravity), sorted by ID for stable positioning.
         // Also exclude the currently-focused session's id to prevent double-rendering when focus relay
         // promotes a sibling to primary (agentType → claude-code, sessionId → sibling.id).
         let siblings = siblingSessions
-            .filter { $0.agentType != "daemon" && $0.agentType != "openclaw" && $0.agentType != "codex-cli" && $0.agentType != "codex-app" && $0.agentType != "opencode" && $0.agentType != "antigravity" }
-            .filter { $0.agentType != "kiro-cli" && $0.agentType != "kiro-ide" }
+            .filter { Self.isOctopusAgent($0.agentType) }
             .filter { !(primaryIsOctopus && $0.id == sessionId) }
             .sorted { $0.id < $1.id }
 
@@ -583,6 +578,14 @@ extension DashboardState {
         case .processing: .working
         case .awaitingPermission, .awaitingOption, .awaitingDiff: .asking
         }
+    }
+
+    /// Agent types drawn as the octopus. SSOT-mirrored from `CODING_AGENTS`
+    /// in `bridge/src/pixoo/pixoo-renderer.ts` — keep the two in step, and keep
+    /// this an allow-list so an unknown agent renders as nothing rather than as
+    /// Claude.
+    static func isOctopusAgent(_ agentType: String?) -> Bool {
+        agentType == "claude-code"
     }
 
     private func mapToKiroState(_ connState: AgentConnectionState) -> KiroVisualState {

--- a/apple/AgentDeck/Terrarium/TerrariumState.swift
+++ b/apple/AgentDeck/Terrarium/TerrariumState.swift
@@ -94,6 +94,17 @@ struct AntigravityCreatureState: Identifiable {
     var subagentActivity: SubagentVisualActivity = .none
 }
 
+struct KiroCreatureState: Identifiable {
+    let id: String
+    let projectName: String?
+    let modelName: String?
+    let state: KiroVisualState
+    let homeX: Float
+    let homeY: Float
+    let scale: Float
+    var subagentActivity: SubagentVisualActivity = .none
+}
+
 // MARK: - Terrarium State (aggregate)
 
 struct TerrariumState {
@@ -101,6 +112,7 @@ struct TerrariumState {
     var cloudCreatures: [CloudCreatureState] = []
     var opencodeCreatures: [OpenCodeCreatureState] = []
     var antigravityCreatures: [AntigravityCreatureState] = []
+    var kiroCreatures: [KiroCreatureState] = []
     var crayfishState: CrayfishVisualState = .dormant
     var crayfishVisible: Bool = false
     var tetraState: TetraVisualState = .circling
@@ -134,12 +146,19 @@ extension DashboardState {
             && agentType != "codex-app"
             && agentType != "opencode"
             && agentType != "antigravity"
+            // Kiro ghosts have their own band. Note this bucket is defined by
+            // EXCLUSION, so an agent nobody lists here silently becomes a
+            // Claude octopus — which is exactly what Kiro sessions did until
+            // this line existed.
+            && agentType != "kiro-cli"
+            && agentType != "kiro-ide"
 
         // Octopus siblings (exclude daemon/openclaw/codex-cli/opencode/antigravity), sorted by ID for stable positioning.
         // Also exclude the currently-focused session's id to prevent double-rendering when focus relay
         // promotes a sibling to primary (agentType → claude-code, sessionId → sibling.id).
         let siblings = siblingSessions
             .filter { $0.agentType != "daemon" && $0.agentType != "openclaw" && $0.agentType != "codex-cli" && $0.agentType != "codex-app" && $0.agentType != "opencode" && $0.agentType != "antigravity" }
+            .filter { $0.agentType != "kiro-cli" && $0.agentType != "kiro-ide" }
             .filter { !(primaryIsOctopus && $0.id == sessionId) }
             .sorted { $0.id < $1.id }
 
@@ -415,6 +434,45 @@ extension DashboardState {
         }
         result.antigravityCreatures = antigravityCreatures
 
+        // Kiro ghosts
+        let isKiro: (String?) -> Bool = { $0 == "kiro-cli" || $0 == "kiro-ide" }
+        let primaryIsKiro = state != .disconnected && isKiro(agentType)
+        let kiroSiblings = siblingSessions
+            .filter { isKiro($0.agentType) }
+            .filter { !(primaryIsKiro && $0.id == sessionId) }
+            .sorted { $0.id < $1.id }
+        let kiroCount = (primaryIsKiro ? 1 : 0) + kiroSiblings.count
+        let kiroSlots = CreatureLayout.layoutKiroCreatures(count: kiroCount)
+
+        var kiroCreatures: [KiroCreatureState] = []
+        var kiroSlotIdx = 0
+        if primaryIsKiro {
+            let s = kiroSlots.first ?? CreatureSlot(x: 0.18, y: 0.24, scale: 1.0)
+            kiroCreatures.append(KiroCreatureState(
+                id: sessionId ?? "kiro-primary",
+                projectName: projectName,
+                modelName: modelName,
+                state: mapToKiroState(state),
+                homeX: s.x, homeY: s.y, scale: s.scale,
+                subagentActivity: subagentActivityBySession[sessionId ?? "kiro-primary"] ?? .none
+            ))
+            kiroSlotIdx = 1
+        }
+        for (i, sibling) in kiroSiblings.enumerated() {
+            guard !kiroSlots.isEmpty else { break }
+            let idx = min(kiroSlotIdx + i, kiroSlots.count - 1)
+            let s = kiroSlots[idx]
+            kiroCreatures.append(KiroCreatureState(
+                id: sibling.id,
+                projectName: sibling.projectName,
+                modelName: sibling.modelName,
+                state: mapSiblingToKiroState(sibling.state),
+                homeX: s.x, homeY: s.y, scale: s.scale,
+                subagentActivity: subagentActivityBySession[sibling.id] ?? .none
+            ))
+        }
+        result.kiroCreatures = kiroCreatures
+
         // Environment state — in daemon mode, derive from most active sibling
         let isDaemonLike = agentType == "daemon" ||
             (agentType != nil && siblingSessions.contains(where: { $0.agentType == agentType }))
@@ -524,6 +582,24 @@ extension DashboardState {
         case .idle: .floating
         case .processing: .working
         case .awaitingPermission, .awaitingOption, .awaitingDiff: .asking
+        }
+    }
+
+    private func mapToKiroState(_ connState: AgentConnectionState) -> KiroVisualState {
+        switch connState {
+        case .disconnected: .sleeping
+        case .idle: .floating
+        case .processing: .working
+        case .awaitingPermission, .awaitingOption, .awaitingDiff: .asking
+        }
+    }
+
+    private func mapSiblingToKiroState(_ stateStr: String?) -> KiroVisualState {
+        switch stateStr {
+        case "processing": .working
+        case "awaiting_permission", "awaiting_option", "awaiting_diff": .asking
+        case "idle": .floating
+        default: .sleeping
         }
     }
 

--- a/apple/AgentDeckTests/UnknownAgentForwardCompatTests.swift
+++ b/apple/AgentDeckTests/UnknownAgentForwardCompatTests.swift
@@ -1,0 +1,140 @@
+#if os(macOS)
+import XCTest
+import SwiftUI
+@testable import AgentDeck
+
+/// The daemon and each dashboard ship on their own schedules, so a dashboard
+/// WILL receive `agentType` values it has never heard of — every time a new
+/// agent is added, for as long as it takes the app to catch up.
+///
+/// The contract for those is narrow: render a neutral default, or render
+/// nothing. What must never happen is rendering them as some OTHER agent,
+/// because that is not a degraded view — it is a wrong one, and it is the
+/// failure mode this codebase actually had. Two bucket definitions were spelled
+/// as deny-lists ("everything except the agents we know"), which silently
+/// dressed every future agent as Claude.
+///
+/// These tests pin the polarity rather than the membership: adding a real agent
+/// should not require touching them, and removing the guard should fail here.
+final class UnknownAgentForwardCompatTests: XCTestCase {
+
+    /// A type no build of this app has ever seen, standing in for whatever the
+    /// daemon ships next.
+    private let futureAgent = "some-future-agent"
+
+    private func session(id: String, agentType: String, state: String = "processing") -> SessionInfo {
+        SessionInfo(
+            id: id,
+            port: 9120,
+            projectName: "AgentDeck",
+            agentType: agentType,
+            alive: true,
+            state: state,
+            modelName: nil,
+            effortLevel: nil,
+            startedAt: nil
+        )
+    }
+
+    // MARK: - Terrarium
+
+    /// The octopus is Claude's creature. An unknown agent must not wear it.
+    func testUnknownAgentIsNotDrawnAsAClaudeOctopus() {
+        var state = DashboardState()
+        state.state = .processing
+        state.bridgeConnected = true
+        state.agentType = futureAgent
+        state.sessionId = "future:1"
+
+        let terrarium = state.toTerrariumState()
+
+        XCTAssertTrue(
+            terrarium.creatures.isEmpty,
+            "An unknown agentType must produce no octopus — it is Claude's creature, not a default"
+        )
+        XCTAssertTrue(terrarium.cloudCreatures.isEmpty)
+        XCTAssertTrue(terrarium.opencodeCreatures.isEmpty)
+        XCTAssertTrue(terrarium.antigravityCreatures.isEmpty)
+        XCTAssertTrue(terrarium.kiroCreatures.isEmpty)
+    }
+
+    /// Same rule for sibling sessions, which take a separate code path.
+    func testUnknownSiblingIsNotDrawnAsAClaudeOctopus() {
+        var state = DashboardState()
+        state.state = .idle
+        state.bridgeConnected = true
+        state.siblingSessions = [
+            session(id: "future:1", agentType: futureAgent),
+            session(id: "claude:1", agentType: "claude-code"),
+        ]
+
+        let terrarium = state.toTerrariumState()
+
+        XCTAssertEqual(
+            terrarium.creatures.count, 1,
+            "Only the real claude-code session may be an octopus"
+        )
+        XCTAssertEqual(terrarium.creatures.first?.id, "claude:1")
+    }
+
+    /// The allow-list is what makes the above true; state it directly so the
+    /// failure message points at the cause rather than at a creature count.
+    func testOctopusBucketIsAnAllowList() {
+        XCTAssertTrue(DashboardState.isOctopusAgent("claude-code"))
+        XCTAssertFalse(DashboardState.isOctopusAgent(futureAgent))
+        XCTAssertFalse(DashboardState.isOctopusAgent(nil))
+        // Agents with their own creature must not fall back into this bucket.
+        for known in ["codex-cli", "codex-app", "opencode", "openclaw", "antigravity", "kiro-cli", "kiro-ide", "daemon", "monitor"] {
+            XCTAssertFalse(DashboardState.isOctopusAgent(known), "\(known) has its own representation")
+        }
+    }
+
+    // MARK: - Identity surfaces
+
+    /// Colour and label must degrade to neutral values, and crucially not to
+    /// another agent's.
+    func testUnknownAgentGetsNeutralIdentityNotBorrowedIdentity() {
+        XCTAssertEqual(SessionBrand.color(for: futureAgent), Color.secondary)
+        XCTAssertNotEqual(SessionBrand.color(for: futureAgent), SessionBrand.color(for: "claude-code"))
+
+        // The label may be generic, but must not name a different agent.
+        let label = displayAgentLabel(futureAgent)
+        for known in ["Claude", "Codex", "OpenCode", "OpenClaw", "Antigravity", "Kiro"] {
+            XCTAssertFalse(label.contains(known), "Unknown agent label '\(label)' must not name \(known)")
+        }
+    }
+
+    /// The other half of the contract: every agent that IS on the wire must
+    /// resolve to its own colour and its own label. This catches a new agent
+    /// being added to the protocol while nobody wires its identity — the
+    /// symptom Kiro shipped with.
+    func testEveryWireAgentTypeHasItsOwnIdentity() {
+        var seenColors: [String: Color] = [:]
+        for agent in Self.wireAgentTypes {
+            let color = SessionBrand.color(for: agent)
+            XCTAssertNotEqual(
+                color, Color.secondary,
+                "\(agent) is on the wire but falls back to the unknown-agent colour"
+            )
+            let label = displayAgentLabel(agent)
+            XCTAssertNotEqual(label, "Agent", "\(agent) has no display label")
+            seenColors[agent] = color
+        }
+        // Codex CLI/App and Kiro CLI/IDE intentionally share a brand colour;
+        // everything else must be distinguishable from Claude.
+        for agent in Self.wireAgentTypes where agent != "claude-code" {
+            XCTAssertNotEqual(
+                seenColors[agent], seenColors["claude-code"],
+                "\(agent) is coloured as Claude"
+            )
+        }
+    }
+
+    /// Raw wire strings for every agent the generated protocol knows about,
+    /// minus the two non-session rows (`daemon`, `monitor`).
+    private static let wireAgentTypes = [
+        "claude-code", "codex-cli", "codex-app", "opencode",
+        "openclaw", "antigravity", "kiro-cli", "kiro-ide",
+    ]
+}
+#endif

--- a/bridge/src/__tests__/pixoo-creature-sync.test.ts
+++ b/bridge/src/__tests__/pixoo-creature-sync.test.ts
@@ -161,3 +161,47 @@ describe('pixoo creature sync — the `_primary` fallback', () => {
     expect(snapshot[0].state).toBe('processing');
   });
 });
+
+describe('pixoo creature sync — unknown agent types', () => {
+  // The daemon and every dashboard/device renderer ship separately, so this
+  // renderer WILL be handed agentType values it predates. The rule is: a
+  // neutral default or nothing — never another agent's creature. `octopus` is
+  // Claude's, and `creatureTypeFor` falls back to it, so the guard that matters
+  // is the allow-list in front of it.
+  it('draws no creature for an agent type it has never heard of', () => {
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'future:1', agentType: 'some-future-agent' }),
+    ], null);
+
+    expect(snapshot).toHaveLength(0);
+  });
+
+  it('does not let an unknown agent become a Claude octopus alongside real ones', () => {
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'claude:1', agentType: 'claude-code', projectName: 'AgentDeck' }),
+      session({ id: 'future:1', agentType: 'some-future-agent', projectName: 'AgentDeck' }),
+    ], null);
+
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].creatureType).toBe('octopus');
+  });
+
+  it('gives every known agent type its own creature', () => {
+    const expected: Array<[string, string]> = [
+      ['claude-code', 'octopus'],
+      ['codex-cli', 'jellyfish'],
+      ['codex-app', 'jellyfish'],
+      ['opencode', 'opencode'],
+      ['antigravity', 'antigravity'],
+      ['kiro-cli', 'kiro'],
+      ['kiro-ide', 'kiro'],
+    ];
+    for (const [agentType, creatureType] of expected) {
+      const snapshot = getCreatureLayoutSnapshot([
+        session({ id: `s:${agentType}`, agentType, projectName: agentType }),
+      ], null);
+      expect(snapshot, `${agentType} should produce a creature`).toHaveLength(1);
+      expect(snapshot[0].creatureType, `${agentType} creature`).toBe(creatureType);
+    }
+  });
+});

--- a/bridge/src/pixoo/pixoo-renderer.ts
+++ b/bridge/src/pixoo/pixoo-renderer.ts
@@ -30,6 +30,7 @@ import { hasOpenClawSession, foldCodexSessionsForDisplay } from '@agentdeck/shar
 import {
   type CreatureSlot,
   layoutOctopuses, layoutCloudCreatures, layoutOpenCodeCreatures, layoutAntigravityCreatures,
+  layoutKiroCreatures,
 } from '@agentdeck/shared';
 import { drawTextCentered } from './pixoo-font.js';
 import {
@@ -150,9 +151,7 @@ function slotsForType(creatureType: CreatureType, count: number): CreatureSlot[]
     case 'jellyfish': return layoutCloudCreatures(count);
     case 'opencode': return layoutOpenCodeCreatures(count);
     case 'antigravity': return layoutAntigravityCreatures(count);
-    // Until creature-layout.ts is generated across all three mirrors, reuse
-    // the upper-right floating band instead of introducing another hand mirror.
-    case 'kiro': return layoutAntigravityCreatures(count);
+    case 'kiro': return layoutKiroCreatures(count);
   }
 }
 

--- a/shared/src/creature-layout.ts
+++ b/shared/src/creature-layout.ts
@@ -80,6 +80,29 @@ export function layoutAntigravityCreatures(count: number): CreatureSlot[] {
   });
 }
 
+/** Kiro ghosts — top-left band, INSIDE the visible tank.
+ *
+ * Above the octopuses and just left of the Codex clouds (0.30+). The x floor is
+ * 0.21 rather than the tank edge because the dashboard's session-list HUD is
+ * drawn over roughly the left 0.19 of the tank — a band starting at 0.08 put
+ * the ghosts behind that panel, where they were measured to be invisible. The
+ * right side is likewise unavailable: the upstream HUD covers it, and what it
+ * does not cover belongs to the Antigravity hover strip and the crayfish
+ * floor. */
+export function layoutKiroCreatures(count: number): CreatureSlot[] {
+  return layoutBand({
+    count,
+    xMin: 0.21,
+    xMax: 0.32,
+    frontY: 0.10,
+    backY: 0.20,
+    singleRowLimit: 3,
+    baseScale: 0.96,
+    minScale: 0.56,
+    creatureWidth: 0.086,
+  });
+}
+
 /**
  * Hard floor for the crowd-driven shrink. Below the per-band `minScale` so
  * tightly packed bands can still shrink enough to honor the overlap cap before


### PR DESCRIPTION
The dashboard tank had no Kiro creature, and its octopus bucket is defined by **exclusion** — so a Kiro session was silently drawn as a Claude octopus. The other surfaces disagreed with each other about where a ghost even belongs.

![before/after: grey-bullet Claude octopus → violet ghost](https://github.com/puritysb/AgentDeck/pull/205)

## The creature IS the logo

`KiroCreature` fills the canonical ghost silhouette from `design/brand/kiro.svg` (@lobehub/icons-static-svg@1.94.0, MIT) rather than drawing a ghost of our own — the contract `AntigravityCreature` set.

The fill is **even-odd**, and that is load-bearing: the eyes are *holes*, reversed subpaths inside the body. A non-zero fill closes them and produces a blind ghost, recognisably wrong against the mark everyone knows.

Motion is a ghost's, and deliberately unlike its neighbours:

| state | behaviour |
|---|---|
| FLOATING | hovers, slow wide drift (Antigravity bobs faster and tighter) |
| WORKING | rises, sheen pulse, wisps trailing **downward** — Antigravity's sparks rise, so the two never read as one effect in a shared tank |
| SLEEPING | sinks and fades, but **stops above the sand** — the floor belongs to the octopuses and the crayfish |
| ASKING | the shared "?" bubble |

## One band, asked for by name

Kiro had been riding other agents' bands: the Node Pixoo renderer borrowed Antigravity's (`case 'kiro': return layoutAntigravityCreatures(count)`), Android borrowed OpenCode's, and Swift had none at all. `layoutKiroCreatures` now exists in all three mirrors of `creature-layout` with identical constants, and **all three consumers call it**. The mirrors are only a single source of truth if every side asks the same function for the same agent — the file's own header warns that divergence shows up as the same session set drawn in different places depending on which daemon drives the device.

Measured: no slot overlap with the Antigravity or OpenCode bands.

The band is `x 0.21..0.32`, not the tank edge. A first pass put it at `0.08` and the ghosts rendered **behind the session-list HUD**, which covers roughly the left 0.19 of the tank — caught on screen, then moved.

## Every other surface

- **Pixoo / Timebox / iDotMatrix**: admitted to the `creatureAgents` gate. `MicroGlyphs` already carried Kiro's official 24/9/8px masks and violet, so that gate was the only thing keeping the ghost off the dot-matrix devices.
- **Android**: keeps its shared vector-mark creature class (it already rendered the official ghost); only the slot source changed, via `vectorMarkSlots`. Its `isKiroAgent` had a second spelling — now one package-level function, since two copies of that predicate is exactly how one surface places a ghost in a band another does not.
- **TUI terrarium**: glyph + short label.
- **Stream Deck slot palette**: violet pair.
- **ESP32**: already covered by the glyph generator — no change needed.

## Verified

vitest 3062 · Android `compileDebugKotlin` + `testDebugUnitTest` · macOS `xcodebuild` · and the running dashboard, where the ghost renders with its eyes intact, clear of the HUD and of every other band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)