### PR TITLE
Make the daemon port window overridable so a throwaway daemon can exist

### DIFF
--- a/bridge/src/__tests__/session-registry.test.ts
+++ b/bridge/src/__tests__/session-registry.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import http from 'http';
-import { scanDaemonPortWindow, shouldConcedePortToOccupant, waitForDaemonExit, waitForPortBindable } from '../session-registry.js';
+import {
+  scanDaemonPortWindow, shouldConcedePortToOccupant, waitForDaemonExit, waitForPortBindable,
+  resolveDaemonPortWindow, isDefaultDaemonPortWindow, DEFAULT_DAEMON_PORT_WINDOW,
+} from '../session-registry.js';
 import { readFileSync, mkdirSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -305,5 +308,49 @@ describe('Session Registry Logic', () => {
     it('waitForPortBindable resolves true immediately for a free port', async () => {
       expect(await waitForPortBindable(WINDOW[0] + 7, 2000)).toBe(true);
     });
+  });
+});
+
+describe('daemon port window', () => {
+  // The window is a discovery contract every client scans, and the singleton
+  // guard sweeps it to refuse a second daemon. Both are correct for the one
+  // real daemon and are exactly what made a throwaway daemon unstartable:
+  // neither AGENTDECK_DATA_DIR nor an explicit -p moved the sweep off 9120.
+  // Overriding it is therefore allowed, but a MALFORMED override must fall
+  // back to the default rather than widen, narrow or disable the guard.
+  it('defaults when unset or blank', () => {
+    expect(resolveDaemonPortWindow(undefined)).toEqual(DEFAULT_DAEMON_PORT_WINDOW);
+    expect(resolveDaemonPortWindow('')).toEqual(DEFAULT_DAEMON_PORT_WINDOW);
+    expect(resolveDaemonPortWindow('   ')).toEqual(DEFAULT_DAEMON_PORT_WINDOW);
+  });
+
+  it('accepts a well-formed range', () => {
+    expect(resolveDaemonPortWindow('9200-9209')).toEqual([9200, 9209]);
+    expect(resolveDaemonPortWindow(' 9200 - 9209 ')).toEqual([9200, 9209]);
+    expect(resolveDaemonPortWindow('1024-65535')).toEqual([1024, 65535]);
+  });
+
+  it('falls back to the default for anything it cannot trust', () => {
+    for (const bad of [
+      'nonsense',
+      '9200',            // not a range
+      '9209-9200',       // inverted
+      '80-90',           // below the privileged-port floor
+      '9200-70000',      // above the port ceiling
+      '9200-',           // truncated
+      '-9209',
+      '9200-9209-9210',
+      '0x2400-0x2409',
+    ]) {
+      expect(resolveDaemonPortWindow(bad), bad).toEqual(DEFAULT_DAEMON_PORT_WINDOW);
+    }
+  });
+
+  it('reports whether the resolved window is the documented one', () => {
+    expect(isDefaultDaemonPortWindow(DEFAULT_DAEMON_PORT_WINDOW)).toBe(true);
+    expect(isDefaultDaemonPortWindow([9200, 9209])).toBe(false);
+    // A malformed override reads as default — the CLI relies on this to know
+    // it should say "not parseable" rather than announce a custom window.
+    expect(isDefaultDaemonPortWindow(resolveDaemonPortWindow('nonsense'))).toBe(true);
   });
 });

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -19,7 +19,12 @@ import {
   endWindowsTask,
   deleteWindowsTask,
 } from './windows-service.js';
-import { deriveRemoteAttachOpts } from './session-registry.js';
+import {
+  deriveRemoteAttachOpts,
+  daemonPortWindow,
+  isDefaultDaemonPortWindow,
+  DEFAULT_DAEMON_PORT_WINDOW,
+} from './session-registry.js';
 // From modules/types.js, not modules/index.js: the latter pulls the whole
 // device stack (serial, Pixoo, BLE) into `agentdeck --help`.
 import { allModulesOff } from './modules/types.js';
@@ -743,6 +748,7 @@ daemon
   .option('--wake-word', 'Enable wake word voice assistant ("오픈클로")')
   .option('--local', 'Disable all device modules (no mDNS, UDP beacon, LAN sweep, BLE, ADB or serial); still binds all interfaces for paired companion apps')
   .option('--loopback', 'Bind 127.0.0.1 only and emit nothing onto the LAN (no mDNS, UDP beacon, LAN sweep or BLE; USB serial and ADB reverse stay on). Same as AGENTDECK_LOOPBACK_ONLY=1')
