### PR TITLE
Tell an unreadable Kiro transcript apart from one nobody has typed into

### DIFF
--- a/bridge/src/__tests__/kiro-diagnostics.test.ts
+++ b/bridge/src/__tests__/kiro-diagnostics.test.ts
@@ -6,6 +6,7 @@ import { buildKiroDiagnosticReport, formatKiroDiagnosticReport } from '../kiro-d
 import {
   applyKiroPendingTurnMarker,
   kiroTranscriptRecordKinds,
+  kiroTranscriptLineCount,
   parseKiroTranscript,
   parseKiroSqliteRows,
   readKiroV3SessionSnapshots,
@@ -274,6 +275,45 @@ describe('Kiro privacy-safe diagnostics', () => {
     });
     expect(unknown.sessions.entries[0].format).toBe('unknown');
     expect(unknown.findings).toContain('At least one inspected transcript uses an unrecognized record format.');
+  });
+
+  // The other direction of the same conflation. `recordKinds` is empty both
+  // when nothing has been written and when this build could not read any of
+  // what WAS written — lines that fail to parse are dropped silently, and a
+  // record with no kind/type/method contributes nothing. Calling the second
+  // case "no records yet" suppresses the unrecognized-format finding exactly
+  // when it is true, which is the failure the finding exists to prevent.
+  it('reports an unreadable transcript as unrecognized, not as not-yet-prompted', () => {
+    const base = {
+      processes: [],
+      v3DirectoryPresent: true,
+      directoryPresent: true,
+      primaryStore: 'jsonl-v3' as const,
+      now: NOW,
+      salt: 'test-only-salt',
+    };
+    const unreadable = buildKiroDiagnosticReport({
+      ...base,
+      snapshots: [snapshot({ recordKinds: [], transcriptLineCount: 12 })],
+    });
+    expect(unreadable.sessions.entries[0].format).toBe('unknown');
+    expect(unreadable.findings).toContain('At least one inspected transcript uses an unrecognized record format.');
+
+    // Truly nothing written keeps the quiet reading.
+    const notYetPrompted = buildKiroDiagnosticReport({
+      ...base,
+      snapshots: [snapshot({ recordKinds: [], transcriptLineCount: 0 })],
+    });
+    expect(notYetPrompted.sessions.entries[0].format).toBe('empty');
+    expect(notYetPrompted.findings).not.toContain('At least one inspected transcript uses an unrecognized record format.');
+  });
+
+  it('counts only non-blank transcript lines as evidence of content', () => {
+    expect(kiroTranscriptLineCount('')).toBe(0);
+    expect(kiroTranscriptLineCount('\n\n   \n')).toBe(0);
+    expect(kiroTranscriptLineCount('{"a":1}\n\n{"b":2}\n')).toBe(2);
+    // Unparseable content still counts — that is the whole point.
+    expect(kiroTranscriptLineCount('not json at all\nnor this\n')).toBe(2);
   });
 
   it('discovers the measured v3 workspace/session directory layout', async () => {

--- a/bridge/src/kiro-diagnostics.ts
+++ b/bridge/src/kiro-diagnostics.ts
@@ -168,7 +168,7 @@ export function buildKiroDiagnosticReport(input: KiroDiagnosticInput): KiroDiagn
       cwdKnown: Boolean(snapshot.cwd),
       ...(snapshot.cwd ? { cwdKey: opaqueKey('cwd', snapshot.cwd) } : {}),
       ageSeconds: Math.max(0, Math.round((now - snapshot.lastActivityAt) / 1000)),
-      format: diagnosticFormat(recordKinds),
+      format: diagnosticFormat(recordKinds, snapshot.transcriptLineCount),
       recordKinds,
       hasModel: Boolean(snapshot.modelName),
       hasCreatedAt: snapshot.createdAt !== undefined,
@@ -314,8 +314,21 @@ export function formatKiroDiagnosticReport(report: KiroDiagnosticReport): string
 // "unrecognized record format" sends the reader hunting a parser gap that does
 // not exist (measured 2026-08-17: a 14s-old `kiro-cli chat` with a 0-byte
 // messages file raised exactly that finding).
-function diagnosticFormat(kinds: readonly string[]): KiroDiagnosticFormat {
-  if (kinds.length === 0) return 'empty';
+//
+// But "no recognized kinds" is NOT the same claim as "nothing was written", and
+// gating on the kind set alone conflated them in the other direction: a
+// transcript whose lines fail to parse, or whose records carry no
+// `kind`/`type`/`method`, also yields an empty kind set — and reporting THAT as
+// "no records yet" suppresses the unrecognized-format finding at the exact
+// moment it is true. So `empty` requires evidence of emptiness: zero non-blank
+// lines. Lines present with nothing recognized is `unknown`, which is what the
+// finding is for. `lineCount` is optional because older snapshots predate it;
+// absent it, fall back to the kind set rather than inventing a count.
+function diagnosticFormat(kinds: readonly string[], lineCount?: number): KiroDiagnosticFormat {
+  if (kinds.length === 0) {
+    if (lineCount === undefined) return 'empty';
+    return lineCount === 0 ? 'empty' : 'unknown';
+  }
   const v2 = kinds.some((kind) => ['ConversationV2', 'Prompt', 'AssistantMessage', 'ToolResults', 'ToolResult'].includes(kind));
   const v3 = kinds.some((kind) => ['user', 'assistant', 'turn_start', 'turn_end', 'session_start'].includes(kind));
   const acp = kinds.some((kind) => kind === 'session/prompt' || kind.startsWith('session/notification'));

--- a/bridge/src/kiro-session.ts
+++ b/bridge/src/kiro-session.ts
@@ -63,6 +63,14 @@ export interface KiroSessionSnapshot extends KiroSessionMetadata, KiroTranscript
   transcriptPath: string;
   lastActivityAt: number;
   recordKinds: string[];
+  /** Non-blank lines in the sampled transcript, whether or not they parsed.
+   *  `recordKinds` alone cannot tell "nothing has been written yet" from
+   *  "written, but this build could not read any of it" — `parseJsonl` drops
+   *  unreadable lines silently, and a record with no `kind`/`type`/`method`
+   *  contributes nothing either. Both collapse to an empty kind set, and
+   *  calling that "empty" hides exactly the format drift the diagnostic is
+   *  meant to surface. */
+  transcriptLineCount?: number;
 }
 
 interface KiroSessionCacheEntry {
@@ -302,6 +310,16 @@ export function parseKiroTranscript(raw: string): KiroTranscriptSummary {
  * Return schema markers only. Safe for diagnostics: values, prompt text,
  * tool input, response text, and message ids never leave this function.
  */
+/** Non-blank lines in a transcript sample — the evidence that something WAS
+ *  written, independent of whether this build could interpret it. */
+export function kiroTranscriptLineCount(raw: string): number {
+  let count = 0;
+  for (const line of raw.split('\n')) {
+    if (line.trim()) count++;
+  }
+  return count;
+}
+
 export function kiroTranscriptRecordKinds(raw: string): string[] {
   const kinds = new Set<string>();
   for (const value of parseJsonl(raw)) {
@@ -415,6 +433,7 @@ export async function readKiroSessionSnapshots(
       lastActivityAt: metadata.updatedAt ?? file.mtimeMs,
       goal: summary.goal ?? metadata.title,
       recordKinds: kiroTranscriptRecordKinds(transcriptRaw),
+      transcriptLineCount: kiroTranscriptLineCount(transcriptRaw),
     };
     snapshots.push(snapshot);
     cache?.set(transcriptPath, { ...signature, snapshot });
@@ -500,6 +519,7 @@ export async function readKiroV3SessionSnapshots(
         ?? Math.max(candidate.transcriptMtimeMs, candidate.metadataMtimeMs),
       goal: summary.goal ?? metadata.title,
       recordKinds: kiroTranscriptRecordKinds(transcriptRaw),
+      transcriptLineCount: kiroTranscriptLineCount(transcriptRaw),
     };
     snapshots.push(snapshot);
     cache?.set(candidate.transcriptPath, { ...signature, snapshot });
@@ -648,6 +668,10 @@ export function parseKiroSqliteRows(rows: readonly KiroSqliteRow[], dbPath: stri
       state: 'idle',
       ...(goal ? { goal } : {}),
       ...(response ? { response } : {}),
+      // Row-backed, not line-backed: there is no transcript text to count, and
+      // 'ConversationV2' is always present, so the empty-kinds branch that uses
+      // this is unreachable here.
+      transcriptLineCount: 0,
       recordKinds: [
         'ConversationV2',
         ...(row.historyCount > 0 ? ['Prompt'] : []),


### PR DESCRIPTION
Found by review on master (thanks to the posture session for flagging it) — not by the failure, because **the failure mode here is silence**.

## The conflation

`diagnosticFormat` gated `empty` on the kind set being empty. #202 fixed one direction of that: a freshly launched chat with a 0-byte messages file was reported as *"unrecognized record format"*, sending the reader after a parser gap that did not exist.

This is the other direction, and it is worse. `recordKinds` is **also** empty when the transcript has content this build could not read:

- `parseJsonl` drops unparseable lines silently
- a record carrying no `kind`/`type`/`method` contributes nothing either — which is exactly what a Kiro format change looks like

Reporting that as *"no records yet"* suppresses the unrecognized-format finding **at the moment it becomes true**. The one signal that would surface format drift gets silenced by drift.

## The fix

`empty` now requires evidence of emptiness: zero non-blank lines in the sampled transcript, carried on the snapshot as `transcriptLineCount`. Lines present with nothing recognized is `unknown`.

The count deliberately **includes lines that fail to parse** — being unreadable is the thing it is evidence of. It is optional so older snapshots keep the previous reading rather than having a count invented for them, and SQLite-backed rows set `0` explicitly since they are row-backed with no transcript text (their kind set always carries `ConversationV2`, so the branch is unreachable there).

## Verified

Against the 8 real Kiro transcripts on this machine: all still classify as v2/v3 with unchanged kinds, `agentdeck diag kiro` reports no findings, and the SQLite row correctly shows `lines=0` without being called empty.

Tests pin both directions — unreadable-with-content → `unknown` + finding raised; genuinely-empty → `empty` + finding suppressed — plus the line counter itself.

vitest 3068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)