### PR TITLE
Say why an OpenClaw turn failed, and let the failed turn close its task

### DIFF
--- a/bridge/src/__tests__/apme-collector.test.ts
+++ b/bridge/src/__tests__/apme-collector.test.ts
@@ -316,4 +316,45 @@ describe('ApmeCollector', () => {
     collector.ingestHook('s-resend', 'UserPromptSubmit', { prompt: '반복 질문' });
     expect(store.listTurns(runId).length).toBe(3);
   });
+
+  it('an agent_error span records the failure reason in the trajectory without closing the task', async () => {
+    const collector = new ApmeCollector(store);
+    const runId = collector.openRun({ sessionId: 's-err', agentType: 'openclaw', projectName: 'OpenClaw' });
+    collector.ingestHook('s-err', 'UserPromptSubmit', { prompt: 'summarize today' });
+
+    collector.ingestSpan('s-err', {
+      traceId: 't', spanId: 'sp1', name: 'agentdeck.agent.error', kind: 'agent_error',
+      ts: Date.now(),
+      attributes: {
+        'agentdeck.error_label': 'The AI service is temporarily overloaded. Please try again in a moment.',
+        'agentdeck.error_detail': 'kind unavailable · run 95babe45',
+      },
+    });
+
+    const taskId = store.listTasksForRun(runId)[0]?.id;
+    expect(taskId).toBeTruthy();
+    const sample = store.getSample(taskId!);
+    const info = sample!.events.find((e) => e.kind === 'info');
+    // Before this, a failed turn reached the eval as a turn_start with no
+    // response and no annotation — indistinguishable from a dropped event.
+    expect(info).toMatchObject({
+      kind: 'info',
+      label: 'The AI service is temporarily overloaded. Please try again in a moment.',
+      detail: 'kind unavailable · run 95babe45',
+    });
+    // The task stays open: the agent may retry the same prompt, and the
+    // boundary belongs to the adapter's idle-gap timer.
+    expect(store.listTasksForRun(runId)[0].boundarySignal).toBe('open');
+  });
+
+  it('drops an agent_error span with no open task instead of inventing one', async () => {
+    const collector = new ApmeCollector(store);
+    const runId = collector.openRun({ sessionId: 's-err2', agentType: 'openclaw', projectName: 'OpenClaw' });
+    collector.ingestSpan('s-err2', {
+      traceId: 't', spanId: 'sp1', name: 'agentdeck.agent.error', kind: 'agent_error',
+      ts: Date.now(),
+      attributes: { 'agentdeck.error_label': 'boom' },
+    });
+    expect(store.listTasksForRun(runId).length).toBe(0);
+  });
 });