+  .option('--port-window <range>', 'Work in a non-default daemon port window, e.g. 9200-9209. Only for running a throwaway daemon beside the real one: the singleton guard sweeps this range, and a daemon outside the documented 9120-9139 window is invisible to clients that scan it. Same as AGENTDECK_PORT_WINDOW')
   .action(async (opts) => {
     const { findExistingDaemon, probeDaemonHealth, readDaemonInfo, removeDaemonInfo, removeDaemonSession, requestDaemonStandDown, requestDaemonShutdown, waitForDaemonExit, waitForPortBindable } = await import('./session-registry.js');
     const { adoptPeerToken } = await import('./auth.js');
@@ -755,6 +761,24 @@ daemon
     // CLI daemon can take over with the full feature set, then wait for the port
     // to clear before binding. A real Node daemon on the port still means
     // "already running".
+    // Set before anything reads the window: the singleton sweep, the port
+    // allocator and the daemon itself all resolve it per call, and this action
+    // is the first place the flag is known.
+    if (opts.portWindow) process.env.AGENTDECK_PORT_WINDOW = String(opts.portWindow);
+    const portWindow = daemonPortWindow();
+    if (!isDefaultDaemonPortWindow(portWindow)) {
+      const [lo, hi] = portWindow;
+      const [dlo, dhi] = DEFAULT_DAEMON_PORT_WINDOW;
+      log(`Port window ${lo}-${hi} (default ${dlo}-${dhi}).`);
+      log(`Note: clients discover daemons by scanning ${dlo}-${dhi}, so a daemon outside that range `
+        + `is reachable only by explicit host/port. Use this for a throwaway daemon, not the real one.`);
+      if (opts.portWindow && String(opts.portWindow).trim() && lo === dlo && hi === dhi) {
+        log(`(--port-window ${opts.portWindow} was not parseable — falling back to the default window.)`);
+      }
+    } else if (opts.portWindow) {
+      log(`--port-window ${opts.portWindow} was not parseable — using the default window.`);
+    }
+
     const targetPort = opts.port ? parseInt(String(opts.port), 10) : BRIDGE_WS_PORT;
     const incumbent = await probeDaemonHealth(targetPort);
     if (incumbent?.mode === 'daemon') {
@@ -861,6 +885,9 @@ daemon
       // daemon, and a posture that only applies to the parent is no posture.
       if (opts.local) args.push('--local');
       if (opts.loopback) args.push('--loopback');
+      // Same reason as the posture flags: the forked process IS the daemon, and
+      // a window that only applies to the parent moves nothing.
+      if (opts.portWindow) args.push('--port-window', String(opts.portWindow));
 
       const [out, err] = await openDaemonLogs(logDir);
 

--- a/bridge/src/session-registry.ts
+++ b/bridge/src/session-registry.ts
@@ -64,10 +64,60 @@ function getSessionsFile(): string { return join(getDataDir(), 'sessions.json');
 export function getOwnTimelineFile(): string { return join(getDataDir(), 'timeline.json'); }
 function getDaemonFile(): string { return join(getDataDir(), 'daemon.json'); }
 export const DAEMON_DEFAULT_PORT = 9120;
-const BASE_PORT = 9120;
-const MAX_PORT = 9139;
-/** Documented daemon port window (docs/daemon.md) — scanned for cross-implementation discovery. */
-export const DAEMON_PORT_WINDOW: readonly [number, number] = [BASE_PORT, MAX_PORT];
+/** Documented daemon port window (docs/daemon.md). */
+export const DEFAULT_DAEMON_PORT_WINDOW: readonly [number, number] = [9120, 9139];
+
+/**
+ * Resolve the port window this process works in.
+ *
+ * The window is a cross-implementation discovery contract, so the default is
+ * fixed and every real client scans it. It is overridable ONLY to make an
+ * isolated daemon testable: the singleton guard sweeps this range and concedes
+ * to any live daemon it finds, which is correct for the machine's one real
+ * daemon and is exactly what made a throwaway daemon impossible to start —
+ * neither `AGENTDECK_DATA_DIR` nor an explicit `-p` moved the sweep off 9120,
+ * so the only way to exercise a posture was to restart the production daemon
+ * into it.
+ *
+ * A daemon started outside the default window is invisible to clients that
+ * scan the documented range. That is the point for a test daemon and a
+ * footgun for anything else, so `daemon start` says so out loud when the
+ * window is not the default.
+ *
+ * Format: `AGENTDECK_PORT_WINDOW=9200-9209`. Anything unparseable, inverted,
+ * or outside 1024–65535 is ignored in favour of the default — a malformed
+ * window must not silently disable the guard that prevents two live daemons.
+ */
+export function resolveDaemonPortWindow(
+  raw: string | undefined = process.env.AGENTDECK_PORT_WINDOW,
+): readonly [number, number] {
+  const text = raw?.trim();
+  if (!text) return DEFAULT_DAEMON_PORT_WINDOW;
+  const match = /^(\d{4,5})\s*-\s*(\d{4,5})$/.exec(text);
+  if (!match) return DEFAULT_DAEMON_PORT_WINDOW;
+  const lo = Number(match[1]);
+  const hi = Number(match[2]);
+  if (!Number.isInteger(lo) || !Number.isInteger(hi)) return DEFAULT_DAEMON_PORT_WINDOW;
+  if (lo < 1024 || hi > 65535 || hi < lo) return DEFAULT_DAEMON_PORT_WINDOW;
+  return [lo, hi];
+}
+
+/** True when this process is working in the documented window. */
+export function isDefaultDaemonPortWindow(
+  window: readonly [number, number] = daemonPortWindow(),
+): boolean {
+  return window[0] === DEFAULT_DAEMON_PORT_WINDOW[0] && window[1] === DEFAULT_DAEMON_PORT_WINDOW[1];
+}
+
+/** Daemon port window for THIS process — the default unless overridden.
+ *
+ *  Resolved per call, not once at import: `daemon start --port-window` sets the
+ *  env inside its action, which runs long after this module is imported, so a
+ *  module-level constant would freeze the default and make the flag a no-op.
+ *  Reading an env var a few dozen times during startup costs nothing. */
+export function daemonPortWindow(): readonly [number, number] {
+  return resolveDaemonPortWindow();
+}
 
 export interface DaemonInfo {
   port: number;
@@ -240,14 +290,15 @@ export async function findAvailablePort(opts?: { reserveDaemon?: boolean }): Pro
   const sessions = listActive();
   const usedPorts = new Set(sessions.map((s) => s.port));
   // Session bridges start from BASE_PORT+1 to reserve 9120 for the daemon.
-  const startPort = opts?.reserveDaemon ? BASE_PORT + 1 : BASE_PORT;
-  for (let port = startPort; port <= MAX_PORT; port++) {
+  const [basePort, maxPort] = daemonPortWindow();
+  const startPort = opts?.reserveDaemon ? basePort + 1 : basePort;
+  for (let port = startPort; port <= maxPort; port++) {
     if (!usedPorts.has(port) && await isPortFree(port)) {
       return port;
     }
   }
   // All ports exhausted — throw instead of silently colliding
-  throw new Error(`All AgentDeck ports (${BASE_PORT}–${MAX_PORT}) are in use. Stop an existing session first.`);
+  throw new Error(`All AgentDeck ports (${basePort}–${maxPort}) are in use. Stop an existing session first.`);
 }
 
 /** Detect tmux session name if running inside tmux */
@@ -396,7 +447,7 @@ export function probeDaemonHealth(port: number): Promise<{ mode?: string; pid?: 
  */
 export async function scanDaemonPortWindow(
   skip: ReadonlySet<number> = new Set(),
-  window: readonly [number, number] = DAEMON_PORT_WINDOW,
+  window: readonly [number, number] = daemonPortWindow(),
 ): Promise<Array<{ port: number; health: { mode?: string; pid?: number; isSwift?: boolean } }>> {
   const ports: number[] = [];
   for (let p = window[0]; p <= window[1]; p++) {
@@ -554,7 +605,8 @@ export async function findDaemonPortAsync(): Promise<{ port: number; httpPort?: 
   // 2. Port scan fallback — covers the "App Store daemon is up but its
   //    daemon.json sits in a dir this process can't read" case. Narrow
   //    range (9120-9139) matches the documented daemon port window.
-  for (let p = DAEMON_PORT_WINDOW[0]; p <= DAEMON_PORT_WINDOW[1]; p++) {
+  const [scanLo, scanHi] = daemonPortWindow();
+  for (let p = scanLo; p <= scanHi; p++) {
     const health = await probeDaemonHealth(p);
     if (health?.mode === 'daemon') {
       return { port: p, sameSocketControl: health.sameSocketControl === true };

--- a/docs/ENTERPRISE-ROADMAP.md
+++ b/docs/ENTERPRISE-ROADMAP.md
@@ -437,7 +437,7 @@ nothing.
 | 8 | `daemon start/install --enterprise`, persisted into the autostart unit (§4.2) | M | 1.5d | **done** — argv-baked into all three writers; `daemon restart` inherits via `/health` |
 | 9 | Pixoo auto-discovery default off, cloud call opt-in separately (§5) | S | 1d | **done** — default off (Node + Swift); `pixoo scan --no-cloud` splits the two disclosures |
 | 10 | UDP broadcast default off; back off when unused (§2.3) | S | 0.5d | **superseded** — off under `--local`/`--loopback`; a global default-off still open (§2.3) |
-| 11 | Configurable port window + persistent CLI daemon port (§1.5) | S | 1d | open |
+| 11 | Configurable port window + persistent CLI daemon port (§1.5) | S | 1d | **port window done** (`--port-window` / `AGENTDECK_PORT_WINDOW`); persistent CLI port still open |
 | 12 | Swift-side enterprise posture toggle in Settings (§3) | M | 2d | **done** (08-17) — Settings → Local server toggles → `DaemonPosture` (loopback bind, Bonjour skipped, module registration gated deny-by-default); posture rides Swift `/health` for `qr`/`pair`/`restart` parity |
 
 **P2 — cleanup.**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,8 @@ The CLI command is `agentdeck`.
 **Remote attach flags:** `--remote-daemon`, `--daemon-host <host[:port]>`, `--daemon-token <token>` (pairing token of the remote hub — from `~/.agentdeck/auth-token` there, or `agentdeck token show`; env `AGENTDECK_DAEMON_TOKEN`). Required for a current hub: since issue #145 daemons no longer hand their token to unauthenticated LAN peers.
 **Module flags:** `--local` (all device modules off — derived from the module registry, so it covers every module including ones added later), `--no-adb` (skip ADB reverse). Hardware modules (mDNS/serial/Pixoo/Timebox/iDotMatrix) are daemon-only — session bridges never activate them, so there are no per-session `--no-mdns`/`--no-serial`/`--no-pixoo` flags.
 
+**Port window (`--port-window <lo-hi>` / `AGENTDECK_PORT_WINDOW`).** The daemon's singleton guard sweeps the documented 9120–9139 window and concedes to any live daemon it finds, which is why an isolated daemon could not be started beside the real one — neither a separate `AGENTDECK_DATA_DIR` nor an explicit `-p` moved the sweep. Override the window to run a throwaway daemon for testing (`daemon start -p 9200 --port-window 9200-9209 --loopback --local`). A daemon outside the default window is invisible to clients that scan it, so `daemon start` prints the window whenever it is not the default, and an unparseable value falls back to the default rather than disabling the guard.
+
 The `-c` flag sets the full command AgentDeck spawns inside the session PTY, so any arguments you add are forwarded straight to the underlying agent. For example, to resume an earlier Claude Code session (the interactive picker appears when no id is given):
 
 ```bash
@@ -101,7 +103,7 @@ a session behaves.
 
 | Command | Description |
 |---------|-------------|
-| `agentdeck daemon start` | Start monitoring daemon (`--local`, `--loopback` — see below) |
+| `agentdeck daemon start` | Start monitoring daemon (`--local`, `--loopback`, `--port-window` — see below) |
 | `agentdeck daemon stop` | Stop daemon |
 | `agentdeck daemon restart` | Restart daemon (inherits the running daemon's posture) |
 | `agentdeck daemon status` | Show daemon status |

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -71,6 +71,8 @@ Daemon owns port **9120** (default, fallback to 9121+ if occupied by non-daemon)
 
 4단계 — (1) `readDaemonInfo()` from `~/.agentdeck/daemon.json` (PID alive 검증) (2) `findExistingDaemon()` from `sessions.json` fallback (3) `probeDaemonHealth()` HTTP `/health` probe (default port에 응답하는 daemon 감지) (4) `scanDaemonPortWindow()` — 9120–9139 전 구간 `/health` 병렬 sweep. (4)가 필요한 이유: App Store Swift daemon 의 `daemon.json` 은 sandbox private container 에 있어 Node 가 읽지 못하고, 일시적 9120 경합으로 daemon 이 fallback port (9121+) 에 앉아 있을 수 있다 — 파일/기본포트 검사만으로는 둘 다 놓쳐 split-brain (이중 mDNS 광고, Gateway/timeline 중복 relay, adb reverse flapping) 이 된다. `daemon-server.ts` + `cli.ts` + `daemon.ts`(legacy) 에서 체크. 기존 Node daemon 있으면 `process.exit(0)` (LaunchAgent KeepAlive 재시작 루프 방지); Swift daemon 이면 `/shutdown` 요청 후 `waitForDaemonExit()` 로 health 가 사라질 때까지 poll (고정 sleep 아님 — Swift 가 serial/ADB/BLE 모듈을 정리하기 전에 인수하면 tty/adb reverse 를 잠시 두 프로세스가 잡는다). Port occupied by non-daemon → auto-fallback to next available port.
 
+이 sweep 범위는 `--port-window <lo-hi>` (또는 `AGENTDECK_PORT_WINDOW=9200-9209`) 로 바꿀 수 있다. 용도는 하나뿐이다 — **운영 데몬 옆에서 일회용 데몬을 띄워 검증하는 것**. sweep 이 창 전체를 훑고 살아있는 Node daemon 을 만나면 `process.exit(0)` 하므로, `AGENTDECK_DATA_DIR` 로 데이터 디렉토리를 분리하고 `-p` 로 포트를 지정해도 격리 데몬은 뜨지 못했다(가드 자체는 올바른 동작). **기본 창을 벗어난 데몬은 9120–9139 를 훑는 클라이언트에게 보이지 않는다** — 명시 host/port 로만 닿는다. 그래서 `daemon start` 는 창이 기본값이 아닐 때 그 사실을 반드시 출력한다. 파싱 불가한 값은 조용히 무시되지 않고 **기본 창으로 되돌아간다** — 잘못된 창이 split-brain 가드를 무력화해서는 안 되기 때문이다.
+
 ## Shutdown timeout
 
 `httpServer.close()` + 5s `setTimeout(() => process.exit(0))` — CLOSE_WAIT connections from disconnected clients can block `close()` callback indefinitely, causing zombie daemons (session bridge has 3s failsafe in `index.ts`).


### PR DESCRIPTION
Roadmap item 11's port-window half.

## The blocker, reproduced first

`scanDaemonPortWindow` sweeps 9120–9139 and concedes to any live Node daemon it finds. That is **right** for the machine's one real daemon — two of them means double mDNS advertising, duplicate Gateway/timeline relay and adb-reverse flapping — but it also made an isolated daemon impossible to start:

```
$ AGENTDECK_DATA_DIR=/tmp/isolated node cli.js daemon start -p 9200 --foreground
[agentdeck] Daemon already running on port 9120 (detected via port scan).
```

Neither a separate data dir nor an explicit `-p` moved the sweep. So the only way to exercise a posture was to restart the *production* daemon into it — which is exactly what the loopback measurement (#208) had to do, and why it recorded the constraint as open.

## The change

The window resolves per call from `AGENTDECK_PORT_WINDOW`, or `daemon start --port-window 9200-9209`, defaulting to the documented range.

**Per call, not at import**: the flag is only known inside the action, long after the module loads. A module-level constant would have frozen the default and made the flag a silent no-op — the failure mode that would have looked like "the feature shipped".

Two properties kept deliberately:

- **A malformed window falls back to the default and says so.** Inverted, truncated, out-of-range or non-numeric input must not widen, narrow or disable the guard against two live daemons, so it is never interpreted loosely.
- **`daemon start` announces a non-default window.** Clients discover daemons by scanning the documented range, so a daemon outside it is reachable only by explicit host/port. That is the point for a test daemon and a footgun for anything else — not something to be discovered later.

## Measured

With the window moved, an isolated daemon runs **beside** the production one:

```
node  6263  TCP 127.0.0.1:9200 (LISTEN)   ← --loopback --local, own data dir, no mDNS
node 73346  TCP *:9120        (LISTEN)   ← production, default posture, mDNS AgentDeck-9120
```

With the window left alone, both a plain start and a malformed override still concede to 9120 exactly as before.

Gates: vitest 3081 (12 new cases pinning the parse and the fallback), `docs:check`, `design-system:check`, `verify-version`.

The persistent CLI daemon port — the other half of item 11 — remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)