### PR TITLE
Tell the turns that never owed a Stop apart from the ones that lost it

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,86 @@
 
 ---
 
+## 2026-08-17 — Stop 유실 5건은 전부 유실이 아니었다 (그리고 워치독은 살아 있었다)
+
+### 조사: `Synth 0`
+
+7일 창 계측이 이랬다 — 턴 100, Stop 55, **Synth 0**, NoStop 5, SessEnd 14, Open 2,
+`?` 24, 손실 "8% of 60". 워치독 복구가 0건인데 미복구 유실이 5건이면 둘 중 하나다:
+복구 경로가 프로덕션에서 한 번도 발화한 적 없거나(1.0.20 이 그랬듯), 그 5건이 워치독
+타임아웃 전에 다음 프롬프트로 닫혔거나. **0 은 죽은 경로와 구별되지 않으므로** 숫자가
+아니라 경로 발화를 직접 확인했다.
+
+경로는 살아 있었다. 격리 데몬(`-p 9199 --port-window 9190-9199 --loopback`,
+전용 `AGENTDECK_DATA_DIR`)에 가짜 transcript 와 hook POST 를 넣어 실측:
+
+```
+[watchdog] turn closed from transcript (end_turn @ ...)
+[watchdog] observed session aaaaaaaa turn ended (end_turn) — injecting synthetic Stop
+[APME]     closeTurn 63e02c35 index=0 tools=0 src=synthetic_stop
+```
+
+음성 대조군(끝나지 않은 transcript)에서는 25초 동안 발화하지 않았다. 즉 데몬 self-POST
+→ `/hooks/Stop` → collector 까지 전 구간이 동작한다.
+
+그렇다면 그 5건은 무엇이었나. 5건 전부 transcript 로 되짚어 확인했다 — **하나도 Stop
+유실이 아니었다.**
+
+- **3건: 클라이언트 중단.** `You've hit your session limit · resets 5:50pm` 이 assistant
+  레코드 하나로 `stop_reason: "stop_sequence"` 와 함께 기록되고, 그 뒤에
+  `stop_hook_summary` 가 **없다** — Claude Code 가 Stop hook 을 아예 쏘지 않는다. 워치독의
+  술어는 `end_turn` 뿐이라 걸리지 않았고, 두 건 모두 턴이 **8시간 넘게** 열려 있었다.
+- **2건: 돌지도 않은 턴.** `<task-notification>` 주입이 130ms 간격 쌍으로 들어오고 모델
+  턴 하나가 둘을 처리한다. 앞 행은 116ms 만에 다음 프롬프트에 밀려 닫혔다 — 애초에 그
+  턴에 빚진 Stop 이 없다.
+
+즉 측정된 Claude Stop 유실률은 **8% 가 아니라 0/60** 이고, 계측기가 유실이 아닌 두
+모양을 유실로 세고 있었다. (계측 도입 이래 기록된 Claude `next_prompt` 5건이 전부 이
+둘이다. 나머지 `next_prompt` 3건은 Codex 세션으로, 자기 `codex_stop` 을 갖는 다른 에이전트다.)
+
+### 해결
+
+`end_source` 에 버킷 둘을 추가했다. ESC 취소를 따로 세는 것과 정확히 같은 이유다 —
+**올 Stop 이 없었던 턴은 온 적 없는 Stop 을 보고할 수 없다.**
+
+- **`aborted`** — 클라이언트가 끝낸 턴(한도·인증·크레딧·API 오류). 워치독이
+  `stop_sequence` 를 세 번째 종료 근거로 인정해 ~15초 안에 닫는다. 통계보다 이쪽이 본질
+  이다: 중단된 턴이 8시간씩 열려 있으면 모든 기기에 PROCESSING 으로 뜨고 APME run 이
+  열린 채 남아 eval 을 굶긴다.
+- **`superseded`** — 다음 프롬프트가 밀어냈지만 그 사이 assistant 레코드가 **하나도**
+  없는 턴. 시간 임계값이 아니라 transcript 근거로 판별한다.
+
+술어를 믿기 전에 재 봤다. 로컬 transcript 211개 / assistant 레코드 61,281건에서
+`stop_reason` 은 `tool_use` 58,765 · `end_turn` 2,513 · `stop_sequence` 37 이고, 그 37건은
+전부 클라이언트 중단 메시지, **하나도** `stop_hook_summary` 가 뒤따르지 않으며, 같은 턴
+에서 assistant 작업이 이어진 것도 없다. 혼동할 양성 모양이 없다.
+
+다음 프롬프트 close 경로는 이제 tail 을 **한 번** 읽어 세 가지를 함께 답한다
+(`readOpenTurnEvidence`: 취소 마커 / 중단 레코드 / assistant 가 뭐라도 썼는지).
+`readInterruptSince` 를 대체한 것인데, 그 함수는 "읽을 수 없음"과 "근거 없음"을 같은
+`null` 로 뭉갰다 — 새 판별에서는 전자가 `next_prompt`(추측 금지), 후자가 `superseded` 로
+갈리므로 구별이 필요했다.
+
+두 새 경로 모두 격리 데몬에서 실측했다:
+
+```
+[watchdog] observed session bbbbbbbb turn ended (aborted) — injecting synthetic Stop
+[APME]     closeTurn e70cd2ed index=0 tools=0 src=aborted
+[APME]     closeTurn 7a9cf391 index=0 tools=0 src=superseded
+```
+
+### 교훈
+
+- **0 은 값이 아니라 질문이다.** 복구 0건은 "복구가 필요 없었다"와 "복구가 죽었다"를
+  구별하지 못한다. `debug()` 는 `--debug` 없이는 아무것도 쓰지 않으므로 로그의 침묵도
+  근거가 아니다. 경로를 직접 쏴 보는 것 말고 답이 없다.
+- **손실 계측기는 손실이 아닌 것을 먼저 정의해야 한다.** ESC(2026-08-15), 클라이언트
+  중단, 밀려난 프롬프트 — 셋 다 "Stop 이 빚지지 않은 턴"이고, 하나씩 발견될 때마다
+  유실률이 내려갔다. 분모 규칙을 `stopDeliveryLoss()` 한 곳에 둔 이유다.
+- **턴이 안 닫히는 버그는 통계 버그로 위장한다.** `Synth 0` 을 쫓다 나온 진짜 문제는
+  숫자가 아니라 8시간 열린 턴이었다.
+
+---
 ## 2026-08-17 — 데몬 포트에 "의도" 를 만들고, 잠깐 뺏긴 포트를 되찾게 하다
 
 ### 문제

--- a/bridge/src/__tests__/apme-stop-delivery.test.ts
+++ b/bridge/src/__tests__/apme-stop-delivery.test.ts
@@ -139,6 +139,26 @@ describe('turns.end_source', () => {
     expect(turnsOf(store, runId)[0].end_source).toBe('interrupted');
   });
 