--- a/bridge/src/__tests__/openclaw-chat-error.test.ts
+++ b/bridge/src/__tests__/openclaw-chat-error.test.ts
@@ -1,0 +1,123 @@
+/**
+ * OpenClaw chat `error` → timeline row + APME lifecycle.
+ *
+ * A real one (2026-08-17 10:41): z.ai answered `glm-5.2` with HTTP 429,
+ * OpenClaw's failover gave up on that profile and threw
+ * `FailoverError: The AI service is temporarily overloaded...`, and the row
+ * that reached the timeline was that sentence and nothing else — no duration,
+ * no tools, no run id. Diagnosing it meant opening the gateway log by hand.
+ * Worse, the turn's APME task was left open: `chat.send` clears the idle-gap
+ * timer and only `final` re-armed it, so a prompt that errored and was then
+ * abandoned never closed its task at all.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const ingestSpan = vi.fn();
+vi.mock('../apme/index.js', () => ({
+  getApme: () => ({ collector: { ingestSpan } }),
+}));
+
+import { OpenClawAdapter } from '../adapters/openclaw.js';
+import type { AdapterEvent, TimelineEntry, TelemetrySpan } from '@agentdeck/shared';
+
+function collectTimeline(adapter: OpenClawAdapter): TimelineEntry[] {
+  const out: TimelineEntry[] = [];
+  adapter.on('event', (evt: AdapterEvent) => {
+    if (evt.source === 'timeline' && evt.entry && !evt.upsert) out.push(evt.entry);
+  });
+  return out;
+}
+
+function gw(adapter: OpenClawAdapter, event: string, payload: Record<string, unknown>): void {
+  (adapter as unknown as { handleGatewayEvent(e: string, p: Record<string, unknown>): void })
+    .handleGatewayEvent(event, payload);
+}
+
+const OVERLOADED = 'The AI service is temporarily overloaded. Please try again in a moment.';
+
+function errorFrame(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    state: 'error',
+    runId: '95babe45-b6b5-4a19-b199-44ae7956e4d8',
+    sessionKey: 's1',
+    errorMessage: OVERLOADED,
+    errorKind: 'unavailable',
+    stopReason: 'error',
+    ...extra,
+  };
+}
+
+describe('OpenClaw chat error → timeline row', () => {
+  it('keeps the provider sentence as the row label and puts the turn context in detail', () => {
+    const adapter = new OpenClawAdapter({ autoReconnect: false });
+    const rows = collectTimeline(adapter);
+    (adapter as unknown as { lastPrompt: string | null }).lastPrompt = '오늘 요약해줘';
+
+    gw(adapter, 'chat', { state: 'delta', runId: 'r1', sessionKey: 's1' });
+    gw(adapter, 'exec.approval.requested', { id: 'a1', command: 'bash -lc ls' });
+    gw(adapter, 'chat', errorFrame());
+
+    const errors = rows.filter((r) => r.type === 'error');
+    expect(errors.length).toBe(1);
+    expect(errors[0].raw).toBe(OVERLOADED);
+    // The gateway's error frame reports no provider and no model, so the row
+    // carries what it DOES have — including the run id, which is the join key
+    // into the gateway log where the provider/model and HTTP status live.
+    expect(errors[0].detail).toContain('kind unavailable');
+    expect(errors[0].detail).toContain('stop error');
+    expect(errors[0].detail).toContain('run 95babe45');
+    expect(errors[0].detail).toContain('1 tool: bash');
+    // A failed turn is still a turn: it gets the same time bounds as a close.
+    expect(errors[0].startedAt).toBeTypeOf('number');
+    expect(errors[0].endedAt).toBeTypeOf('number');
+  });
+
+  it('flags an errored gateway-initiated turn automated, like every other close row', () => {
+    const adapter = new OpenClawAdapter({ autoReconnect: false });
+    const rows = collectTimeline(adapter);
+
+    // No lastPrompt → the delta path flags the chat as automated (cron).
+    gw(adapter, 'chat', { state: 'delta', runId: 'r2', sessionKey: 's1' });
+    gw(adapter, 'chat', errorFrame({ runId: 'r2' }));
+
+    const err = rows.find((r) => r.type === 'error');
+    // Without this an errored cron turn was indistinguishable from a user's.
+    expect(err?.automated).toBe(true);
+  });
+
+  it('describes a message-less error frame instead of writing the word "unknown"', () => {
+    const adapter = new OpenClawAdapter({ autoReconnect: false });
+    const rows = collectTimeline(adapter);
+
+    gw(adapter, 'chat', { state: 'error', runId: 'r3', sessionKey: 's1', errorKind: 'unavailable' });
+
+    expect(rows.find((r) => r.type === 'error')?.raw).toBe('Chat error (unavailable)');
+  });
+});
+
+describe('OpenClaw chat error → APME lifecycle', () => {
+  it('records the failure and re-arms the idle-gap timer so the task can still close', () => {
+    ingestSpan.mockClear();
+    const adapter = new OpenClawAdapter({ autoReconnect: false });
+    adapter.setApmeSession('openclaw-gateway', '/tmp/proj');
+    const idleTimer = () => (adapter as unknown as { apmeIdleTimer: NodeJS.Timeout | null }).apmeIdleTimer;
+
+    // `chat.send` clears the timer; that is the state a failing turn starts in.
+    (adapter as unknown as { clearIdleGapTimer(): void }).clearIdleGapTimer();
+    expect(idleTimer()).toBeNull();
+
+    gw(adapter, 'chat', { state: 'delta', runId: 'r1', sessionKey: 's1' });
+    gw(adapter, 'chat', errorFrame());
+
+    const spans = ingestSpan.mock.calls.map((c) => c[1] as TelemetrySpan);
+    const err = spans.find((s) => s.kind === 'agent_error');
+    expect(err).toBeDefined();
+    expect(err!.attributes['agentdeck.error_label']).toBe(OVERLOADED);
+    // The failure must not close the task — the agent may retry the prompt.
+    expect(spans.some((s) => s.kind === 'task_boundary')).toBe(false);
+    // …but the timer that eventually WILL close it has to be running again.
+    expect(idleTimer()).not.toBeNull();
+
+    (adapter as unknown as { clearIdleGapTimer(): void }).clearIdleGapTimer();
+  });
+});

--- a/bridge/src/__tests__/openclaw-hook.test.ts
+++ b/bridge/src/__tests__/openclaw-hook.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import {
   openclawChatEventToSpans,
+  openclawChatErrorLabel,
+  openclawChatErrorDetail,
   openclawIdleGapTaskBoundary,
   openclawChatSendToSpan,
   OPENCLAW_IDLE_GAP_MS,
 } from '../apme/adapters/openclaw-hook.js';
-import type { AdapterContext, ChatEventPayload } from '@agentdeck/shared';
+import { sampleEventToTimeline } from '../apme/sample-to-timeline.js';
+import type { AdapterContext, ChatEventPayload, ApmeSampleEventRow } from '@agentdeck/shared';
 
 const ctx: AdapterContext = {
   sessionId: 'sess',
@@ -66,13 +69,17 @@ describe('openclaw-hook → telemetry spans', () => {
     expect(spans[0].attributes['agentdeck.boundary_signal']).toBe('manual');
   });
 
-  it('chat.error emits nothing — the agent may retry, idle timer keeps running', () => {
+  it('chat.error emits an agent_error span — and NOT a task_boundary, the agent may retry', () => {
     const spans = openclawChatEventToSpans(ctx, {
       state: 'error',
       runId: 'r1',
       error: 'rate limited',
     });
-    expect(spans).toEqual([]);
+    expect(spans.length).toBe(1);
+    expect(spans[0].kind).toBe('agent_error');
+    expect(spans[0].attributes['agentdeck.error_label']).toBe('rate limited');
+    // The failure must not close the task — that stays with the idle-gap timer.
+    expect(spans.some((s) => s.kind === 'task_boundary')).toBe(false);
   });
 
   it('idle-gap task_boundary span carries boundary_signal=idle_gap', () => {
@@ -80,6 +87,68 @@ describe('openclaw-hook → telemetry spans', () => {
     expect(span.kind).toBe('task_boundary');
     expect(span.attributes['agentdeck.boundary_signal']).toBe('idle_gap');
     expect(span.attributes['agentdeck.agent_type']).toBe('openclaw');
+  });
+
+  it('agent_error carries the turn context the Gateway frame omits', () => {
+    const spans = openclawChatEventToSpans(ctx, {
+      state: 'error',
+      runId: '95babe45-b6b5-4a19-b199-44ae7956e4d8',
+      error: 'The AI service is temporarily overloaded. Please try again in a moment.',
+      errorKind: 'unavailable',
+      stopReason: 'error',
+      durationSec: 12,
+      toolNames: ['bash', 'read'],
+    });
+    const detail = spans[0].attributes['agentdeck.error_detail'] as string;
+    // Without these the row said only what the provider replied — nothing
+    // about this turn — so diagnosing it meant opening the gateway log.
+    expect(detail).toContain('failed after 12s');
+    expect(detail).toContain('2 tools: bash, read');
+    expect(detail).toContain('kind unavailable');
+    expect(detail).toContain('stop error');
+    // Truncated run id: the join key into the OpenClaw gateway log.
+    expect(detail).toContain('run 95babe45');
+  });
+
+  it('agent_error falls back to a describable label when the frame carries no message', () => {
+    // The previous fallback was the bare word "unknown", which as a whole
+    // timeline row told the reader nothing at all.
+    expect(openclawChatErrorLabel({ state: 'error', errorKind: 'unavailable' }))
+      .toBe('Chat error (unavailable)');
+    expect(openclawChatErrorLabel({ state: 'error' })).toBe('Chat error');
+  });
+
+  it('omits detail entirely when it would only repeat the label', () => {
+    expect(openclawChatErrorDetail({ state: 'error', error: 'boom' })).toBeUndefined();
+  });
+
+  it('label is byte-equal to the projected row raw, so the two never render twice', () => {
+    // Under AGENTDECK_TIMELINE_PROJECTION=1 the `info` event this span becomes
+    // is projected back into an `error` row while the adapter's own row is NOT
+    // suppressed (`error` is not in PROJECTED_TYPES). The store's exact-dedup
+    // (same type + raw within 8 s) is what collapses them — which only holds
+    // while both strings are identical, hence the shared label helper.
+    const payload = {
+      state: 'error' as const,
+      runId: 'r1',
+      error: 'x'.repeat(400),
+      errorKind: 'unavailable',
+    };
+    const label = openclawChatErrorLabel(payload);
+    const row: ApmeSampleEventRow = {
+      taskId: 't1', runId: 'r1', turnIndex: 0, turnId: null, seq: 1,
+      ts: 1, kind: 'info', model: null, inputTokens: null, outputTokens: null,
+      costUsd: null, latencyMs: null, toolName: null, toolStatus: null,
+      toolError: null,
+      payload: JSON.stringify({ label, detail: openclawChatErrorDetail(payload) }),
+      dedupKey: 'k',
+    };
+    const projected = sampleEventToTimeline(row, {
+      sessionId: 'openclaw-gateway', runId: 'r1', taskId: 't1',
+      agentType: 'openclaw', projectName: 'OpenClaw',
+    });
+    expect(projected?.type).toBe('error');
+    expect(projected?.raw).toBe(label);
   });
 
   it('all emitted spans propagate traceId for run correlation', () => {

--- a/bridge/src/adapters/openclaw.ts
+++ b/bridge/src/adapters/openclaw.ts
@@ -35,11 +35,14 @@ import { fetchModelCatalog, getDefaultModelName, invalidateModelCache } from '..
 import { getApme } from '../apme/index.js';
 import {
   openclawChatEventToSpans,
+  openclawChatErrorLabel,
+  openclawChatErrorDetail,
   openclawChatSendToSpan,
   openclawIdleGapTaskBoundary,
   openclawSessionToolToSpans,
   openclawSessionMessageToSpans,
   OPENCLAW_IDLE_GAP_MS,
+  type OpenClawChatEventInput,
 } from '../apme/adapters/openclaw-hook.js';
 import type { SessionToolPayload, SessionMessagePayload } from '@agentdeck/shared';
 
@@ -1015,15 +1018,57 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
           }
 
           case 'error': {
-            const errMsg = (payload.errorMessage as string) || 'unknown';
+            // The Gateway's error frame reports only the user-facing message
+            // plus `errorKind`/`stopReason`/`runId` — never the provider or
+            // model that failed (OpenClaw's failover means the failing model
+            // isn't the one the turn ends on anyway). So the row is built from
+            // the frame PLUS this adapter's own turn counters; anything not
+            // reported stays absent rather than getting guessed. `runId` is
+            // the join key into the gateway log, where the provider/model and
+            // the HTTP status do live.
+            //
+            // The frame spells the sentence `errorMessage` while
+            // `ChatEventPayload` declares `error` — accept either rather than
+            // silently losing it to a name mismatch.
+            const errText = [payload.errorMessage, payload.error]
+              .find((v): v is string => typeof v === 'string' && v.trim().length > 0)?.trim();
+            const errInput: OpenClawChatEventInput = {
+              state: 'error',
+              ...(errText ? { error: errText } : {}),
+              ...(typeof payload.errorKind === 'string' ? { errorKind: payload.errorKind } : {}),
+              ...(typeof payload.stopReason === 'string' ? { stopReason: payload.stopReason } : {}),
+              ...(runId ? { runId } : {}),
+              ...(sessionKey ? { sessionKey } : {}),
+              durationSec: this.chatStarted ? Math.round((Date.now() - this.chatStartTime) / 1000) : 0,
+              toolNames: [...this.chatToolNames],
+            };
+            const errLabel = openclawChatErrorLabel(errInput);
+            const errDetail = openclawChatErrorDetail(errInput);
+            const errTs = Date.now();
             this.emitTimelineEntry({
-              ts: Date.now(), type: 'error', raw: errMsg,
+              ts: errTs, type: 'error', raw: errLabel,
+              ...(errDetail ? { detail: errDetail } : {}),
+              // Parity with the `final`/`aborted` rows: without this an
+              // errored cron turn is indistinguishable from a user's.
+              ...(this.chatIsAutomated ? { automated: true } : {}),
+              ...(this.chatStarted ? { startedAt: this.chatStartTime, endedAt: errTs } : {}),
             });
+
+            // APME: record the failure in the trajectory, then re-arm the
+            // idle-gap timer. `chat.send` cleared that timer and only `final`
+            // used to re-arm it, so a prompt that errored and was then
+            // abandoned left its task open indefinitely.
+            const errCtx = this.buildApmeCtx();
+            if (errCtx) {
+              this.ingestApmeSpans(openclawChatEventToSpans(errCtx, errInput));
+              this.armIdleGapTimer();
+            }
+
             this.chatStarted = false;
             this.lastPrompt = null;
             this.accumulatedResponse = '';
             this.currentRunId = null;
-            debug('adapter:openclaw', `Chat error: ${errMsg}`);
+            debug('adapter:openclaw', `Chat error: ${errLabel}`);
             this.emitAdapterEvent({ source: 'parser', event: 'idle' });
             break;
           }

--- a/bridge/src/apme/adapters/openclaw-hook.ts
+++ b/bridge/src/apme/adapters/openclaw-hook.ts
@@ -72,6 +72,91 @@ import { spanNameForKind } from '@agentdeck/shared';
 export const OPENCLAW_IDLE_GAP_MS = 90_000;
 
 /**
+ * `ChatEventPayload` widened with the turn facts only the OpenClaw adapter
+ * holds. The Gateway's `chat` error frame carries just
+ * `errorMessage`/`errorKind`/`stopReason`/`runId` — no provider, no model, and
+ * nothing about what the turn had already done — so "how long did it run" and
+ * "which tools ran" have to come from the adapter's own turn counters.
+ *
+ * Kept here rather than on `ChatEventPayload` (`shared/src/gateway-protocol.ts`)
+ * because that type describes the wire, and these fields are not on the wire.
+ * `ChatEventPayload` is assignable to this, so existing callers are unaffected.
+ */
+export type OpenClawChatEventInput = ChatEventPayload & {
+  /** Gateway `errorKind`, e.g. "unavailable". */
+  errorKind?: string;
+  /** Gateway `stopReason` for the failed run. */
+  stopReason?: string;
+  /** Seconds the turn ran before failing. 0/absent when unknown. */
+  durationSec?: number;
+  /** Tool names used in the failed turn, first-use order. */
+  toolNames?: readonly string[];
+};
+
+/** Cap for the one-line label. Matches the slice `sample-to-timeline.ts`
+ *  applies when projecting an `info` event, so the projected row and the
+ *  adapter's own row stay byte-equal (see `openclawChatErrorLabel`). */
+const ERROR_LABEL_MAX = 120;
+/** Cap for the detail block. Matches the projection's slice for the same reason. */
+const ERROR_DETAIL_MAX = 1000;
+
+/**
+ * One-line failure label for a `chat` error frame.
+ *
+ * **Single source on purpose.** The adapter writes this string into the
+ * timeline row's `raw`, and the same string rides the `agent_error` span into
+ * the trajectory as the `info` event's label. Under
+ * `AGENTDECK_TIMELINE_PROJECTION=1` the projection turns that `info` event
+ * back into an `error` row — if the two strings differed the user would see
+ * the same failure twice; being byte-equal, the timeline store's exact-dedup
+ * (same type + raw within 8 s) collapses them.
+ */
+export function openclawChatErrorLabel(payload: OpenClawChatEventInput): string {
+  const message = (payload.error ?? '').trim();
+  if (message) return message.slice(0, ERROR_LABEL_MAX);
+  const kind = (payload.errorKind ?? '').trim();
+  // Previously this fell back to the bare word "unknown", which as a whole
+  // timeline row told the reader nothing at all.
+  return (kind ? `Chat error (${kind})` : 'Chat error').slice(0, ERROR_LABEL_MAX);
+}
+
+/**
+ * Context block for the failure row's `detail`. The gateway message alone
+ * ("The AI service is temporarily overloaded") says what the provider replied
+ * but nothing about *this* turn, so reading the timeline used to require
+ * opening the OpenClaw gateway log to learn anything else. The run id is the
+ * join key into that log, hence its inclusion.
+ *
+ * Returns undefined when there is nothing beyond the label — a `detail` that
+ * merely repeats `raw` is noise on every surface that renders both.
+ */
+export function openclawChatErrorDetail(payload: OpenClawChatEventInput): string | undefined {
+  const lines: string[] = [];
+  const message = (payload.error ?? '').trim();
+  if (message) lines.push(message);
+
+  const facts: string[] = [];
+  const duration = payload.durationSec ?? 0;
+  if (duration > 0) facts.push(`failed after ${duration}s`);
+  const tools = (payload.toolNames ?? []).filter((t) => !!t && t.trim());
+  if (tools.length) facts.push(`${tools.length} tool${tools.length === 1 ? '' : 's'}: ${tools.join(', ')}`);
+  if (facts.length) lines.push(facts.join(' · '));
+
+  const ids: string[] = [];
+  const kind = (payload.errorKind ?? '').trim();
+  if (kind) ids.push(`kind ${kind}`);
+  const stopReason = (payload.stopReason ?? '').trim();
+  if (stopReason) ids.push(`stop ${stopReason}`);
+  const runId = (payload.runId ?? '').trim();
+  if (runId) ids.push(`run ${runId.slice(0, 8)}`);
+  if (ids.length) lines.push(ids.join(' · '));
+
+  if (lines.length === 0) return undefined;
+  if (lines.length === 1 && lines[0] === openclawChatErrorLabel(payload)) return undefined;
+  return lines.join('\n').slice(0, ERROR_DETAIL_MAX);
+}
+
+/**
  * Convert a Gateway `chat` event payload into the spans the APME collector
  * should ingest right now. Does NOT emit the idle-gap `task_boundary` —
  * that's owned by the adapter's timer (it needs setTimeout + per-session
@@ -80,7 +165,7 @@ export const OPENCLAW_IDLE_GAP_MS = 90_000;
  */
 export function openclawChatEventToSpans(
   ctx: AdapterContext,
-  payload: ChatEventPayload,
+  payload: OpenClawChatEventInput,
 ): TelemetrySpan[] {
   const ts = Date.now();
   const baseAttrs: TelemetryAttributes = {
@@ -137,10 +222,22 @@ export function openclawChatEventToSpans(
   }
 
   if (payload.state === 'error') {
-    // Error doesn't close the task — agent might retry on the same prompt.
-    // The error is recorded for context but the idle timer continues to
-    // run. Returning empty array lets the adapter keep its lifecycle state.
-    return [];
+    // Error doesn't close the task — the agent might retry on the same
+    // prompt, so the boundary stays with the adapter's idle-gap timer (which
+    // it re-arms here, exactly as it does after `final`; before that it armed
+    // nothing and a prompt that ERRORED and was then abandoned left the task
+    // open forever, which starves the eval).
+    //
+    // What this span adds is the *reason*. Returning [] meant a failed turn
+    // reached the trajectory as a turn_start with no response and no
+    // annotation — byte-identical to a turn whose response event was dropped,
+    // so neither a judge nor a human could tell a provider outage from a bug
+    // in our own capture.
+    const detail = openclawChatErrorDetail(payload);
+    return [make('agent_error', {
+      'agentdeck.error_label': openclawChatErrorLabel(payload),
+      ...(detail ? { 'agentdeck.error_detail': detail } : {}),
+    })];
   }
 
   return [];

--- a/bridge/src/apme/collector.ts
+++ b/bridge/src/apme/collector.ts
@@ -1012,6 +1012,31 @@ export class ApmeCollector {
         }
         return;
       }
+      case 'agent_error': {
+        // Record the failure in the trajectory. Deliberately does NOT close
+        // the turn or the task: the agent may retry the same prompt, and the
+        // adapter owns the boundary (OpenClaw re-arms its idle-gap timer).
+        // Without this the judge sees a turn_start with no response and no
+        // reason — indistinguishable from a dropped event.
+        const label = (a['agentdeck.error_label'] as string | undefined)?.trim();
+        if (!label) return;
+        const detail = (a['agentdeck.error_detail'] as string | undefined)?.trim();
+        const task = this.sessionToTask.get(sessionId);
+        const turnIndex = this.sessionToTurn.get(sessionId)?.index;
+        if (!task || turnIndex === undefined) {
+          debug('APME', `agent_error span dropped: no open task/turn for ${sessionId}`);
+          return;
+        }
+        this.appendSampleEvent(
+          { taskId: task.id, runId: task.runId, turnIndex, turnId: this.turnIdFor(sessionId) },
+          {
+            kind: 'info',
+            dedupCore: `agent_error:${label}`,
+            payloadObj: { label, ...(detail ? { detail } : {}) },
+          },
+        );
+        return;
+      }
       case 'raw_step': {
         const event = (a['agentdeck.raw_event'] as string | undefined) ?? 'raw';
         const payload = (a['agentdeck.raw_payload'] as Record<string, unknown> | undefined) ?? {};

--- a/docs/apme.md
+++ b/docs/apme.md
@@ -234,6 +234,10 @@ v_category_scorecard    -- (task_category, model_id) 그룹: runs, avg_overall,
 5. `usage_info` 메타데이터 → `apme.collector.updateUsage(sessionId, snapshot)`
 6. `state_changed` → `apme.collector.updateModel(sessionId, modelName)`
 
+> **실패한 턴도 턴이다 — 이유를 남기고, 경계는 그대로 둔다.** OpenClaw `chat` 의 `error` 프레임은 오래도록 궤적에 아무것도 남기지 않았다. 그래서 실패한 턴이 `turn_start` 만 있고 응답도 주석도 없는 모양으로 도착했고, 이는 **응답 이벤트가 유실된 턴과 바이트 단위로 동일**해서 judge 도 사람도 프로바이더 장애와 우리 캡처 버그를 구분할 수 없었다. 지금은 `agent_error` span(`agentdeck.error_label` / `.error_detail`)이 `info` 궤적 이벤트로 기록된다. 두 가지가 계약이다 — **(1) 태스크를 닫지 않는다**: 에이전트가 같은 프롬프트를 재시도할 수 있으므로 경계는 여전히 idle-gap 타이머 소유다. **(2) 그 타이머를 다시 건다**: `chat.send` 가 타이머를 지우고 `final` 만 다시 걸었기 때문에, 에러 후 사용자가 자리를 뜬 프롬프트는 태스크가 영영 열린 채 남아 eval 을 굶겼다. 라벨 문자열은 어댑터의 타임라인 행 `raw` 와 **같은 헬퍼**(`openclawChatErrorLabel`)에서 나온다 — `AGENTDECK_TIMELINE_PROJECTION=1` 일 때 projection 이 같은 실패를 `error` 행으로 되돌리는데, `error` 는 `PROJECTED_TYPES` 에 없어 어댑터 행이 억제되지 않으므로 두 문자열이 바이트 동일해야 스토어의 exact-dedup(같은 type+raw, 8초)이 둘을 합친다.
+>
+> Gateway 의 error 프레임은 `errorMessage`/`errorKind`/`stopReason`/`runId` 만 싣는다 — **프로바이더도 모델도 없다**(failover 때문에 실패한 모델은 턴이 끝난 모델과 애초에 다르다). 그래서 행의 `detail` 은 프레임이 준 것 + 어댑터가 아는 턴 사실(소요 시간, 사용 툴)로만 구성하고 없는 건 추측하지 않는다. `runId` 는 프로바이더·모델·HTTP 상태가 실제로 남는 OpenClaw gateway 로그로 들어가는 join key 라서 넣는다.
+
 ### BridgeCore (`bridge/src/bridge-core.ts`)
 
 - `registerSession(agentType)` → `apme.collector.openRun()` (daemon meta-session 제외)

--- a/shared/src/__tests__/timeline.test.ts
+++ b/shared/src/__tests__/timeline.test.ts
@@ -346,6 +346,26 @@ describe('isRepetitiveEntry', () => {
     expect(isRepetitiveEntry(entry, recent)).toBe(0);
   });
 
+  it('exempts error rows from the content-agnostic automated collapse', () => {
+    // The flag-only merge exists to stop cron chatter flooding the strip. On
+    // an `error` row it would collapse two automated turns that failed for
+    // completely different reasons into one row wearing the newer message —
+    // and the window is 8 h, so a whole day of distinct failures reads as one.
+    const recent: TimelineEntry[] = [
+      { ts: 500, type: 'error', raw: 'The AI service is temporarily overloaded.', automated: true },
+    ];
+    const different: TimelineEntry = {
+      ts: 800, type: 'error', raw: 'API key has run out of credits.', automated: true,
+    };
+    expect(isRepetitiveEntry(different, recent)).toBe(-1);
+
+    // A genuinely recurring failure still collapses, by similarity.
+    const same: TimelineEntry = {
+      ts: 900, type: 'error', raw: 'The AI service is temporarily overloaded.', automated: true,
+    };
+    expect(isRepetitiveEntry(same, recent)).toBe(0);
+  });
+
   it('does not dedup automated vs non-automated', () => {
     const recent: TimelineEntry[] = [
       { ts: 500, type: 'chat_end', raw: 'WhatsApp 연결 확인 완료', automated: true },

--- a/shared/src/telemetry-envelope.ts
+++ b/shared/src/telemetry-envelope.ts
@@ -37,6 +37,13 @@ export type TelemetrySpanKind =
   /** Model id resolved or usage snapshot updated. Carries either
    *  `gen_ai.request.model` or `agentdeck.usage.*`. */
   | 'session_meta'
+  /** The agent reported a failure for the current turn (provider error,
+   *  failover exhaustion, transport give-up). Records the reason in the
+   *  trajectory WITHOUT closing the turn or the task — the agent may retry
+   *  the same prompt. Carries `agentdeck.error_label` (+ optional
+   *  `agentdeck.error_detail`). Without it a failed turn is byte-identical
+   *  to a turn whose response event was simply dropped. */
+  | 'agent_error'
   /** Generic step — record verbatim into `steps` table without lifecycle
    *  side effects. Carries `agentdeck.raw_event` + `agentdeck.raw_payload`. */
   | 'raw_step';
@@ -68,6 +75,12 @@ export interface TelemetryAttributes {
   'agentdeck.raw_payload'?: Record<string, unknown>;
   /** Tool name as reported by the source (Claude hooks use `tool_name`). */
   'agentdeck.tool_name'?: string;
+  /** One-line failure label for agent_error. Doubles as the timeline row's
+   *  `raw`, so the projected row and the adapter's own row are byte-equal
+   *  and the store's exact-dedup collapses them instead of rendering twice. */
+  'agentdeck.error_label'?: string;
+  /** Optional multi-line context for agent_error (duration, tools, ids). */
+  'agentdeck.error_detail'?: string;
 
   // ─── Usage (session_meta when usage updated) ───
   'agentdeck.usage.input_tokens'?: number;
@@ -135,6 +148,7 @@ export function spanNameForKind(kind: TelemetrySpanKind): string {
     case 'tool_result':   return 'agentdeck.tool.result';
     case 'task_boundary': return 'agentdeck.task.boundary';
     case 'session_meta':  return 'agentdeck.session.meta';
+    case 'agent_error':   return 'agentdeck.agent.error';
     case 'raw_step':      return 'agentdeck.step.raw';
   }
 }

--- a/shared/src/timeline.ts
+++ b/shared/src/timeline.ts
@@ -566,8 +566,14 @@ export function isRepetitiveEntry(
     // old behavior).
     if (entry.sessionId && e.sessionId && entry.sessionId !== e.sessionId) continue;
 
-    // Automated entries: content-agnostic dedup (any two automated chats collapse)
-    if (entry.automated && e.automated) return i;
+    // Automated entries: content-agnostic dedup (any two automated chats collapse).
+    // NOT for `error` rows. That rule exists to stop cron chatter from flooding
+    // the strip, and it merges on the flag alone — so with an 8 h window two
+    // automated turns that failed for completely different reasons would
+    // collapse into one row wearing the newer message. A failure's whole value
+    // IS its content; errors still dedup by similarity below, which keeps a
+    // genuinely recurring failure at one row with a repeatCount.
+    if (entry.automated && e.automated && entry.type !== 'error') return i;
 
     const eCore = extractSemanticCore(e.raw, e.type);
     if (isSimilarCore(core, eCore)) return i;


### PR DESCRIPTION
A `chat` error frame produced a timeline row that was the provider's sentence and nothing else. On 2026-08-17 10:41 that read *"The AI service is temporarily overloaded. Please try again in a moment."* — true, but it named no run, no duration, no tools, so working out that z.ai had answered `glm-5.2` with a 429 and that OpenClaw's failover had recovered on `glm-5.3` five seconds later meant opening the gateway log by hand.

The frame carries `errorMessage`/`errorKind`/`stopReason`/`runId` and nothing more — no provider, no model (failover means the failing model isn't the one the turn ends on anyway). The row now carries those plus the adapter's own turn facts, and guesses nothing it wasn't told. `runId` is included because it is the join key into the gateway log, where the provider, model and HTTP status actually live.

## Two bugs surfaced while wiring it

- **The turn's APME task could never close.** `chat.send` clears the idle-gap timer and only `final` re-armed it, so a prompt that errored and was then abandoned left its task open indefinitely — an open task starves the eval. `error` now re-arms it, which is what the code always claimed ("the idle timer continues to run") but never did.
- **The failure left no trace in the trajectory**, so a failed turn reached the judge as a `turn_start` with no response and no annotation — byte-identical to a turn whose response event was dropped. A new `agent_error` span records the reason as an `info` event, activating a trajectory kind that had readers on both sides and no producer. It deliberately does **not** close the turn or the task; the agent may retry.

## Notes

- The label is minted by one helper shared by the timeline row and the span. Under `AGENTDECK_TIMELINE_PROJECTION=1` the projection turns that `info` event back into an `error` row while the adapter's own row is not suppressed (`error` is not in `PROJECTED_TYPES`) — only byte-equal strings let the store's exact-dedup collapse them into one.
- `error` rows are exempted from the content-agnostic automated collapse. The row is now flagged `automated` for parity with every other close row, and that flag merges on the flag alone over an 8 h window, so two cron turns failing for entirely different reasons would have become one row wearing the newer message. Similarity dedup still folds a genuinely recurring failure into one row with a `repeatCount`.
- Message-less frames now read `Chat error (<kind>)` instead of the bare word `unknown`.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm test` (3076 passed, 1 skipped — `fm-helper-build` skips without the prebuilt Swift helper), `npx vitest run --coverage`, `pnpm docs:check`, `pnpm design-system:check`, `node scripts/check-preview-mirror-sync.mjs` — all green.

New/updated tests cover the enriched row, the `automated` parity, the message-less fallback, the idle-timer re-arm, the collector's `info` write, the no-open-task drop, the projection byte-equality, and the dedup exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)