+  it('a client abort is tagged `aborted`, even though it arrives as a synthetic Stop', () => {
+    // Usage limit / expired auth / API error: Claude Code writes the message
+    // and fires no Stop, so the abort can only ever reach the collector as a
+    // synthetic one — reading `synthetic` first would file an exhausted usage
+    // window as dropped infrastructure.
+    const runId = openRun();
+    prompt(collector, SID, 'first');
+    collector.noteTurnStop(SID, { synthetic: true, aborted: true });
+
+    expect(turnsOf(store, runId)[0].end_source).toBe('aborted');
+  });
+
+  it('a cancel outranks an abort when both flags somehow arrive', () => {
+    const runId = openRun();
+    prompt(collector, SID, 'first');
+    collector.noteTurnStop(SID, { synthetic: true, interrupted: true, aborted: true });
+
+    expect(turnsOf(store, runId)[0].end_source).toBe('interrupted');
+  });
+
   it('a displaced turn whose transcript shows a cancel is `interrupted`, not `next_prompt`', () => {
     // Cancel-then-retype buries the marker under the new prompt within
     // seconds, so the watchdog never sees it as the tail. Left unattributed,
@@ -146,7 +166,7 @@ describe('turns.end_source', () => {
     const seen: Array<{ path: string; since: number }> = [];
     const c = new ApmeCollector(store, undefined, (path, since) => {
       seen.push({ path, since });
-      return since + 1_000;
+      return { interruptedAt: since + 1_000, abortedAt: null, sawAssistant: true };
     });
     const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
     c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
@@ -157,8 +177,35 @@ describe('turns.end_source', () => {
     expect(seen[0].path).toBe('/t.jsonl');
   });
 
-  it('no marker in the window still means `next_prompt` — absence is never a cancel', () => {
-    const c = new ApmeCollector(store, undefined, () => null);
+  it('a displaced turn whose transcript shows a client abort is `aborted`', () => {
+    // The watchdog closes these at +15s, but not when it was swept for
+    // idleness first or the daemon restarted mid-turn — and an aborted turn is
+    // exactly the shape that then sits open until the next morning's prompt.
+    const c = new ApmeCollector(store, undefined, (_p, since) =>
+      ({ interruptedAt: null, abortedAt: since + 2_000, sawAssistant: true }));
+    const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
+
+    expect(turnsOf(store, runId)[0].end_source).toBe('aborted');
+  });
+
+  it('a displaced turn the assistant never answered is `superseded`, not a lost Stop', () => {
+    // Two prompts ~130ms apart (queued messages, <task-notification> pairs):
+    // one model turn serves both and owes exactly one Stop, which closes the
+    // last of them. The first row never ran, so nothing was lost for it.
+    const c = new ApmeCollector(store, undefined, () =>
+      ({ interruptedAt: null, abortedAt: null, sawAssistant: false }));
+    const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
+
+    expect(turnsOf(store, runId)[0].end_source).toBe('superseded');
+  });
+
+  it('no evidence in the window still means `next_prompt` — absence is never a verdict', () => {
+    const c = new ApmeCollector(store, undefined, () =>
+      ({ interruptedAt: null, abortedAt: null, sawAssistant: true }));
     const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
     c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
     c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
@@ -170,7 +217,10 @@ describe('turns.end_source', () => {
     // The marker and the JSONL shape are Claude Code's; a Codex turn has
     // neither, and probing one would be a wasted read at best.
     let probed = 0;
-    const c = new ApmeCollector(store, undefined, () => { probed++; return Date.now(); });
+    const c = new ApmeCollector(store, undefined, () => {
+      probed++;
+      return { interruptedAt: Date.now(), abortedAt: null, sawAssistant: true };
+    });
     c.openRun({ sessionId: 'codex-sess', agentType: 'codex-cli' });
     c.ingestHook('codex-sess', 'UserPromptSubmit', { message: { content: 'a' }, transcript_path: '/t.jsonl' });
     c.ingestHook('codex-sess', 'UserPromptSubmit', { message: { content: 'b' }, transcript_path: '/t.jsonl' });
@@ -184,12 +234,20 @@ describe('turns.end_source', () => {
   });
 
   it('an unreadable transcript falls back to `next_prompt` rather than guessing', () => {
-    const c = new ApmeCollector(store, undefined, () => { throw new Error('EACCES'); });
-    const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
-    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
-    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
+    // Both shapes of "cannot read": a throw, and the probe's own null. Neither
+    // may become `superseded` — "no assistant record" and "no transcript" are
+    // different facts and only the first one is evidence.
+    for (const probe of [
+      () => { throw new Error('EACCES'); },
+      () => null,
+    ]) {
+      const c = new ApmeCollector(store, undefined, probe as never);
+      const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
+      c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
+      c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
 
-    expect(turnsOf(store, runId)[0].end_source).toBe('next_prompt');
+      expect(turnsOf(store, runId)[0].end_source).toBe('next_prompt');
+    }
   });
 
   it('the response still lands on the turn when the Stop closes it first', () => {

--- a/bridge/src/__tests__/apme-stop-delivery.test.ts
+++ b/bridge/src/__tests__/apme-stop-delivery.test.ts
@@ -203,6 +203,21 @@ describe('turns.end_source', () => {
     expect(turnsOf(store, runId)[0].end_source).toBe('superseded');
   });
 
+  it('a displaced turn that called tools is never `superseded`, whatever the transcript says', () => {
+    // The transcript walk stops at the first record older than the window and
+    // Claude Code's JSONL is not strictly ordered, so one inverted stamp near
+    // the tail can hide the assistant work behind it. A tool call is
+    // independent proof the turn ran.
+    const c = new ApmeCollector(store, undefined, () =>
+      ({ interruptedAt: null, abortedAt: null, sawAssistant: false }));
+    const runId = c.openRun({ sessionId: SID, agentType: 'claude-code' }) as string;
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'first' }, transcript_path: '/t.jsonl' });
+    c.ingestHook(SID, 'PreToolUse', { tool_name: 'Bash', transcript_path: '/t.jsonl' });
+    c.ingestHook(SID, 'UserPromptSubmit', { message: { content: 'second' }, transcript_path: '/t.jsonl' });
+
+    expect(turnsOf(store, runId)[0].end_source).toBe('next_prompt');
+  });
+
   it('no evidence in the window still means `next_prompt` — absence is never a verdict', () => {
     const c = new ApmeCollector(store, undefined, () =>
       ({ interruptedAt: null, abortedAt: null, sawAssistant: true }));

--- a/bridge/src/__tests__/claude-transcript-reader.test.ts
+++ b/bridge/src/__tests__/claude-transcript-reader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { readLastTurn, readTurnEndProbe, readInterruptSince } from '../apme/claude-transcript-reader.js';
+import { readLastTurn, readTurnEndProbe, readOpenTurnEvidence } from '../apme/claude-transcript-reader.js';
 
 // Picks the most recent user→assistant turn out of a Claude Code JSONL
 // transcript. These fixtures mirror the structure Claude Code writes to
@@ -214,7 +214,7 @@ describe('readTurnEndProbe', () => {
   });
 });
 
-describe('readInterruptSince', () => {
+describe('readOpenTurnEvidence', () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'transcript-test-')); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
@@ -226,6 +226,8 @@ describe('readInterruptSince', () => {
   }
 
   const AT = (iso: string) => Date.parse(iso);
+  const readInterruptSince = (path: string, since: number) =>
+    readOpenTurnEvidence(path, since)?.interruptedAt ?? null;
 
   it('finds a marker buried under the retyped prompt that followed it', () => {
     // The commonest ESC shape: cancel, then immediately retype. The marker is
@@ -268,5 +270,57 @@ describe('readInterruptSince', () => {
     ]));
     expect(readInterruptSince(path, AT('2026-08-13T12:00:00.000Z'))).toBeNull();
     expect(readInterruptSince(join(dir, 'missing.jsonl'), 0)).toBeNull();
+  });
+
+  it('distinguishes an unreadable transcript from one holding no evidence', () => {
+    // The caller resolves "no evidence" into a bucket and "cannot read" into a
+    // refusal to guess, so folding them into one null was never safe.
+    const path = writeTranscript(fixture([
+      { type: 'assistant', timestamp: '2026-08-13T12:00:05.000Z',
+        message: { role: 'assistant', stop_reason: 'tool_use', content: [{ type: 'text', text: 'working' }] } },
+    ]));
+    expect(readOpenTurnEvidence(path, AT('2026-08-13T12:00:00.000Z')))
+      .toEqual({ interruptedAt: null, abortedAt: null, sawAssistant: true });
+    expect(readOpenTurnEvidence(join(dir, 'missing.jsonl'), 0)).toBeNull();
+  });
+
+  it('reports the client abort that ends a turn with no Stop hook', () => {
+    // "You've hit your session limit" and friends are written as an assistant
+    // record with stop_reason stop_sequence, and Claude Code fires no Stop.
+    const path = writeTranscript(fixture([
+      { type: 'assistant', timestamp: '2026-08-13T12:00:04.000Z',
+        message: { role: 'assistant', stop_reason: 'tool_use', content: [{ type: 'tool_use', name: 'Bash' }] } },
+      { type: 'assistant', timestamp: '2026-08-13T12:00:06.000Z',
+        message: { role: 'assistant', stop_reason: 'stop_sequence',
+          content: [{ type: 'text', text: "You've hit your session limit · resets 5:50pm (Asia/Seoul)" }] } },
+    ]));
+    const out = readOpenTurnEvidence(path, AT('2026-08-13T12:00:00.000Z'))!;
+    expect(out.abortedAt).toBe(AT('2026-08-13T12:00:06.000Z'));
+    expect(out.sawAssistant).toBe(true);
+  });
+
+  it('will not pay this turn for the previous turn\'s abort', () => {
+    const path = writeTranscript(fixture([
+      { type: 'assistant', timestamp: '2026-08-13T11:00:00.000Z',
+        message: { role: 'assistant', stop_reason: 'stop_sequence', content: [{ type: 'text', text: 'limit' }] } },
+      { type: 'user', timestamp: '2026-08-13T12:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'new turn' }] } },
+    ]));
+    const out = readOpenTurnEvidence(path, AT('2026-08-13T12:00:00.000Z'))!;
+    expect(out.abortedAt).toBeNull();
+    expect(out.sawAssistant).toBe(false);
+  });
+
+  it('reports a turn that never ran — two prompts, no assistant record between', () => {
+    // Queued prompts and <task-notification> injections land ~130ms apart and
+    // one model turn serves both; only the last of them is owed a Stop.
+    const path = writeTranscript(fixture([
+      { type: 'user', timestamp: '2026-08-13T12:00:00.100Z',
+        message: { role: 'user', content: [{ type: 'text', text: '<task-notification>a' }] } },
+      { type: 'user', timestamp: '2026-08-13T12:00:00.230Z',
+        message: { role: 'user', content: [{ type: 'text', text: '<task-notification>b' }] } },
+    ]));
+    expect(readOpenTurnEvidence(path, AT('2026-08-13T12:00:00.000Z')))
+      .toEqual({ interruptedAt: null, abortedAt: null, sawAssistant: false });
   });
 });

--- a/bridge/src/__tests__/claude-turn-watchdog.test.ts
+++ b/bridge/src/__tests__/claude-turn-watchdog.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ClaudeTurnWatchdog, WATCHDOG_QUIET_MS, WATCHDOG_POLL_MS } from '../claude-turn-watchdog.js';
-import type { TurnEndProbe } from '../apme/claude-transcript-reader.js';
+import { CLIENT_ABORT_STOP_REASON, type TurnEndProbe } from '../apme/claude-transcript-reader.js';
 
 const TP = '/tmp/fake-transcript.jsonl';
 
@@ -28,6 +28,13 @@ function endTurnAt(ts: number): TurnEndProbe {
  *  interrupt marker, and no assistant `end_turn` anywhere. */
 function interruptAt(ts: number): TurnEndProbe {
   return { role: 'user', stopReason: null, timestampMs: ts, interrupted: true };
+}
+
+/** The tail Claude Code leaves when the CLIENT ends the turn — usage limit,
+ *  expired auth, an API 429/529. An assistant record carrying the message the
+ *  user sees, and no Stop hook behind it. */
+function abortAt(ts: number): TurnEndProbe {
+  return { role: 'assistant', stopReason: CLIENT_ABORT_STOP_REASON, timestampMs: ts, interrupted: false };
 }
 
 describe('ClaudeTurnWatchdog', () => {
@@ -78,6 +85,29 @@ describe('ClaudeTurnWatchdog', () => {
 
     vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
     expect(fired).toEqual([{ transcript_path: TP, reason: 'interrupted' }]);
+  });
+
+  it('closes a turn the client aborted (usage limit / auth / API error)', () => {
+    // Claude Code writes one assistant record with the abort stop reason and
+    // fires no Stop hook, so `end_turn` alone left these turns open for hours
+    // — PROCESSING on every device, the APME run open behind them — until the
+    // next prompt displaced them and filed them as dropped hooks.
+    let probeResult: TurnEndProbe | null = null;
+    const { wd, fired } = makeWatchdog({ probe: () => probeResult });
+
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    probeResult = abortAt(Date.now() + 3_000);
+
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 2);
+    expect(fired).toEqual([{ transcript_path: TP, reason: 'aborted' }]);
+  });
+
+  it('ignores the previous turn\'s abort', () => {
+    const stale = abortAt(Date.now() - 60_000);
+    const { wd, fired } = makeWatchdog({ probe: () => stale });
+    wd.noteHookEvent('UserPromptSubmit', { transcript_path: TP });
+    vi.advanceTimersByTime(WATCHDOG_QUIET_MS + WATCHDOG_POLL_MS * 3);
+    expect(fired).toHaveLength(0);
   });
 
   it('ignores the previous turn\'s interrupt marker', () => {

--- a/bridge/src/apme/claude-transcript-reader.ts
+++ b/bridge/src/apme/claude-transcript-reader.ts
@@ -149,6 +149,33 @@ export interface TurnEndProbe {
   interrupted: boolean;
 }
 
+/** `stop_reason` Claude Code writes when the CLIENT ended the turn instead of
+ *  the model: usage limit, expired auth, credit limit, an API 429/529. The
+ *  record carries the user-facing message ("You've hit your session limit ·
+ *  resets 5:50pm") and NO Stop hook follows it — so a turn that ends this way
+ *  owes no Stop and must not be charged to the dropped-hook rate.
+ *
+ *  Measured before it was trusted: across 211 local transcripts holding 61,281
+ *  assistant records, `stop_reason` was `tool_use` 58,765 times, `end_turn`
+ *  2,513 times, and `stop_sequence` 37 times — every one of those 37 a client
+ *  abort message, none followed by a `stop_hook_summary` record, and none
+ *  followed by further assistant work in the same turn. There is no benign
+ *  shape to confuse it with. */
+export const CLIENT_ABORT_STOP_REASON = 'stop_sequence';
+
+/** What a bounded backward walk from the transcript tail can prove about a turn
+ *  that is still open. Every field answers a question the next-prompt close has
+ *  to ask, and all three come from ONE tail read. */
+export interface OpenTurnEvidence {
+  /** Newest ESC/interrupt marker in the window (epoch ms), else null. */
+  interruptedAt: number | null;
+  /** Newest client-abort record in the window (epoch ms), else null. */
+  abortedAt: number | null;
+  /** Whether the assistant wrote ANYTHING since the window opened. False means
+   *  the turn never ran — a second prompt displaced it first. */
+  sawAssistant: boolean;
+}
+
 /**
  * Probe whether the transcript's most recent turn has finished. A completed
  * turn's last message-bearing record is `role: "assistant"` with
@@ -204,27 +231,35 @@ export function readTurnEndProbe(transcriptPath: string): TurnEndProbe | null {
 }
 
 /**
- * Timestamp of the newest user-interrupt (ESC) marker at or after `sinceMs`,
- * or null when the window holds none.
+ * Everything a bounded tail read can say about a turn that opened at `sinceMs`
+ * and is still open. Returns null when the transcript is unreadable — the
+ * absence of evidence, which callers must never resolve as a verdict.
  *
- * `readTurnEndProbe` only sees the marker while it is still the tail — the
- * common ESC shape is "cancel, then immediately retype", which buries the
- * marker under the new user message within seconds. That turn ends by
- * cancellation just as surely, so the close path that runs at the next prompt
- * asks this instead of assuming a dropped Stop.
+ * Three questions, one read, because the close path that runs at the next
+ * prompt has to ask all of them and each answer is a different bucket:
  *
- * The backward walk stops at the first record older than the window, so an
- * interrupt belonging to some earlier turn can neither be found nor paid for.
+ *  - Did the user cancel? `readTurnEndProbe` only sees the ESC marker while it
+ *    is still the tail, and the common shape is "cancel, then immediately
+ *    retype", which buries it under the new user message within seconds.
+ *  - Did the CLIENT abort (usage limit, auth, API error)? Same burial, and
+ *    Claude Code owes no Stop for it either.
+ *  - Did the assistant write anything at all? If not, this prompt never got a
+ *    turn of its own — a second prompt landed first and one model turn served
+ *    both, so the displaced row is a counting artifact, not a lost hook.
+ *
+ * The backward walk stops at the first record older than the window, so
+ * evidence belonging to an earlier turn can neither be found nor paid for.
  */
-export function readInterruptSince(transcriptPath: string, sinceMs: number): number | null {
-  const INTERRUPT_TAIL_BYTES = 256 * 1024;
-  const tail = readTailString(transcriptPath, INTERRUPT_TAIL_BYTES);
+export function readOpenTurnEvidence(transcriptPath: string, sinceMs: number): OpenTurnEvidence | null {
+  const EVIDENCE_TAIL_BYTES = 256 * 1024;
+  const tail = readTailString(transcriptPath, EVIDENCE_TAIL_BYTES);
   if (tail == null) return null;
+  const evidence: OpenTurnEvidence = { interruptedAt: null, abortedAt: null, sawAssistant: false };
   const lines = tail.split('\n');
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
     if (!line.trim()) continue;
-    let rec: { timestamp?: string };
+    let rec: { timestamp?: string; message?: { role?: string; stop_reason?: string | null } };
     try {
       rec = JSON.parse(line);
     } catch {
@@ -235,10 +270,16 @@ export function readInterruptSince(transcriptPath: string, sinceMs: number): num
     // window, so it is skipped rather than ending the walk — ending here
     // would let one stampless line hide every marker behind it.
     if (!Number.isFinite(ts)) continue;
-    if (ts < sinceMs) return null;
-    if (isClaudeInterruptRecord(rec)) return ts;
+    if (ts < sinceMs) break;
+    if (evidence.interruptedAt == null && isClaudeInterruptRecord(rec)) evidence.interruptedAt = ts;
+    if (rec.message?.role === 'assistant') {
+      evidence.sawAssistant = true;
+      if (evidence.abortedAt == null && rec.message?.stop_reason === CLIENT_ABORT_STOP_REASON) {
+        evidence.abortedAt = ts;
+      }
+    }
   }
-  return null;
+  return evidence;
 }
 
 /** Read at most `maxBytes` from the end of a file without loading the rest.

--- a/bridge/src/apme/collector.ts
+++ b/bridge/src/apme/collector.ts
@@ -27,7 +27,7 @@ import type { AgentType, TelemetrySpan, ApmeSampleEventRow, TrajectoryEventKind,
 import { priceUsd, providerFor } from '@agentdeck/shared';
 import type { ApmeHwSampler } from './hw-sampler.js';
 import { classifyRunSmart, computeSignals, classify } from './classifier.js';
-import { readInterruptSince } from './claude-transcript-reader.js';
+import { readOpenTurnEvidence, type OpenTurnEvidence } from './claude-transcript-reader.js';
 
 export interface OpenRunInput {
   sessionId: string;
@@ -193,9 +193,10 @@ export class ApmeCollector {
   constructor(
     private readonly store: ApmeStore,
     private readonly hwSampler?: ApmeHwSampler,
-    /** Newest user-interrupt marker at/after a timestamp. Injectable for
-     *  tests; the default reads the Claude transcript tail. */
-    private readonly interruptProbe: (transcriptPath: string, sinceMs: number) => number | null = readInterruptSince,
+    /** What the transcript proves about a turn open since a timestamp — cancel,
+     *  client abort, or never having run at all. Injectable for tests; the
+     *  default reads the Claude transcript tail once for all three. */
+    private readonly openTurnProbe: (transcriptPath: string, sinceMs: number) => OpenTurnEvidence | null = readOpenTurnEvidence,
   ) {}
 
   /** Start a new run and return its id. Safe to call if store disabled (returns ''). */
@@ -450,27 +451,43 @@ export class ApmeCollector {
    *
    *  Idempotent: a duplicate or late Stop finds no active turn and no-ops, so
    *  a synthetic Stop racing a real one cannot overwrite the real attribution. */
-  noteTurnStop(sessionId: string, opts: { synthetic?: boolean; interrupted?: boolean } = {}): void {
+  noteTurnStop(sessionId: string, opts: { synthetic?: boolean; interrupted?: boolean; aborted?: boolean } = {}): void {
     if (!this.store.enabled) return;
-    // `interrupted` outranks `synthetic`: a cancel is always delivered as a
-    // synthetic Stop (there is no real one to deliver), so reading the flags
-    // the other way round would file every user cancel as a dropped hook.
+    // `interrupted` and `aborted` both outrank `synthetic`: neither ending
+    // produces a real Stop, so each can only ever arrive AS a synthetic one,
+    // and reading the flags the other way round would file every user cancel
+    // and every usage-limit abort as a dropped hook. Cancel wins over abort on
+    // the impossible both-set case, for the same reason it wins over synthetic
+    // — it is the narrower, user-caused claim.
     const source: TurnEndSource = opts.interrupted ? 'interrupted'
-      : opts.synthetic ? 'synthetic_stop'
-        : 'stop';
+      : opts.aborted ? 'aborted'
+        : opts.synthetic ? 'synthetic_stop'
+          : 'stop';
     this.closeTurn(sessionId, source);
   }
 
   /** Attribute a turn that is still open when the next prompt arrives.
    *
-   *  The watchdog catches a cancel only while the interrupt marker is still
-   *  the transcript's tail. The commonest ESC shape — cancel, then retype
-   *  straight away — buries it under the new user message in seconds and
-   *  fires a fresh `UserPromptSubmit`, so the displaced turn would land in
-   *  `next_prompt` and inflate the very loss rate this instrument measures.
-   *  Asking the transcript here costs one bounded tail read, and only on the
-   *  path where a turn was already left open — a healthy turn is closed by
-   *  its Stop long before this runs. */
+   *  `next_prompt` is the only bucket that means "a Stop was owed and never
+   *  came", so everything that reaches here for some other reason has to be
+   *  told apart before it inflates the very loss rate this instrument
+   *  measures. Three do, and one bounded tail read answers all three — on this
+   *  path only, since a healthy turn is closed by its Stop long before this
+   *  runs:
+   *
+   *   - A CANCEL. The watchdog catches one only while the interrupt marker is
+   *     still the transcript's tail; the commonest ESC shape — cancel, then
+   *     retype straight away — buries it under the new user message in seconds
+   *     and fires a fresh `UserPromptSubmit`.
+   *   - A CLIENT ABORT (usage limit, expired auth, API error). The watchdog
+   *     closes those at +15s, but not if it was swept for idleness first
+   *     (30 min) or the daemon restarted mid-turn — and an abort is exactly
+   *     the shape that then sits open for hours.
+   *   - A turn that NEVER RAN. Queued prompts and `<task-notification>`
+   *     injections arrive in pairs ~130 ms apart; Claude serves both with one
+   *     model turn and owes exactly one Stop, which closes the LAST of them.
+   *     A displaced row with no assistant record behind it at all is that
+   *     artifact, not a lost hook. */
   private resolveDisplacedTurnSource(sessionId: string, data: Record<string, unknown>): TurnEndSource {
     const turn = this.sessionToTurn.get(sessionId);
     // No open turn: closeTurn no-ops, so the value is immaterial.
@@ -480,10 +497,16 @@ export class ApmeCollector {
     const transcriptPath = typeof data.transcript_path === 'string' ? data.transcript_path : '';
     if (!transcriptPath) return 'next_prompt';
     try {
-      const at = this.interruptProbe(transcriptPath, turn.startedAt - TURN_INTERRUPT_SLACK_MS);
-      return at != null ? 'interrupted' : 'next_prompt';
+      const evidence = this.openTurnProbe(transcriptPath, turn.startedAt - TURN_INTERRUPT_SLACK_MS);
+      // An unreadable transcript is no evidence of anything — never guess.
+      if (!evidence) return 'next_prompt';
+      if (evidence.interruptedAt != null) return 'interrupted';
+      if (evidence.abortedAt != null) return 'aborted';
+      // Ordered last on purpose: a cancelled or aborted turn that also wrote
+      // nothing is still a cancel or an abort, not a superseded prompt.
+      if (!evidence.sawAssistant) return 'superseded';
+      return 'next_prompt';
     } catch {
-      // An unreadable transcript is no evidence of a cancel — never guess.
       return 'next_prompt';
     }
   }

--- a/bridge/src/apme/collector.ts
+++ b/bridge/src/apme/collector.ts
@@ -504,7 +504,15 @@ export class ApmeCollector {
       if (evidence.abortedAt != null) return 'aborted';
       // Ordered last on purpose: a cancelled or aborted turn that also wrote
       // nothing is still a cancel or an abort, not a superseded prompt.
-      if (!evidence.sawAssistant) return 'superseded';
+      //
+      // Two independent facts must agree before a turn is called one that
+      // never ran, because the transcript walk alone is not quite enough for
+      // this claim: it stops at the first record older than the window, and
+      // Claude Code's JSONL is not strictly ordered (auxiliary records land
+      // tens of ms out of sequence), so one inverted stamp near the tail could
+      // truncate the walk and hide the assistant work behind it. A turn that
+      // called tools demonstrably ran whatever the transcript says.
+      if (!evidence.sawAssistant && turn.toolCalls === 0) return 'superseded';
       return 'next_prompt';
     } catch {
       return 'next_prompt';

--- a/bridge/src/apme/store.ts
+++ b/bridge/src/apme/store.ts
@@ -821,10 +821,12 @@ export class ApmeStore {
    *  they are reported separately instead of being folded into any bucket,
    *  because their closing signal is genuinely unknown (see the migration).
    *
-   *  `interrupted` is also its own column rather than part of any loss bucket:
-   *  a user cancel is a turn for which Claude Code owes no Stop at all, so
-   *  counting it as a dropped hook would report the user's own ESC key as
-   *  infrastructure loss.
+   *  `interrupted`, `aborted` and `superseded` are their own columns rather
+   *  than part of any loss bucket: each is a turn for which Claude Code owes no
+   *  Stop at all, so counting them as dropped hooks would report the user's own
+   *  ESC key, their exhausted usage window, and an artifact of counting turns
+   *  per prompt as infrastructure loss. `stopDeliveryLoss` in
+   *  `@agentdeck/shared` owns which buckets the ratio may read.
    */
   stopDelivery(opts: { sinceMs: number; agentType?: string } = { sinceMs: 0 }): ApmeStopDeliveryRow[] {
     if (!this.db) return [];
@@ -838,6 +840,8 @@ export class ApmeStore {
               SUM(t.end_source = 'synthetic_stop') AS syntheticStop,
               SUM(t.end_source = 'next_prompt') AS nextPrompt,
               SUM(t.end_source = 'interrupted') AS interrupted,
+              SUM(t.end_source = 'aborted') AS aborted,
+              SUM(t.end_source = 'superseded') AS superseded,
               SUM(t.end_source IN ('session_end','run_close','clear')) AS sessionEnd,
               SUM(t.ended_at IS NULL) AS open,
               SUM(t.ended_at IS NOT NULL AND t.end_source IS NULL) AS preInstrument
@@ -853,6 +857,8 @@ export class ApmeStore {
       syntheticStop: Number(r.syntheticStop ?? 0),
       nextPrompt: Number(r.nextPrompt ?? 0),
       interrupted: Number(r.interrupted ?? 0),
+      aborted: Number(r.aborted ?? 0),
+      superseded: Number(r.superseded ?? 0),
       sessionEnd: Number(r.sessionEnd ?? 0),
       open: Number(r.open ?? 0),
       preInstrument: Number(r.preInstrument ?? 0),

--- a/bridge/src/claude-turn-watchdog.ts
+++ b/bridge/src/claude-turn-watchdog.ts
@@ -24,6 +24,15 @@
  * evidence that exists, so it closes the turn too — tagged `interrupted`, kept
  * out of the loss measurement, because no hook was lost here.
  *
+ * A third ending has the same shape and used to be invisible: the CLIENT aborts
+ * the turn — usage limit reached, auth expired, an API 429/529. Claude Code
+ * writes one assistant record with `stop_reason: "stop_sequence"` carrying the
+ * message the user sees and fires no Stop hook. Both times this happened in the
+ * measured week the turn stayed open for over eight hours (state PROCESSING on
+ * every device, the APME run open behind it) until the next morning's prompt
+ * displaced it, and each was then filed as a dropped hook. `end_turn` was too
+ * narrow a predicate for "the turn is over".
+ *
  * False-positive guards:
  *  - `stop_reason: "tool_use"` (permission prompt / AskUserQuestion open,
  *    tools running) never matches, so a genuine wait is never force-closed.
@@ -37,7 +46,7 @@
  */
 
 import { statSync } from 'fs';
-import { readTurnEndProbe, type TurnEndProbe } from './apme/claude-transcript-reader.js';
+import { readTurnEndProbe, CLIENT_ABORT_STOP_REASON, type TurnEndProbe } from './apme/claude-transcript-reader.js';
 import { debug } from './logger.js';
 
 /** Hook-channel silence required before the transcript is consulted. */
@@ -48,9 +57,11 @@ export const WATCHDOG_POLL_MS = 5_000;
 const TURN_OPEN_SLACK_MS = 2_000;
 
 /** Why the transcript says the open turn is over. `end_turn` is a Stop that
- *  was dropped in flight; `interrupted` is a turn the user cancelled, for
- *  which no Stop was ever due. They close identically and are counted apart. */
-export type TurnEndReason = 'end_turn' | 'interrupted';
+ *  was dropped in flight; `interrupted` is a turn the user cancelled and
+ *  `aborted` one the client ended (usage limit, auth, API error), for neither
+ *  of which a Stop was ever due. All three close the turn identically and are
+ *  counted apart — only the first is a lost hook. */
+export type TurnEndReason = 'end_turn' | 'interrupted' | 'aborted';
 
 export interface ClaudeTurnWatchdogOptions {
   /** Called when the transcript proves the open turn ended without a Stop. */
@@ -152,9 +163,15 @@ export class ClaudeTurnWatchdog {
     const probe = this.probe(this.transcriptPath);
     if (!probe) return;
     const finished = probe.role === 'assistant' && probe.stopReason === 'end_turn';
+    // A client abort is an assistant record too, but with the abort stop
+    // reason — mutually exclusive with `end_turn`, never a refinement of it.
+    const aborted = probe.role === 'assistant' && probe.stopReason === CLIENT_ABORT_STOP_REASON;
     // The marker is a `user` record, so it can never satisfy `finished` — the
-    // two are alternatives, not a refinement of one another.
-    const reason: TurnEndReason | null = finished ? 'end_turn' : probe.interrupted ? 'interrupted' : null;
+    // three are alternatives, not refinements of one another.
+    const reason: TurnEndReason | null = finished ? 'end_turn'
+      : probe.interrupted ? 'interrupted'
+        : aborted ? 'aborted'
+          : null;
     if (!reason) return;
     if (probe.timestampMs == null) return;
     if (probe.timestampMs < this.turnOpenedAt - TURN_OPEN_SLACK_MS) return;

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { request } from 'http';
 import { BRIDGE_WS_PORT } from './types.js';
-import { SESSION_WEIGHT_MIN, SESSION_WEIGHT_MAX } from '@agentdeck/shared';
+import { SESSION_WEIGHT_MIN, SESSION_WEIGHT_MAX, stopDeliveryLoss } from '@agentdeck/shared';
 import { ensureBleRuntime, getBleRuntimeStatus } from './python-ble-runtime.js';
 import {
   TASK_NAME,
@@ -2848,23 +2848,22 @@ apme
     if (rows.length === 0) { log(`No turns started in the last ${opts.since}.`); return; }
 
     log(`\n  Turns started in the last ${opts.since} — how each one's end was learned`);
-    log(`  ${'Agent'.padEnd(14)} ${'Turns'.padEnd(7)} ${'Stop'.padEnd(7)} ${'Synth'.padEnd(7)} ${'NoStop'.padEnd(7)} ${'Esc'.padEnd(6)} ${'SessEnd'.padEnd(8)} ${'Open'.padEnd(6)} ${'?'.padEnd(6)} Stop loss`);
-    log(`  ${'─'.repeat(14)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(6)} ${'─'.repeat(8)} ${'─'.repeat(6)} ${'─'.repeat(6)} ${'─'.repeat(9)}`);
+    log(`  ${'Agent'.padEnd(14)} ${'Turns'.padEnd(7)} ${'Stop'.padEnd(7)} ${'Synth'.padEnd(7)} ${'NoStop'.padEnd(7)} ${'Esc'.padEnd(6)} ${'Abort'.padEnd(6)} ${'Folded'.padEnd(7)} ${'SessEnd'.padEnd(8)} ${'Open'.padEnd(6)} ${'?'.padEnd(6)} Stop loss`);
+    log(`  ${'─'.repeat(14)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(6)} ${'─'.repeat(6)} ${'─'.repeat(7)} ${'─'.repeat(8)} ${'─'.repeat(6)} ${'─'.repeat(6)} ${'─'.repeat(9)}`);
     for (const r of rows) {
-      // Denominator is turns whose Stop we can actually adjudicate: a real
-      // Stop, a recovered one, or a turn the next prompt displaced. Turns that
-      // ended with the session, were cancelled by the user, are still open, or
-      // predate the column are NOT evidence either way and stay out of the
-      // ratio — a cancel in particular is a turn for which no Stop was owed.
-      const adjudicated = r.stop + r.syntheticStop + r.nextPrompt;
-      const lost = r.syntheticStop + r.nextPrompt;
-      const rate = adjudicated > 0 ? `${((lost / adjudicated) * 100).toFixed(0)}% of ${adjudicated}` : '—';
-      log(`  ${r.agentType.slice(0, 14).padEnd(14)} ${String(r.total).padEnd(7)} ${String(r.stop).padEnd(7)} ${String(r.syntheticStop).padEnd(7)} ${String(r.nextPrompt).padEnd(7)} ${String(r.interrupted).padEnd(6)} ${String(r.sessionEnd).padEnd(8)} ${String(r.open).padEnd(6)} ${String(r.preInstrument).padEnd(6)} ${rate}`);
+      // Which buckets the ratio may read is defined once, in shared — see
+      // `stopDeliveryLoss`. Restating it here is how the instrument would come
+      // to measure something other than what its legend claims.
+      const { adjudicated, ratio } = stopDeliveryLoss(r);
+      const rate = ratio != null ? `${(ratio * 100).toFixed(0)}% of ${adjudicated}` : '—';
+      log(`  ${r.agentType.slice(0, 14).padEnd(14)} ${String(r.total).padEnd(7)} ${String(r.stop).padEnd(7)} ${String(r.syntheticStop).padEnd(7)} ${String(r.nextPrompt).padEnd(7)} ${String(r.interrupted).padEnd(6)} ${String(r.aborted).padEnd(6)} ${String(r.superseded).padEnd(7)} ${String(r.sessionEnd).padEnd(8)} ${String(r.open).padEnd(6)} ${String(r.preInstrument).padEnd(6)} ${rate}`);
     }
     log('');
     log('  Synth  = Stop hook dropped, watchdog recovered it from the transcript');
     log('  NoStop = Stop hook dropped and nothing recovered it (closed by the next prompt)');
     log('  Esc    = user cancelled the turn — Claude Code owes no Stop, so not a loss');
+    log('  Abort  = usage limit / auth / API error ended the turn — no Stop is fired for those');
+    log('  Folded = a second prompt arrived before this one ran; one turn served both');
     log('  ?      = closed before end_source existed — signal unknown, never guessed');
     log('');
   });

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -1249,6 +1249,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           // turn must not be charged to that rate.
           synthetic_stop: true,
           ...(reason === 'interrupted' ? { interrupted: true } : {}),
+          // Same for a client abort (usage limit, auth, API error): Claude
+          // Code fires no Stop for it, so nothing was lost to recover.
+          ...(reason === 'aborted' ? { aborted: true } : {}),
           ...(cwd ? { cwd } : {}),
           ...(projectName ? { project_name: projectName } : {}),
         }),
@@ -2483,6 +2486,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             apme.collector.noteTurnStop(hookSid, {
               synthetic: json.synthetic_stop === true,
               interrupted: json.interrupted === true,
+              aborted: json.aborted === true,
             });
           }
           if (turnOpen && lastStart) {

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -582,8 +582,10 @@ export async function startSession(opts: SessionOptions): Promise<void> {
           data: {
             transcript_path,
             synthetic_stop: true,
-            // A user cancel is not a lost hook — same close, different bucket.
+            // A user cancel and a client abort are not lost hooks — same
+            // close, different buckets.
             ...(reason === 'interrupted' ? { interrupted: true } : {}),
+            ...(reason === 'aborted' ? { aborted: true } : {}),
           },
         } as AdapterEvent);
       },
@@ -1691,6 +1693,7 @@ function wireClaudeCodeTimeline(
           apmeRef.collector.noteTurnStop(core.sessionId, {
             synthetic: evt.data?.synthetic_stop === true,
             interrupted: evt.data?.interrupted === true,
+            aborted: evt.data?.aborted === true,
           });
         }
 

--- a/docs/apme.md
+++ b/docs/apme.md
@@ -152,6 +152,8 @@ Claude 턴을 닫는 권한은 Stop hook **하나뿐**이고 그 전달은 fire-
 | `synthetic_stop` | Stop 유실 → `claude-turn-watchdog.ts` 가 transcript tail 근거로 복구. **이 개수가 곧 유실 측정치** |
 | `next_prompt` | Stop 도 없고 복구도 없었음 — 다음 프롬프트가 밀어내며 닫음. **미복구 유실** |
 | `interrupted` | 사용자가 ESC 로 취소 — Claude Code 는 취소 시 hook 을 **하나도 emit 하지 않으므로** 애초에 올 Stop 이 없었다. 유실이 아니다 |
+| `aborted` | **클라이언트가** 턴을 끝냄 — 사용량 한도(`You've hit your session limit`), 인증 만료(`Please run /login`), 크레딧 소진, API 429/529. assistant 레코드 하나에 `stop_reason: "stop_sequence"` 로 기록되고 Stop hook 은 발화하지 않는다. 취소와 같은 이유로 유실이 아니다 |
+| `superseded` | 이 프롬프트의 턴이 **돌기도 전에** 다음 프롬프트가 도착 — 큐잉된 메시지와 `<task-notification>` 주입은 ~130ms 간격 쌍으로 들어오고, 모델 턴 하나가 둘을 처리하며 Stop 도 하나만 빚진다(마지막 것에 대해). 밀려난 행은 "프롬프트당 턴 1개" 계수 방식의 산물이지 유실이 아니다 |
 | `session_end` / `run_close` / `clear` | 턴이 열린 채로 세션·run 이 끝나거나 `/clear` 로 잘림 |
 | `NULL` | 아직 열려 있음(`ended_at IS NULL`), 또는 컬럼 도입 이전 행 |
 
@@ -159,13 +161,19 @@ Claude 턴을 닫는 권한은 Stop hook **하나뿐**이고 그 전달은 fire-
 
 **ESC 취소를 유실로 세지 않는 이유와 그 근거 위치.** 취소는 `PostToolUse`/`Stop`/`UserPromptSubmit` 중 무엇도 emit 하지 않으므로(2026-07-18 실측) 전달될 Stop 자체가 없다 — 이걸 `next_prompt` 로 두면 사용자의 ESC 키가 인프라 유실로 집계된다. 증거는 transcript 의 interrupt 마커 하나뿐이고, 판별 규칙은 `bridge/src/claude-interrupt-marker.ts` 한 곳에 있다(관측자·워치독·collector 3소비자 공용). 마커는 **text 블록만** 본다 — `tool_result` 가 같은 문장을 인용하는 일이 흔해서(자기 transcript 를 grep 하는 세션이면 반드시 생긴다) 원문 매칭은 유령 취소를 만든다.
 
-취소는 두 지점에서 잡힌다. 마커가 tail 로 남아 있으면 워치독이(= ESC 후 그대로 둔 경우, 5분 stuck timeout 까지 PROCESSING 으로 남던 것도 같이 해소), 취소 직후 바로 다시 입력해 마커가 새 프롬프트 밑에 묻히면 다음 프롬프트의 close 경로가 `readInterruptSince` 로 확인한다. 후자의 읽기는 **이미 열린 채 밀려난 턴**에서만 발생한다 — 정상 턴은 Stop 이 그 전에 닫는다.
+취소는 두 지점에서 잡힌다. 마커가 tail 로 남아 있으면 워치독이(= ESC 후 그대로 둔 경우, 5분 stuck timeout 까지 PROCESSING 으로 남던 것도 같이 해소), 취소 직후 바로 다시 입력해 마커가 새 프롬프트 밑에 묻히면 다음 프롬프트의 close 경로가 `readOpenTurnEvidence` 로 확인한다. 후자의 읽기는 **이미 열린 채 밀려난 턴**에서만 발생한다 — 정상 턴은 Stop 이 그 전에 닫는다.
+
+**클라이언트 중단(`aborted`) 을 유실로 세지 않는 이유.** `stop_reason: "stop_sequence"` 는 모델이 아니라 클라이언트가 턴을 끝냈다는 뜻이고, 그 레코드 뒤에 Stop hook 은 오지 않는다. 추측이 아니라 실측이다 — 로컬 transcript 211개(assistant 레코드 61,281건)에서 `stop_reason` 은 `tool_use` 58,765 / `end_turn` 2,513 / `stop_sequence` 37 이었고, 그 37건은 **전부** 한도·인증·크레딧·API 오류 메시지였으며, **하나도** `stop_hook_summary` 레코드가 뒤따르지 않았고, 같은 턴에서 assistant 작업이 이어진 것도 없었다. 혼동할 양성 모양이 존재하지 않는다.
+
+이 값이 중요한 진짜 이유는 통계가 아니라 **턴이 안 닫히는 것**이다. 중단된 턴은 워치독의 `end_turn` 술어에 걸리지 않아 다음 프롬프트까지 열려 있었고 — 2026-08-16 실측 두 건 모두 **8시간 넘게** — 그동안 모든 기기에 PROCESSING 으로 떠 있고 APME run 도 열린 채였다(open run/task 는 eval 을 굶긴다). 이제 워치독이 ~15초 안에 닫는다.
+
+**`superseded` 는 계수 방식의 산물이다.** 턴은 `UserPromptSubmit` 마다 생성되는데, 큐잉된 메시지와 `<task-notification>` 주입은 ~130ms 간격 쌍으로 도착하고 Claude 는 그 둘을 **모델 턴 하나로** 처리한다. 그래서 앞 행은 "돌지도 않은 턴"이고 Stop 은 마지막 행 하나에만 빚진다. 판별 근거는 시간 임계값이 아니라 transcript 다 — 턴이 열린 뒤 assistant 레코드가 **하나도** 없으면 그 턴은 돈 적이 없다. transcript 를 못 읽으면 `next_prompt` 로 남긴다(읽을 수 없음 ≠ 근거 없음).
 
 ```bash
 agentdeck apme stop-health --since 7d [--agent claude-code]
 ```
 
-분모는 **판정 가능한 턴만** — `stop + synthetic_stop + next_prompt`. 열린 턴·취소된 턴·세션 종료로 닫힌 턴·도입 이전 행은 Stop 도착 여부의 증거가 아니므로 비율에서 제외한다. 다만 `total` 에는 열린 턴이 포함되는데, 열린 턴이야말로 "아직 안 온 Stop" 이라 분모에서 빼면 측정하려는 실패를 숨기게 되기 때문이다.
+분모는 **판정 가능한 턴만** — `stop + synthetic_stop + next_prompt`. 열린 턴·취소된 턴·중단된 턴·밀려난 턴·세션 종료로 닫힌 턴·도입 이전 행은 Stop 도착 여부의 증거가 아니므로 비율에서 제외한다. 어느 버킷이 분자·분모에 들어가는지는 `stopDeliveryLoss()`(`@agentdeck/shared`) 한 곳에만 있다 — 소비자가 그 규칙을 다시 적으면 범례가 주장하는 것과 다른 값을 재게 된다. 다만 `total` 에는 열린 턴이 포함되는데, 열린 턴이야말로 "아직 안 온 Stop" 이라 분모에서 빼면 측정하려는 실패를 숨기게 되기 때문이다.
 
 ### steps — 훅 이벤트 + tool 호출 기록
 

--- a/shared/src/eval-schema.ts
+++ b/shared/src/eval-schema.ts
@@ -250,6 +250,23 @@ export type ResponseKind = 'text' | 'tool_only' | 'empty';
  *                       NOT a lost hook. It is its own bucket precisely so it
  *                       stops being counted as one; the transcript's interrupt
  *                       marker is the only evidence it happened.
+ *   - `aborted`         the CLIENT ended the turn: usage limit reached, auth
+ *                       expired (`Please run /login`), credit limit, an API
+ *                       429/529. Claude Code writes one assistant record with
+ *                       `stop_reason: "stop_sequence"` and fires no Stop hook,
+ *                       so — like a cancel — no Stop was ever due. Measured,
+ *                       not assumed: across 211 local transcripts (61k
+ *                       assistant records) every one of the 37 `stop_sequence`
+ *                       records was such an abort message, none was followed by
+ *                       a `stop_hook_summary`, and none was followed by more
+ *                       assistant work in the same turn.
+ *   - `superseded`      a second prompt landed before this one's turn ever ran
+ *                       (queued messages and `<task-notification>` injections
+ *                       arrive in pairs ~130 ms apart), so one model turn served
+ *                       both and only the LAST of them is owed a Stop. The
+ *                       displaced row is an artifact of counting turns per
+ *                       `UserPromptSubmit`; the evidence is that the transcript
+ *                       holds no assistant record at all since the turn opened.
  *   - `session_end`     the session ended while the turn was open (an
  *                       abandoned turn).
  *   - `run_close`       the run was closed or reaped out from under the turn.
@@ -262,6 +279,8 @@ export type TurnEndSource =
   | 'synthetic_stop'
   | 'next_prompt'
   | 'interrupted'
+  | 'aborted'
+  | 'superseded'
   | 'session_end'
   | 'run_close'
   | 'clear';
@@ -276,12 +295,33 @@ export interface ApmeStopDeliveryRow {
   nextPrompt: number;
   /** User cancels. Reported beside the loss buckets, never inside them. */
   interrupted: number;
+  /** Client-side aborts (usage limit, auth, API error). Like a cancel, no Stop
+   *  was owed — reported beside the loss buckets, never inside them. */
+  aborted: number;
+  /** Prompts folded into the following turn before they ran. No Stop owed. */
+  superseded: number;
   /** `session_end` + `run_close` + `clear` folded together. */
   sessionEnd: number;
   /** Still open at query time. */
   open: number;
   /** Closed, but written before `end_source` existed — signal unknown. */
   preInstrument: number;
+}
+
+/** The Stop-delivery rate a row actually supports.
+ *
+ *  Defined once, here, because "which buckets are evidence of a lost hook" is
+ *  the whole instrument and a second consumer restating it would quietly
+ *  measure something else. Only turns whose Stop can be adjudicated are in the
+ *  denominator: a real Stop, a recovered one, or a turn the next prompt
+ *  displaced while it was genuinely running. Cancels, client aborts, superseded
+ *  prompts, session ends, still-open turns and pre-column rows are not evidence
+ *  either way — a turn for which Claude Code never owed a Stop cannot report a
+ *  dropped one. */
+export function stopDeliveryLoss(row: ApmeStopDeliveryRow): { adjudicated: number; lost: number; ratio: number | null } {
+  const adjudicated = row.stop + row.syntheticStop + row.nextPrompt;
+  const lost = row.syntheticStop + row.nextPrompt;
+  return { adjudicated, lost, ratio: adjudicated > 0 ? lost / adjudicated : null };
 }
 
 // ─── HTTP API response envelopes ──────────────────────────────────────────────


### PR DESCRIPTION
## What the instrument said

```
Agent          Turns   Stop    Synth   NoStop  Esc    SessEnd  Open   ?      Stop loss
claude-code    100     55      0       5       0      14       2      24     8% of 60
```

`Synth 0` beside five unrecovered losses has two readings — the recovery path never fired in production (as in 1.0.20, which shipped a watchdog that covered no real traffic), or those five closed before it could. **A zero does not distinguish a path that was never needed from a dead one**, so the path was fired directly rather than inferred.

## The path is alive

An isolated daemon (`-p 9199 --port-window 9190-9199 --loopback`, its own `AGENTDECK_DATA_DIR`) fed one hook POST and a transcript tail:

```
[watchdog] turn closed from transcript (end_turn @ ...)
[watchdog] observed session aaaaaaaa turn ended (end_turn) — injecting synthetic Stop
[APME]     closeTurn 63e02c35 index=0 tools=0 src=synthetic_stop
```

Silent for 25s against an unfinished transcript (negative control). Daemon self-POST → `/hooks/Stop` → collector all work.

## The five "losses" were not losses

Every one traced back to its transcript:

- **3 × client abort.** `You've hit your session limit · resets 5:50pm` is one assistant record with `stop_reason: "stop_sequence"`, and **no `stop_hook_summary` follows it** — Claude Code fires no Stop. The watchdog's `end_turn`-only predicate missed them, and both stayed open **over eight hours**: PROCESSING on every device, the APME run open behind them (open runs starve the eval).
- **2 × a turn that never ran.** `<task-notification>` injections arrive in ~130 ms pairs and one model turn serves both. The leading row closed 116 ms later at the next prompt — it never owed a Stop.

Measured Claude Stop-hook loss in the window is **0 of 60**, not 8%. (All five Claude `next_prompt` rows ever recorded are these two shapes; the other three in the DB are Codex sessions, which have their own `codex_stop`.)

## Change

Two `end_source` buckets, for exactly the reason ESC already has one — **a turn for which no Stop was due cannot report a dropped one**:

- **`aborted`** — the watchdog accepts `stop_sequence` as a third way a turn ends, so an abort closes in ~15s instead of at the next morning's prompt. The statistic is the smaller half of this; the eight-hour open turn is the bug.
- **`superseded`** — a displaced turn with no assistant record behind it. The evidence is the transcript, not a duration threshold.

The predicate was measured before it was trusted: across 211 local transcripts / 61,281 assistant records, `stop_reason` was `tool_use` 58,765, `end_turn` 2,513, `stop_sequence` 37 — all 37 client aborts (limit / `Please run /login` / credits / API 429 / 529), none followed by a `stop_hook_summary`, none followed by more assistant work in the same turn. There is no benign shape to confuse it with.

The next-prompt close now answers all three questions from **one** tail read (`readOpenTurnEvidence`). It replaces `readInterruptSince`, which folded "unreadable" and "no evidence" into the same `null` — those now resolve to different buckets, so they had to be told apart. Which buckets the ratio may read lives once, in `stopDeliveryLoss()` in shared.

## Verified

Both new paths fired end-to-end in a real daemon, not only in unit tests:

```
[watchdog] observed session bbbbbbbb turn ended (aborted) — injecting synthetic Stop
[APME]     closeTurn e70cd2ed index=0 tools=0 src=aborted
[APME]     closeTurn 7a9cf391 index=0 tools=0 src=superseded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)