### PR TITLE
Make an OpenClaw approval something the user can read and answer

### DIFF
--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		3173BC2B844664891B8F3934 /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7A8A00EB9D3B9345E36EB4 /* ProtocolTests.swift */; };
 		32577E0D7F449489455D0C9D /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF390BEA92326B1152B55A9 /* HTTPServer.swift */; };
 		34444319598506828DE09006 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF788F02F06C01E401DC8EA6 /* SessionRegistry.swift */; };
+		36177FF16DB44FF20C64B33D /* OpenClawApprovalRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF67EB1D0BDEE57B39E6E9F /* OpenClawApprovalRules.generated.swift */; };
 		36A5E1C9F248EF1B2B36A6D5 /* CodexConfigInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C6FAC4BDE4DAAFA08E74 /* CodexConfigInstaller.swift */; };
 		37445F34EE5090F24D59EB4A /* DataParticleSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57722317EDF1D567981112DE /* DataParticleSystem.swift */; };
 		378C03BA7C86CFABDD41FA06 /* PixooPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC38F54A1C54AB134DB0535 /* PixooPreview.swift */; };
@@ -130,6 +131,7 @@
 		48B83035D9FC3732361014F8 /* ObservedSteering.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4AC33AE24184BF90D4CAFE /* ObservedSteering.swift */; };
 		4A0D8F7C56E1BEB0167E62CB /* ApmeRecommender.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A8B27A341D1DAE1FCF1D01 /* ApmeRecommender.swift */; };
 		4AA7D220242CD3041FB589D8 /* SessionFocusRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788166EF7E8CB65CDE3D3D67 /* SessionFocusRelay.swift */; };
+		4B12BD71DAC0B74F7FB41BDA /* OpenClawApprovalRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF67EB1D0BDEE57B39E6E9F /* OpenClawApprovalRules.generated.swift */; };
 		4B34D6CBC040FE9BE5E51856 /* OctopusCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776467350B975D0CA1A18E84 /* OctopusCreature.swift */; };
 		4BE94600C86341D01E166A9C /* AttentionTheaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1853443C348441BF748662A /* AttentionTheaterView.swift */; };
 		4C5100ED3B4CE6BEDA3F2721 /* ProjectNameResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6D4E03A73AA83A363FA94 /* ProjectNameResolverTests.swift */; };
@@ -532,6 +534,7 @@
 		48F37E295246F5931D533E31 /* TimelineStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStripView.swift; sourceTree = "<group>"; };
 		4A2D26F6BDF08F6E4F2F8439 /* ApmeHttpRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApmeHttpRoutes.swift; sourceTree = "<group>"; };
 		4AA25996ACA820A3C8D6273A /* CreatureGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatureGeometry.swift; sourceTree = "<group>"; };
+		4AF67EB1D0BDEE57B39E6E9F /* OpenClawApprovalRules.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClawApprovalRules.generated.swift; sourceTree = "<group>"; };
 		4BE102D050319B6A78A505B3 /* AquariumSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AquariumSurface.swift; sourceTree = "<group>"; };
 		4C2005980598D651492006A3 /* OpenCodeCreature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeCreature.swift; sourceTree = "<group>"; };
 		4CEC7D8557C3DA805DBA75E1 /* TailDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailDecoder.swift; sourceTree = "<group>"; };
@@ -1089,6 +1092,7 @@
 			children = (
 				7BCC68BE56702DFD637FFE02 /* GatewayProbe.swift */,
 				427B912EBD043285F0A0008D /* OpenClawAdapter.swift */,
+				4AF67EB1D0BDEE57B39E6E9F /* OpenClawApprovalRules.generated.swift */,
 			);
 			path = Gateway;
 			sourceTree = "<group>";
@@ -1581,6 +1585,7 @@
 				F1C357A840E59D7A188C808B /* OnboardingScreen.swift in Sources */,
 				E98F3FC6D7134E8E65163D93 /* OnboardingSheet.swift in Sources */,
 				FD86AF81DA987540254BA326 /* OpenClawAdapter.swift in Sources */,
+				4B12BD71DAC0B74F7FB41BDA /* OpenClawApprovalRules.generated.swift in Sources */,
 				7AA10F90E922138D683C318D /* OpenClawTokenImporter.swift in Sources */,
 				46086D1358BD25389E304052 /* OpenCodeCreature.swift in Sources */,
 				F9EEBCC88FC55225E6D60AEE /* OpenCodeObserver.swift in Sources */,
@@ -1764,6 +1769,7 @@
 				BF6E216F74A8205677B8B82B /* OnboardingScreen.swift in Sources */,
 				F608DAD197953CC405F306A5 /* OnboardingSheet.swift in Sources */,
 				58591ABC081F2367FEE6B563 /* OpenClawAdapter.swift in Sources */,
+				36177FF16DB44FF20C64B33D /* OpenClawApprovalRules.generated.swift in Sources */,
 				D53FC33DD05A32D719809874 /* OpenClawTokenImporter.swift in Sources */,
 				996C92E310F9A7E69C40C803 /* OpenCodeCreature.swift in Sources */,
 				FA2AA2B226EBD69F45238A1F /* OpenCodeObserver.swift in Sources */,

--- a/apple/AgentDeck/Daemon/Gateway/OpenClawAdapter.swift
+++ b/apple/AgentDeck/Daemon/Gateway/OpenClawAdapter.swift
@@ -217,7 +217,12 @@ actor OpenClawAdapter {
     /// ts, sails past the store's 8s dedup window, and lands as a duplicate
     /// row on every reconnect. Dedup must therefore key on line content.
     private var replayedLogLines: Set<Int> = []
-    private var pendingApprovalId: String?
+    /// The exec approval the Gateway is blocked on, normalized for display AND
+    /// for answering. Replaced a bare id: the id alone let the daemon forward a
+    /// device press with no `decision` on it (rejected by the Gateway), and left
+    /// every surface with nothing to show but "PERMIT?".
+    private var pendingApproval: OpenClawApprovalPrompt?
+    private var pendingApprovalId: String? { pendingApproval?.id }
     private struct RPCResponse: @unchecked Sendable {
         let ok: Bool
         let payload: [String: Any]?
@@ -545,10 +550,25 @@ actor OpenClawAdapter {
             if let runId = currentRunId { chatEvent["runId"] = runId }
             self._onEvent?(chatEvent)
         case ADGatewayEventName.execApprovalRequested.rawValue:
-            pendingApprovalId = payload["id"] as? String
-            self._onEvent?(["type": "gateway_approval", "payload": payload])
+            // Parse through the SSOT rather than reading fields off the payload
+            // here: everything the user needs to see lives under `request`, and
+            // reading it flat (`payload["tool"]`, which never exists) is what
+            // shipped an approval with no command on it.
+            pendingApproval = OpenClawApprovalRules.parse(payload, nowMs: Date().timeIntervalSince1970 * 1000)
+            var approvalEvent: [String: Any] = ["type": "gateway_approval", "payload": payload]
+            if let prompt = pendingApproval {
+                approvalEvent["prompt"] = Self.promptDict(prompt)
+            }
+            self._onEvent?(approvalEvent)
         case ADGatewayEventName.execApprovalResolved.rawValue:
-            pendingApprovalId = nil
+            // Key off the payload's own id: a resolution can arrive for an
+            // approval we already dropped, and clearing unconditionally would
+            // discard a newer pending one.
+            if let resolvedId = payload["id"] as? String, resolvedId != pendingApproval?.id {
+                // Not ours — leave the pending prompt alone.
+            } else {
+                pendingApproval = nil
+            }
             self._onEvent?(["type": "gateway_approval_resolved", "payload": payload])
         case ADGatewayEventName.presence.rawValue, ADGatewayEventName.systemPresence.rawValue:
             self._onEvent?(["type": "gateway_presence", "payload": payload])
@@ -694,6 +714,11 @@ actor OpenClawAdapter {
             requestBaselineState()
             requestSessionsList()
             Task { await self.emitModelCatalog() }
+            // Catch up on approvals already waiting. `exec.approval.requested`
+            // is a broadcast and is never replayed, so without this a daemon
+            // restart leaves the agent blocked on an approval that exists on
+            // exactly one side — idle deck, stalled agent, nothing to act on.
+            Task { await self.adoptPendingApprovals() }
         case "sessions.subscribe":
             let subscribed = payload?["subscribed"] as? Bool ?? false
             sessionsSubscribed = subscribed
@@ -966,6 +991,121 @@ actor OpenClawAdapter {
         sendRPC(method: method, params: params, continuation: nil)
     }
 
+    // MARK: - Pending exec approval
+
+    /// The approval the Gateway is blocked on, for the virtual
+    /// `openclaw-gateway` session row. Without the question and options on that
+    /// row, every deck falls back to "PERMIT? / answer in terminal" — and the
+    /// Gateway session has no terminal to answer in.
+    func currentPendingApproval() -> [String: Any]? {
+        pendingApproval.map(Self.promptDict)
+    }
+
+    /// Read the approvals the Gateway is already blocked on and surface the
+    /// oldest one. Called once per handshake.
+    ///
+    /// Only one is adopted: the deck renders a single question at a time, and
+    /// the Gateway blocks the agent on each in turn, so the oldest is the one
+    /// actually holding work up.
+    private func adoptPendingApprovals() async {
+        let response = await rpcRequest(method: "exec.approval.list", params: [:])
+        guard response.ok else { return }
+        // The result is a bare array, which some transports box under a key.
+        let rows: [[String: Any]] = {
+            if let list = response.payload as? [[String: Any]] { return list }
+            if let dict = response.payload as? [String: Any],
+               let list = dict["approvals"] as? [[String: Any]] { return list }
+            return []
+        }()
+        guard !rows.isEmpty else { return }
+        let sorted = rows.sorted {
+            (($0["createdAtMs"] as? Double) ?? 0) < (($1["createdAtMs"] as? Double) ?? 0)
+        }
+        guard let oldest = sorted.first,
+              let prompt = OpenClawApprovalRules.parse(
+                oldest, nowMs: Date().timeIntervalSince1970 * 1000),
+              prompt.id != pendingApproval?.id
+        else { return }
+        pendingApproval = prompt
+        DaemonLogger.shared.debug("OpenClaw", "adopted pending approval \(prompt.id) on connect")
+        self._onEvent?([
+            "type": "gateway_approval",
+            "payload": oldest,
+            "prompt": Self.promptDict(prompt),
+        ])
+    }
+
+    /// Answer the pending approval from a device command (`select_option` /
+    /// `respond`).
+    ///
+    /// This exists because the call sites used to forward the RAW device command
+    /// as the RPC params — `{type:"select_option", index:0, sessionId:…}`, which
+    /// carries no `decision` at all. The Gateway validates `decision` before it
+    /// looks the id up, so every press came back INVALID_REQUEST and the
+    /// approval stayed pending with nothing logged.
+    ///
+    /// Returns false when there is nothing pending or the press names no
+    /// decision this request allows — an ambiguous press is dropped, never
+    /// guessed into an approval.
+    @discardableResult
+    func resolvePendingApproval(command: [String: Any]) -> Bool {
+        guard let prompt = pendingApproval else { return false }
+        let type = command["type"] as? String ?? ""
+        let decision: ExecApprovalDecision?
+        switch type {
+        case "select_option":
+            // A press must name the question it answers: a prompt the Gateway
+            // has already moved past would otherwise apply this index to a
+            // different command.
+            if let echo = command["question"] as? String, !Self.approvalEchoMatches(prompt, echo) {
+                DaemonLogger.shared.debug(
+                    "OpenClaw", "select_option dropped: question echo does not match pending approval")
+                return false
+            }
+            let index = command["index"] as? Int ?? -1
+            decision = OpenClawApprovalRules.decision(forOptionIndex: index, in: prompt)
+        case "respond":
+            decision = OpenClawApprovalRules.decision(
+                forRespondValue: command["value"] as? String ?? "", in: prompt)
+        default:
+            decision = nil
+        }
+        guard let decision else {
+            DaemonLogger.shared.debug(
+                "OpenClaw", "approval \(type) named no allowed decision — ignored")
+            return false
+        }
+        sendRPC(method: "exec.approval.resolve", params: ["id": prompt.id, "decision": decision.rawValue])
+        return true
+    }
+
+    /// Truncation-tolerant echo compare. Devices cap the question they display,
+    /// so an exact match would refuse every press from a small surface.
+    /// Compares `.utf16` so the Swift and TS daemons cut at the same units.
+    private static func approvalEchoMatches(_ prompt: OpenClawApprovalPrompt, _ echo: String) -> Bool {
+        let a = Array(prompt.question.trimmingCharacters(in: .whitespacesAndNewlines).utf16)
+        let b = Array(echo.trimmingCharacters(in: .whitespacesAndNewlines).utf16)
+        if b.isEmpty { return true }
+        let n = min(a.count, b.count)
+        return Array(a.prefix(n)) == Array(b.prefix(n))
+    }
+
+    /// Wire form of a prompt — the same field names the Node daemon puts on the
+    /// session row, so devices see one shape regardless of which daemon runs.
+    private static func promptDict(_ prompt: OpenClawApprovalPrompt) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": prompt.id,
+            "question": prompt.question,
+            "command": prompt.command,
+            "options": prompt.options.map {
+                ["index": $0.index, "label": $0.label, "shortcut": $0.shortcut]
+            },
+        ]
+        if let detail = prompt.detail { dict["detail"] = detail }
+        if let cwd = prompt.cwd { dict["cwd"] = cwd }
+        return dict
+    }
+
     private func rpcRequest(method: String, params: [String: Any]) async -> RPCResponse {
         await withCheckedContinuation { continuation in
             sendRPC(method: method, params: params, continuation: continuation)
@@ -1003,8 +1143,34 @@ actor OpenClawAdapter {
                 resolvedParams["runId"] = runId
             }
         case "exec.approval.resolve":
+            // Direct callers (the held-gate `permission_decision` path) still
+            // build their own params; only fill in what they left out. Device
+            // presses go through `resolvePendingApproval(command:)` instead,
+            // which is the only path that can map an index to a decision.
             if resolvedParams["id"] == nil, let pendingApprovalId {
                 resolvedParams["id"] = pendingApprovalId
+            }
+            // A decision the Gateway does not recognize is rejected before the
+            // id is even looked up, so normalize the legacy `allow`/`deny`
+            // spellings through the SSOT instead of letting them leave as-is.
+            // Never substitute a decision the user did not express: an
+            // unmappable value is dropped and logged, not turned into a deny.
+            let rawDecision = resolvedParams["decision"] as? String ?? ""
+            if ExecApprovalDecision(rawValue: rawDecision) == nil {
+                if let prompt = pendingApproval,
+                   let mapped = OpenClawApprovalRules.decision(forRespondValue: rawDecision, in: prompt) {
+                    resolvedParams["decision"] = mapped.rawValue
+                } else {
+                    DaemonLogger.shared.debug(
+                        "OpenClaw",
+                        "exec.approval.resolve dropped: '\(rawDecision)' is not a decision this approval allows")
+                    continuation?.resume(returning: RPCResponse(
+                        ok: false,
+                        payload: nil,
+                        error: ["code": "INVALID_DECISION", "message": "unsupported approval decision"]
+                    ))
+                    return
+                }
             }
         default:
             break

--- a/apple/AgentDeck/Daemon/Gateway/OpenClawApprovalRules.generated.swift
+++ b/apple/AgentDeck/Daemon/Gateway/OpenClawApprovalRules.generated.swift
@@ -1,0 +1,187 @@
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: shared/src/openclaw-approval.ts
+// Regenerate: pnpm generate-openclaw-approval-rules (drift gated by shared/src/__tests__/openclaw-approval-rules-sync.test.ts)
+
+import Foundation
+
+#if os(macOS)
+
+/// The decisions the OpenClaw Gateway will accept for an exec approval.
+///
+/// `allow` is deliberately NOT a member. The Gateway's `isApprovalDecision`
+/// rejects it, and it does so before the approval id is looked up — so a resolve
+/// carrying it returns INVALID_REQUEST and the approval stays pending with no
+/// visible failure anywhere.
+enum ExecApprovalDecision: String, CaseIterable, Sendable {
+    case allowOnce = "allow-once"
+    case allowAlways = "allow-always"
+    case deny = "deny"
+
+    static let ordered: [ExecApprovalDecision] = [.allowOnce, .allowAlways, .deny]
+
+    /// Short device-facing label (Stream Deck keys, D200H cells).
+    var label: String {
+        switch self {
+        case .allowOnce: return "Allow once"
+        case .allowAlways: return "Always allow"
+        case .deny: return "Deny"
+        }
+    }
+
+    /// What a non-navigable `respond` press carries for this decision.
+    var shortcut: String {
+        switch self {
+        case .allowOnce: return "y"
+        case .allowAlways: return "a"
+        case .deny: return "n"
+        }
+    }
+
+    var allowsExecution: Bool {
+        self == .allowOnce || self == .allowAlways
+    }
+}
+
+/// One renderable choice on a deck surface. The decision rides the option so an
+/// index press is never re-derived (and mis-derived) at the answer site.
+struct ExecApprovalOption: Sendable, Equatable {
+    let index: Int
+    let label: String
+    let shortcut: String
+    let decision: ExecApprovalDecision
+}
+
+/// Normalized `exec.approval.requested` — what surfaces render and what an
+/// answer maps back through.
+struct OpenClawApprovalPrompt: Sendable, Equatable {
+    let id: String
+    let question: String
+    let detail: String?
+    let command: String
+    let cwd: String?
+    let options: [ExecApprovalOption]
+    let expiresAtMs: Double?
+    let requestedAtMs: Double
+    let sessionKey: String?
+}
+
+enum OpenClawApprovalRules {
+
+    /// Parse a raw `exec.approval.requested` payload.
+    ///
+    /// The Gateway sends `{ id, request, createdAtMs, expiresAtMs }` — every
+    /// display field lives under `request`. The flat lookup is a compatibility
+    /// path only, so a Gateway that inlines a field degrades instead of blanking
+    /// the prompt. Returns nil only when there is no usable id: a request with no
+    /// command text still yields a prompt, because the user must keep the ability
+    /// to deny something they cannot see.
+    static func parse(_ payload: [String: Any], nowMs: Double) -> OpenClawApprovalPrompt? {
+        let id = (payload["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !id.isEmpty else { return nil }
+
+        var body = payload
+        if let request = payload["request"] as? [String: Any] {
+            for (k, v) in request { body[k] = v }
+        }
+
+        let argv = (body["commandArgv"] as? [String])?.joined(separator: " ")
+        let command = firstNonEmpty([
+            body["command"] as? String,
+            body["commandPreview"] as? String,
+            argv,
+        ]) ?? ""
+
+        let cwd = firstNonEmpty([body["cwd"] as? String])
+        var detailParts: [String] = []
+        if let cwd { detailParts.append("cwd: \(cwd)") }
+        let warning = firstNonEmpty([body["warningText"] as? String])
+        if let warning { detailParts.append(warning) }
+        if let analysis = firstNonEmpty([body["commandAnalysis"] as? String]), analysis != warning {
+            detailParts.append(analysis)
+        }
+
+        let options = resolveDecisions(body).enumerated().map { idx, decision in
+            ExecApprovalOption(
+                index: idx, label: decision.label, shortcut: decision.shortcut, decision: decision)
+        }
+
+        return OpenClawApprovalPrompt(
+            id: id,
+            question: command.isEmpty ? "Approve tool execution (command not reported)" : command,
+            detail: detailParts.isEmpty ? nil : detailParts.joined(separator: "\n"),
+            command: command,
+            cwd: cwd,
+            options: options,
+            expiresAtMs: numeric(payload["expiresAtMs"]),
+            requestedAtMs: numeric(payload["createdAtMs"]) ?? nowMs,
+            sessionKey: firstNonEmpty([body["sessionKey"] as? String])
+        )
+    }
+
+    /// Map a `select_option` index onto the decision that option represents.
+    static func decision(forOptionIndex index: Int, in prompt: OpenClawApprovalPrompt)
+        -> ExecApprovalDecision?
+    {
+        prompt.options.first(where: { $0.index == index })?.decision
+    }
+
+    /// Map a `respond` value onto a decision. Accepts the option shortcut, the
+    /// decision name, and the y/n/a spellings hardware keys and the wake-word
+    /// assistant send. Unrecognized input returns nil — an ambiguous press must
+    /// never be guessed into an approval.
+    static func decision(forRespondValue value: String, in prompt: OpenClawApprovalPrompt)
+        -> ExecApprovalDecision?
+    {
+        let v = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !v.isEmpty else { return nil }
+        if let byDecision = prompt.options.first(where: { $0.decision.rawValue == v }) {
+            return byDecision.decision
+        }
+        if let byShortcut = prompt.options.first(where: { $0.shortcut == v }) {
+            return byShortcut.decision
+        }
+        if let byLabel = prompt.options.first(where: { $0.label.lowercased() == v }) {
+            return byLabel.decision
+        }
+        let alias: [String: ExecApprovalDecision] = [
+            "y": .allowOnce, "yes": .allowOnce, "allow": .allowOnce, "once": .allowOnce,
+            "a": .allowAlways, "always": .allowAlways,
+            "n": .deny, "no": .deny, "reject": .deny,
+        ]
+        guard let mapped = alias[v] else { return nil }
+        // Honor the request's own policy: a spoken "always" against a request
+        // that forbids allow-always must be refused, not downgraded.
+        return prompt.options.contains(where: { $0.decision == mapped }) ? mapped : nil
+    }
+
+    /// Decisions this specific request permits. The Gateway narrows them
+    /// per-request (an `ask: "always"` policy drops allow-always), so never
+    /// offer one it forbids. Deny is always kept: a prompt the user can only
+    /// accept is not a prompt.
+    private static func resolveDecisions(_ body: [String: Any]) -> [ExecApprovalDecision] {
+        let allowed = (body["allowedDecisions"] as? [String] ?? [])
+            .compactMap(ExecApprovalDecision.init(rawValue:))
+        let base = allowed.isEmpty ? ExecApprovalDecision.ordered : allowed
+        let unavailable = Set(body["unavailableDecisions"] as? [String] ?? [])
+        let kept = base.filter { !unavailable.contains($0.rawValue) }
+        return kept.isEmpty ? [.deny] : kept
+    }
+
+    private static func firstNonEmpty(_ values: [String?]) -> String? {
+        for value in values {
+            if let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    private static func numeric(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let n = value as? NSNumber { return n.doubleValue }
+        return nil
+    }
+}
+
+#endif

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -463,6 +463,12 @@ final class DaemonServer {
     private var gatewaySessionState: String = "idle"
     private var gatewayCurrentTool: String? = nil
     private var gatewayModelName: String? = nil
+    /// Wire form of the exec approval the Gateway is blocked on, mirrored here
+    /// from the adapter event so the (synchronous) sessions-list builder can put
+    /// it on the virtual row. Cleared on resolve, on any turn end, and on
+    /// disconnect — the Gateway emits no `resolved` event for the last two, so
+    /// nothing else would ever take the prompt off the deck.
+    private var gatewayPendingApproval: [String: Any]? = nil
 
     // State caches
     private var cachedSessions: [DaemonSessionEntry] = []
@@ -3185,13 +3191,16 @@ final class DaemonServer {
                 return
             }
             let gw = gatewayAdapter
-            let cmdBox = SendableDict(cmd)
+            // Send ONLY the two params the method takes. Forwarding the whole
+            // device command dragged `type`/`requestId` into the RPC alongside a
+            // decision spelling the Gateway does not accept.
+            let cmdBox = SendableDict(["type": "respond", "value": decision])
             Task {
                 if await ObservedSteering.shared.resolveGate(requestId: requestId, decision: decision) != nil {
                     return // held route handler resumes + clears the overlay
                 }
                 if let gw {
-                    await gw.sendRPC(method: "exec.approval.resolve", params: cmdBox.value)
+                    await gw.resolvePendingApproval(command: cmdBox.value)
                 } else {
                     DaemonLogger.shared.debug("Daemon", "permission_decision: no gate/gateway for request \(requestId)")
                 }
@@ -3293,11 +3302,15 @@ final class DaemonServer {
         if !sessionScopedCmd, let gw = gatewayAdapter {
             let cmdBox = SendableDict(cmd)
             switch type {
-            case "respond": Task { await gw.sendRPC(method: "exec.approval.resolve", params: cmdBox.value) }
+            // Device presses carry an option index or a shortcut, never a
+            // Gateway decision — forwarding the raw command as RPC params (which
+            // this did) sent `{type:"respond", value:"y"}` and no `decision` at
+            // all, so the Gateway rejected it and the approval stayed pending.
+            case "respond": Task { await gw.resolvePendingApproval(command: cmdBox.value) }
                 _ = stateMachine.transition(trigger: "user_response", source: .user); broadcastStateUpdate()
             case "interrupt": Task { await gw.sendRPC(method: "chat.abort", params: [:]) }
                 _ = stateMachine.transition(trigger: "interrupt", source: .user); broadcastStateUpdate()
-            case "select_option": Task { await gw.sendRPC(method: "exec.approval.resolve", params: cmdBox.value) }
+            case "select_option": Task { await gw.resolvePendingApproval(command: cmdBox.value) }
                 _ = stateMachine.transition(trigger: "user_selection", source: .user); broadcastStateUpdate()
             case "send_prompt": Task { await gw.sendRPC(method: "chat.send", params: cmdBox.value) }
                 _ = stateMachine.transition(trigger: "user_prompt_submit", source: .hook); broadcastStateUpdate()
@@ -6336,6 +6349,10 @@ final class DaemonServer {
                         _ = self?.stateMachine.transition(trigger: "session_end", source: .hook)
                         self?.gatewaySessionState = "idle"
                         self?.gatewayCurrentTool = nil
+                        // Pending approvals are Gateway-process state: a
+                        // reconnect issues new ids, so a retained prompt would
+                        // offer buttons that resolve to "unknown or expired".
+                        self?.gatewayPendingApproval = nil
                         // APME: close the gateway run on disconnect
                         self?.apmeCollectorGateway?.handleHook(event: "session_end", data: [
                             "session_id": "openclaw-gateway",
@@ -6388,6 +6405,7 @@ final class DaemonServer {
         cachedGatewayAuthMessage = nil
         gatewaySessionState = "idle"
         gatewayCurrentTool = nil
+        gatewayPendingApproval = nil
         // Note: gatewayModelName is intentionally preserved across brief disconnects
         // so the model row doesn't flash empty on reconnect.
         _ = stateMachine.transition(trigger: "session_end", source: .hook)
@@ -6405,10 +6423,15 @@ final class DaemonServer {
         case "gateway_chat":
             let chatPayload = event["payload"] as? [String: Any] ?? [:]
             let chatState = chatPayload["state"] as? String
+            let hadApproval = gatewayPendingApproval != nil
             switch chatState {
             case "final", "aborted":
                 gatewaySessionState = "idle"
                 gatewayCurrentTool = nil
+                // A run cancelled while an approval was outstanding is what
+                // stranded the deck on PERMIT?: the Gateway drops the approval
+                // without emitting `resolved`, so this is its only close.
+                gatewayPendingApproval = nil
                 // APME: record response text → triggers inline classification + eval
                 let response = chatPayload["response"] as? String ?? ""
                 if !response.isEmpty {
@@ -6417,24 +6440,37 @@ final class DaemonServer {
             case "error":
                 gatewaySessionState = "idle"
                 gatewayCurrentTool = nil
+                gatewayPendingApproval = nil
             default:
                 gatewaySessionState = "processing"
             }
             broadcastStateUpdate()
+            // Only when the row's prompt actually went away — `default` fires on
+            // every streaming delta, and a sessions_list per delta is a broadcast
+            // storm on a fleet of boards.
+            if hadApproval && gatewayPendingApproval == nil { broadcastSessionsList() }
         case "gateway_approval":
             gatewaySessionState = "awaiting_permission"
-            if let payload = event["payload"] as? [String: Any] {
-                gatewayCurrentTool = payload["tool"] as? String
-            }
+            // `prompt` is the adapter's SSOT-parsed form. The old
+            // `payload["tool"]` read was an invented field the Gateway never
+            // sends, so the row showed PERMIT? with nothing on it.
+            gatewayPendingApproval = event["prompt"] as? [String: Any]
+            gatewayCurrentTool = (gatewayPendingApproval?["command"] as? String)
+                .flatMap { $0.split(separator: " ").first.map(String.init) }
             broadcastStateUpdate()
+            broadcastSessionsList()
         case "gateway_approval_resolved":
             let resolvedPayload = event["payload"] as? [String: Any]
             let decision = resolvedPayload?["decision"] as? String
-            // "deny" means tool execution was blocked — agent returns to idle.
-            // "allow" (or any other value) means execution resumes → processing.
-            gatewaySessionState = (decision == "deny") ? "idle" : "processing"
+            // Only an allow resumes the turn. The decisions are allow-once /
+            // allow-always / deny — testing for the string "deny" was right by
+            // accident, but testing for allow (as the Node side did) was not.
+            let allowed = ExecApprovalDecision(rawValue: decision ?? "")?.allowsExecution ?? false
+            gatewaySessionState = allowed ? "processing" : "idle"
+            gatewayPendingApproval = nil
             gatewayCurrentTool = nil
             broadcastStateUpdate()
+            broadcastSessionsList()
         case "gateway_presence":
             break // Heartbeat
         case "gateway_auth":
@@ -7018,6 +7054,19 @@ final class DaemonServer {
                 }
                 if let tool = gatewayCurrentTool { gatewaySession["currentTool"] = tool }
                 if let modelName = gatewayModelName { gatewaySession["modelName"] = modelName }
+                // The exec approval the Gateway is blocked on. Every deck reads
+                // its option cells off the session row and only falls back to
+                // the dead-end "PERMIT? / answer in terminal" tile when they are
+                // absent — and this row never carried them, while the Gateway
+                // session has no terminal to answer in.
+                if let prompt = gatewayPendingApproval {
+                    gatewaySession["question"] = prompt["question"]
+                    gatewaySession["options"] = prompt["options"]
+                    gatewaySession["promptType"] = "yes_no_always"
+                    // The daemon can deliver this answer over the Gateway RPC,
+                    // so the cells are live rather than display-only.
+                    gatewaySession["liveAnswerable"] = true
+                }
                 // The virtual row bypasses sessionToDict, so attach the REVIEW
                 // badge here too — without it the deck never shows REVIEWING /
                 // the verdict for OpenClaw reviews.

--- a/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
@@ -24,7 +24,7 @@
 // against; `scripts/check-preview-mirror-sync.mjs` verifies they match the
 // current `git hash-object` of each file and fails CI when the origin drifts
 // ahead of this mirror. Update them whenever you re-port.
-// SYNC-HASH shared/src/d200h-layout.ts bf1f4798a011ff041242ba42997180b8b4f4f521
+// SYNC-HASH shared/src/d200h-layout.ts 74445bade8a9ad9656d623d0724fb8b69683b6d9
 // SYNC-HASH shared/src/session-utils.ts e3963a0fe056d7d4e92046763078999a8a3d4e88
 //
 // INTENTIONALLY OMITTED (not needed by a read-only preview):
@@ -528,12 +528,16 @@ public enum D200HLayoutModel {
         if isAwaiting(sState) {
             let navigable = focused ? input.navigable : false
             let isObserved = sess?.controlMode == "observed"
-            // A hook-observed session's options are pressable only when the
-            // daemon can deliver the answer — by typing into that session's
-            // terminal, or by holding its AskUserQuestion open to resolve with
-            // the choice. Without the flag the cells mirror the terminal rather
-            // than pretend a press will work.
-            let observedAnswerable = isObserved && (sess?.liveAnswerable == true)
+            // Options are pressable only when the daemon can deliver the answer
+            // — by typing into that session's terminal, by holding its
+            // AskUserQuestion open to resolve with the choice, or (the OpenClaw
+            // Gateway row) by resolving the approval over the Gateway RPC.
+            // `liveAnswerable` covers all three and is NOT observed-only: the
+            // Gateway row is `managed` and has no terminal to fall back to, so
+            // gating on `isObserved` rendered its decisions as a dead mirror.
+            // Without the flag the cells mirror the terminal rather than pretend
+            // a press will work.
+            let answerable = sess?.liveAnswerable == true
             if !options.isEmpty {
                 for (i, opt) in options.enumerated() {
                     // The server-assigned index is what a press must send back;
@@ -544,14 +548,14 @@ public enum D200HLayoutModel {
                     // focused live state first, then the roster row.
                     let q = (focused ? (input.question ?? sess?.question) : sess?.question) ?? ""
                     if !q.isEmpty { payload["question"] = q }
-                    let action: D200HDeckAction = (navigable || observedAnswerable)
+                    let action: D200HDeckAction = (navigable || answerable)
                         ? .command(type: "select_option", payload: payload)
                         : .command(type: "respond", payload: ["value": respondValue(opt, index: i)])
                     cells.append(Cell(
                         kind: .option(index: i),
                         label: optionLabel(opt, index: i),
                         subtitle: nil,
-                        action: (isObserved && !observedAnswerable) ? .none : action))
+                        action: (isObserved && !answerable) ? .none : action))
                 }
             } else if isObserved, let gate = sess?.requestId, !gate.isEmpty {
                 // Held PreToolUse gate: device-native semantics (permit/deny

--- a/bridge/src/__tests__/adapter.test.ts
+++ b/bridge/src/__tests__/adapter.test.ts
@@ -473,10 +473,14 @@ describe('OpenClawAdapter gateway protocol', () => {
     completeHandshake();
     events.length = 0;
 
+    // The real event nests everything under `request` — see
+    // `buildRequestedApprovalEvent` in OpenClaw's approval-shared bundle. This
+    // fixture used to be flat, which is why it stayed green for the entire
+    // period no user could see what they were approving.
     simulateMessage({
       type: 'event',
       event: 'exec.approval.requested',
-      payload: { id: 'approval-1', command: 'rm -rf /tmp/test' },
+      payload: { id: 'approval-1', request: { command: 'rm -rf /tmp/test' } },
     });
 
     expect(events).toContainEqual(
@@ -486,7 +490,7 @@ describe('OpenClawAdapter gateway protocol', () => {
         data: expect.objectContaining({
           question: 'rm -rf /tmp/test',
           options: expect.arrayContaining([
-            expect.objectContaining({ label: 'Allow' }),
+            expect.objectContaining({ label: 'Allow once' }),
             expect.objectContaining({ label: 'Deny' }),
           ]),
         }),
@@ -500,7 +504,7 @@ describe('OpenClawAdapter gateway protocol', () => {
     simulateMessage({
       type: 'event',
       event: 'exec.approval.requested',
-      payload: { id: 'approval-42', command: 'npm install' },
+      payload: { id: 'approval-42', request: { command: 'npm install' } },
     });
 
     wsInstance.send.mockClear();
@@ -512,7 +516,9 @@ describe('OpenClawAdapter gateway protocol', () => {
     expect(sent.type).toBe('req');
     expect(sent.method).toBe('exec.approval.resolve');
     expect(sent.params.id).toBe('approval-42');
-    expect(sent.params.decision).toBe('allow');
+    // NOT 'allow' — the Gateway's `isApprovalDecision` rejects that spelling
+    // before it even looks the id up, so the approval would stay pending.
+    expect(sent.params.decision).toBe('allow-once');
   });
 
   it('sends exec.approval.resolve with deny on respond "n"', () => {
@@ -521,6 +527,8 @@ describe('OpenClawAdapter gateway protocol', () => {
     simulateMessage({
       type: 'event',
       event: 'exec.approval.requested',
+      // Deliberately flat: a Gateway that ever inlines the fields must still
+      // produce an answerable prompt rather than a blank one.
       payload: { id: 'approval-99', command: 'dangerous-cmd' },
     });
 

--- a/bridge/src/__tests__/openclaw-approval-flow.test.ts
+++ b/bridge/src/__tests__/openclaw-approval-flow.test.ts
@@ -1,0 +1,223 @@
+/**
+ * OpenClaw exec-approval: what the user sees, and whether they can answer it.
+ *
+ * The real one (2026-08-17): the deck sat on `PERMIT?` for approvals nobody
+ * could read or resolve. Three independent defects, all silent:
+ *
+ *  1. The adapter read `payload.command` / `payload.ask` flat. The Gateway
+ *     nests them under `request`, so every field was undefined and the prompt
+ *     collapsed to the literal "Approve tool execution?".
+ *  2. It answered with `decision: 'allow'`. The Gateway accepts only
+ *     allow-once / allow-always / deny and validates the decision BEFORE the id
+ *     lookup, so the resolve was rejected, the rejection went to a `debug()`
+ *     line that is off by default, and the approval stayed pending.
+ *  3. A run cancelled while an approval was outstanding emits no
+ *     `exec.approval.resolved`, so nothing ever cleared the prompt.
+ *
+ * These tests drive the adapter with real Gateway frames.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../apme/index.js', () => ({
+  getApme: () => ({ collector: { ingestSpan: vi.fn() } }),
+}));
+
+import { OpenClawAdapter } from '../adapters/openclaw.js';
+import type { AdapterEvent, AdapterParserEvent, TimelineEntry } from '@agentdeck/shared';
+
+type RpcCall = { method: string; params: Record<string, unknown> };
+type ParserEvent = AdapterParserEvent;
+
+/** Adapter + captured timeline rows, parser events, and outbound RPCs. */
+function harness(rpcResult: Promise<unknown> = Promise.resolve({ ok: true })) {
+  const adapter = new OpenClawAdapter({ autoReconnect: false });
+  const rows: TimelineEntry[] = [];
+  const parser: ParserEvent[] = [];
+  const rpcs: RpcCall[] = [];
+  adapter.on('event', (evt: AdapterEvent) => {
+    if (evt.source === 'timeline' && evt.entry) rows.push(evt.entry);
+    if (evt.source === 'parser') parser.push(evt as ParserEvent);
+  });
+  (adapter as unknown as { rpcCall(m: string, p: Record<string, unknown>): Promise<unknown> })
+    .rpcCall = (method, params) => {
+      rpcs.push({ method, params });
+      return rpcResult;
+    };
+  const gw = (event: string, payload: Record<string, unknown>) =>
+    (adapter as unknown as { handleGatewayEvent(e: string, p: Record<string, unknown>): void })
+      .handleGatewayEvent(event, payload);
+  return { adapter, rows, parser, rpcs, gw };
+}
+
+/** The shape `buildRequestedApprovalEvent` actually emits. */
+const REQUESTED = {
+  id: 'aa2318a0-dfdb-40e2-8238-c09e7905f95e',
+  createdAtMs: 1_786_940_704_797,
+  request: {
+    command: 'rg --files-with-matches TODO src',
+    cwd: '/Users/dev/project',
+    ask: 'on-miss',
+    allowedDecisions: ['allow-once', 'allow-always', 'deny'],
+  },
+};
+
+describe('the user can see what they are approving', () => {
+  it('puts the real command on the timeline row and the prompt', () => {
+    const { rows, parser, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+
+    const request = rows.find((r) => r.type === 'tool_request')!;
+    expect(request.raw).toBe('rg --files-with-matches TODO src');
+    expect(request.raw).not.toContain('Approve tool execution');
+    expect(request.detail).toContain('cwd: /Users/dev/project');
+    expect(request.approvalId).toBe(REQUESTED.id);
+    expect(request.status).toBe('pending');
+
+    const prompt = parser.find((e) => e.event === 'permission_prompt')!;
+    expect(prompt.data?.question).toBe('rg --files-with-matches TODO src');
+    expect((prompt.data?.options as Array<{ label: string }>).map((o) => o.label))
+      .toEqual(['Allow once', 'Always allow', 'Deny']);
+  });
+
+  it('exposes the prompt for the session row', () => {
+    const { adapter, gw } = harness();
+    expect(adapter.getPendingApproval()).toBeNull();
+    gw('exec.approval.requested', REQUESTED);
+    expect(adapter.getPendingApproval()?.command).toBe('rg --files-with-matches TODO src');
+  });
+});
+
+describe('the user can actually resolve it', () => {
+  it('sends a decision the Gateway accepts — never the bare "allow"', () => {
+    const { adapter, gw, rpcs } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    adapter.handleCommand({ type: 'select_option', index: 0 });
+
+    expect(rpcs).toHaveLength(1);
+    expect(rpcs[0].method).toBe('exec.approval.resolve');
+    expect(rpcs[0].params).toEqual({ id: REQUESTED.id, decision: 'allow-once' });
+    // The exact string that made every press a no-op.
+    expect(rpcs[0].params.decision).not.toBe('allow');
+  });
+
+  it('maps each option index to its own decision', () => {
+    for (const [index, decision] of [[0, 'allow-once'], [1, 'allow-always'], [2, 'deny']] as const) {
+      const { adapter, gw, rpcs } = harness();
+      gw('exec.approval.requested', REQUESTED);
+      adapter.handleCommand({ type: 'select_option', index });
+      expect(rpcs[0].params.decision).toBe(decision);
+    }
+  });
+
+  it('resolves a shortcut `respond` press too', () => {
+    const { adapter, gw, rpcs } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    adapter.handleCommand({ type: 'respond', value: 'a' });
+    expect(rpcs[0].params.decision).toBe('allow-always');
+  });
+
+  it('drops a press whose question echo names a different approval', () => {
+    const { adapter, gw, rpcs } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    adapter.handleCommand({ type: 'select_option', index: 0, question: 'rm -rf /' });
+    expect(rpcs).toHaveLength(0);
+  });
+
+  it('accepts a truncated echo — small surfaces cut the question', () => {
+    const { adapter, gw, rpcs } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    adapter.handleCommand({ type: 'select_option', index: 0, question: 'rg --files-with' });
+    expect(rpcs).toHaveLength(1);
+  });
+
+  it('keeps the prompt on screen when the resolve fails', async () => {
+    // Clearing optimistically (as the old code did) left the user with no
+    // prompt AND an approval still blocking the agent.
+    const { adapter, gw, parser } = harness(Promise.reject(new Error('boom')));
+    gw('exec.approval.requested', REQUESTED);
+    adapter.handleCommand({ type: 'select_option', index: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(adapter.getPendingApproval()?.id).toBe(REQUESTED.id);
+    expect(parser.filter((e) => e.event === 'permission_prompt')).toHaveLength(2);
+  });
+});
+
+describe('the prompt goes away when the approval does', () => {
+  it('labels a real allow as approved (not denied)', () => {
+    const { rows, parser, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    gw('exec.approval.resolved', { id: REQUESTED.id, decision: 'allow-once' });
+
+    const resolved = rows.find((r) => r.type === 'tool_resolved')!;
+    expect(resolved.status).toBe('approved');
+    expect(resolved.raw).toBe('Approved');
+    expect(parser.at(-1)?.event).toBe('spinner_start');
+  });
+
+  it('a deny ends the turn rather than resuming it', () => {
+    const { parser, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    gw('exec.approval.resolved', { id: REQUESTED.id, decision: 'deny' });
+    expect(parser.at(-1)?.event).toBe('idle');
+  });
+
+  it('closes the approval when the run is cancelled under it', () => {
+    // The stuck state, exactly: approval requested at 13:18, run cancelled at
+    // 13:24, no `resolved` event ever — deck pinned on PERMIT?.
+    const { adapter, rows, parser, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    gw('chat', { state: 'aborted', runId: 'r1', sessionKey: 's1' });
+
+    expect(adapter.getPendingApproval()).toBeNull();
+    const resolved = rows.find((r) => r.type === 'tool_resolved')!;
+    expect(resolved.approvalId).toBe(REQUESTED.id);
+    expect(resolved.status).toBe('denied');
+    expect(resolved.raw).toContain('run cancelled');
+    expect(parser.at(-1)?.event).toBe('idle');
+  });
+
+  it('closes the approval when the turn errors out', () => {
+    const { adapter, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    gw('chat', { state: 'error', runId: 'r1', errorMessage: 'overloaded' });
+    expect(adapter.getPendingApproval()).toBeNull();
+  });
+
+  it('adopts an approval that was already waiting when the adapter connected', async () => {
+    // `exec.approval.requested` is a broadcast and is never replayed, so a
+    // daemon restart under an outstanding approval used to leave the agent
+    // blocked with an idle deck and no way to find out.
+    const { adapter, rows, parser, rpcs } = harness();
+    (adapter as unknown as { rpcCall(m: string, p: unknown): Promise<unknown> }).rpcCall =
+      (method, params) => {
+        rpcs.push({ method, params: params as Record<string, unknown> });
+        return Promise.resolve(method === 'exec.approval.list' ? [REQUESTED] : { ok: true });
+      };
+    await (adapter as unknown as { adoptPendingApprovals(): Promise<void> }).adoptPendingApprovals();
+
+    expect(adapter.getPendingApproval()?.id).toBe(REQUESTED.id);
+    expect(rows.find((r) => r.type === 'tool_request')?.status).toBe('pending');
+    expect(parser.some((e) => e.event === 'permission_prompt')).toBe(true);
+  });
+
+  it('adopts the OLDEST waiting approval — that is the one blocking the agent', async () => {
+    const { adapter, rpcs } = harness();
+    const older = { ...REQUESTED, id: 'older', createdAtMs: 1 };
+    const newer = { ...REQUESTED, id: 'newer', createdAtMs: 2 };
+    (adapter as unknown as { rpcCall(m: string, p: unknown): Promise<unknown> }).rpcCall =
+      (method, params) => {
+        rpcs.push({ method, params: params as Record<string, unknown> });
+        return Promise.resolve(method === 'exec.approval.list' ? [newer, older] : { ok: true });
+      };
+    await (adapter as unknown as { adoptPendingApprovals(): Promise<void> }).adoptPendingApprovals();
+    expect(adapter.getPendingApproval()?.id).toBe('older');
+  });
+
+  it('a resolution for a different approval does not clear the pending one', () => {
+    const { adapter, gw } = harness();
+    gw('exec.approval.requested', REQUESTED);
+    gw('exec.approval.resolved', { id: 'some-other-id', decision: 'deny' });
+    expect(adapter.getPendingApproval()?.id).toBe(REQUESTED.id);
+  });
+});

--- a/bridge/src/__tests__/openclaw-session.test.ts
+++ b/bridge/src/__tests__/openclaw-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parseExecApprovalRequest } from '@agentdeck/shared';
 import { injectOpenClawSession } from '../openclaw-session.js';
 import type { EnrichedSession } from '../session-aggregator.js';
 
@@ -44,6 +45,37 @@ describe('injectOpenClawSession', () => {
     expect(oc.projectName).toBe('my-repo');
     expect(oc.modelName).toBe('opus-4');
     expect(oc.controlMode).toBe('managed');
+  });
+
+  it('carries the pending approval so decks render real, pressable options', () => {
+    // Without these fields every deck falls through to its
+    // "PERMIT? / answer in terminal" tile — and the Gateway session has no
+    // terminal, so that tile is a dead end rather than a hint.
+    const approval = parseExecApprovalRequest({
+      id: 'ap-1',
+      request: { command: 'rm -rf build', allowedDecisions: ['allow-once', 'deny'] },
+    }, 0)!;
+    const out = injectOpenClawSession([claude], {
+      gatewayConnected: true, state: 'awaiting_permission', controlMode: 'managed', approval,
+    });
+    const oc = out.find(s => s.agentType === 'openclaw')!;
+    expect(oc.question).toBe('rm -rf build');
+    expect(oc.options?.map(o => o.label)).toEqual(['Allow once', 'Deny']);
+    expect(oc.promptType).toBe('yes_no_always');
+    expect(oc.liveAnswerable).toBe(true);
+    // `requestId` would make surfaces draw a binary Allow/Deny gate over the
+    // real option list.
+    expect(oc.requestId).toBeUndefined();
+  });
+
+  it('leaves the prompt fields off when nothing is pending', () => {
+    const out = injectOpenClawSession([claude], {
+      gatewayConnected: true, state: 'processing', controlMode: 'managed', approval: null,
+    });
+    const oc = out.find(s => s.agentType === 'openclaw')!;
+    expect(oc.question).toBeUndefined();
+    expect(oc.options).toBeUndefined();
+    expect(oc.liveAnswerable).toBeUndefined();
   });
 
   it('is idempotent — does not duplicate an already-present openclaw session', () => {

--- a/bridge/src/adapters/openclaw.ts
+++ b/bridge/src/adapters/openclaw.ts
@@ -30,6 +30,14 @@ import type {
   DeviceAuthToken,
 } from '../types.js';
 import type { AdapterContext, ChatEventPayload } from '@agentdeck/shared';
+import {
+  parseExecApprovalRequest,
+  decisionForOptionIndex,
+  decisionForRespondValue,
+  execApprovalAllows,
+  type OpenClawApprovalPrompt,
+  type ExecApprovalDecision,
+} from '@agentdeck/shared';
 import { OPENCLAW_CAPABILITIES, OPENCLAW_GATEWAY_PORT } from '../types.js';
 import { fetchModelCatalog, getDefaultModelName, invalidateModelCache } from '../model-catalog.js';
 import { getApme } from '../apme/index.js';
@@ -125,7 +133,14 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
   // Session tracking
   private currentSessionKey: string | null = null;
   private currentRunId: string | null = null;
-  private pendingApprovalId: string | null = null;
+  /** The approval the Gateway is currently blocked on, normalized for display
+   *  AND for answering — the options carry their own decision so an index press
+   *  is never re-derived at the answer site. `null` ⇒ nothing to approve. */
+  private pendingApproval: OpenClawApprovalPrompt | null = null;
+  /** Fires at `expiresAtMs`. The Gateway drops an expired approval without
+   *  emitting `exec.approval.resolved`, so without this the deck would keep
+   *  offering buttons that resolve to "unknown or expired approval id". */
+  private approvalExpiryTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Chat tracking for timeline events
   private chatStarted = false;
@@ -305,35 +320,194 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
     this.connectGateway();
   }
 
+  // ===== Pending exec approval =====
+
+  /**
+   * The approval the Gateway is blocked on, or `null`. Read by the daemon so
+   * the virtual `openclaw-gateway` session row can carry the real question and
+   * option list — without it every deck falls back to "PERMIT? / answer in
+   * terminal", which is not answerable anywhere.
+   */
+  getPendingApproval(): OpenClawApprovalPrompt | null {
+    return this.pendingApproval;
+  }
+
+  /**
+   * Read the approvals the Gateway is already blocked on and surface the oldest
+   * one. Called once per handshake.
+   *
+   * Only one is adopted: the deck renders a single question at a time, and the
+   * Gateway blocks the agent on each in turn, so the oldest is the one actually
+   * holding work up. The rest arrive as `requested` events (or on the next
+   * catch-up) once it is answered.
+   */
+  private async adoptPendingApprovals(): Promise<void> {
+    const pending = await this.rpcCall('exec.approval.list', {});
+    if (!Array.isArray(pending) || pending.length === 0) return;
+    const oldest = [...pending].sort(
+      (a, b) => (a?.createdAtMs ?? 0) - (b?.createdAtMs ?? 0),
+    )[0];
+    const prompt = parseExecApprovalRequest(oldest, Date.now());
+    if (!prompt) return;
+    // Already tracking it (a reconnect that raced the event) — don't re-emit.
+    if (this.pendingApproval?.id === prompt.id) return;
+    debug('adapter:openclaw', `adopted pending approval ${prompt.id} on connect`);
+    this.setPendingApproval(prompt);
+    this.emitTimelineEntry({
+      ts: Date.now(), type: 'tool_request',
+      raw: prompt.question.length > 500 ? prompt.question.slice(0, 497) + '...' : prompt.question,
+      ...(prompt.detail ? { detail: prompt.detail } : {}),
+      approvalId: prompt.id, status: 'pending',
+    });
+    this.rebroadcastPendingApproval();
+  }
+
+  private setPendingApproval(prompt: OpenClawApprovalPrompt): void {
+    this.clearPendingApproval();
+    this.pendingApproval = prompt;
+    if (typeof prompt.expiresAtMs === 'number') {
+      const delay = prompt.expiresAtMs - Date.now();
+      // An already-expired stamp still needs the sweep to run (on the next
+      // tick, not inline) so the row and the state settle the same way.
+      this.approvalExpiryTimer = setTimeout(
+        () => this.abandonPendingApproval(prompt.id, 'Expired'),
+        Math.max(0, delay),
+      );
+      this.approvalExpiryTimer.unref?.();
+    }
+  }
+
+  private clearPendingApproval(): void {
+    if (this.approvalExpiryTimer) {
+      clearTimeout(this.approvalExpiryTimer);
+      this.approvalExpiryTimer = null;
+    }
+    this.pendingApproval = null;
+  }
+
+  /**
+   * The approval went away without a decision — it expired, its run was
+   * cancelled, or the Gateway link dropped. The Gateway emits no
+   * `exec.approval.resolved` for any of those, so nothing else would ever close
+   * the `tool_request` row or move the session off `awaiting_permission`: the
+   * deck kept showing PERMIT? for a request that no longer existed.
+   */
+  private abandonPendingApproval(approvalId: string, reason: string): void {
+    if (!this.pendingApproval || this.pendingApproval.id !== approvalId) return;
+    this.clearPendingApproval();
+    this.emitTimelineEntry({
+      ts: Date.now(), type: 'tool_resolved', raw: `Not approved · ${reason}`,
+      approvalId, status: 'denied',
+    });
+    this.emitAdapterEvent({ source: 'parser', event: 'idle' });
+  }
+
+  /** Called from the turn-end paths (`final` / `aborted` / `error`). */
+  private abandonPendingApprovalForTurnEnd(reason: string): void {
+    const pending = this.pendingApproval;
+    if (pending) this.abandonPendingApproval(pending.id, reason);
+  }
+
+  /**
+   * Send the decision the Gateway actually accepts. The pending pointer is held
+   * until the RPC succeeds: clearing it optimistically (as this used to) meant a
+   * rejected call left the user with no prompt on screen AND an approval still
+   * blocking the agent, with the failure swallowed into a debug line that is off
+   * by default.
+   */
+  private resolveApproval(prompt: OpenClawApprovalPrompt, decision: ExecApprovalDecision): void {
+    debug('adapter:openclaw', `exec.approval.resolve ${prompt.id} → ${decision}`);
+    this.rpcCall('exec.approval.resolve', { id: prompt.id, decision })
+      .then(() => {
+        // The `exec.approval.resolved` event is the authoritative close (it also
+        // arrives when another operator answers). Clear here too so a dropped
+        // event cannot strand the prompt.
+        if (this.pendingApproval?.id === prompt.id) this.clearPendingApproval();
+      })
+      .catch((err) => {
+        logError(`[adapter:openclaw] exec.approval.resolve failed (${decision}): ${String(err)}`);
+        this.emitTimelineEntry({
+          ts: Date.now(), type: 'error',
+          raw: `Approval failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        // Put the prompt back on every surface so the user can retry rather
+        // than staring at a deck that silently did nothing.
+        this.rebroadcastPendingApproval();
+      });
+  }
+
+  /** Re-emit the pending prompt so devices re-sync after a dropped press. */
+  private rebroadcastPendingApproval(): void {
+    const prompt = this.pendingApproval;
+    if (!prompt) return;
+    this.emitAdapterEvent({
+      source: 'parser',
+      event: 'permission_prompt',
+      data: {
+        question: prompt.question,
+        options: prompt.options.map((o) => ({
+          index: o.index, label: o.label, shortcut: o.shortcut,
+        })),
+        navigable: false,
+        cursorIndex: 0,
+      },
+    });
+  }
+
+  /**
+   * Truncation-tolerant echo check. Devices cap the question they display
+   * (ESP32 buffers, 16-char key labels), so an exact compare would refuse every
+   * legitimate press from a small surface. Compare on UTF-16 units to match the
+   * TS producers; the Swift mirror compares `.utf16` for the same reason.
+   */
+  private approvalEchoMatches(prompt: OpenClawApprovalPrompt, echo: string): boolean {
+    const a = prompt.question.trim();
+    const b = echo.trim();
+    if (!b) return true;
+    return a.startsWith(b) || b.startsWith(a);
+  }
+
   handleCommand(cmd: PluginCommand): boolean {
     switch (cmd.type) {
       case 'respond': {
         debug('adapter:openclaw', `respond: "${cmd.value}"`);
-        if (this.pendingApprovalId) {
-          const decision = cmd.value === 'y' ? 'allow' : 'deny';
-          this.rpcCall('exec.approval.resolve', {
-            id: this.pendingApprovalId,
-            decision,
-          }).catch((err) => {
-            debug('adapter:openclaw', `exec.approval.resolve failed: ${err}`);
-          });
-          this.pendingApprovalId = null;
+        const prompt = this.pendingApproval;
+        if (prompt) {
+          const decision = decisionForRespondValue(prompt, cmd.value);
+          if (!decision) {
+            logError(
+              `[adapter:openclaw] respond "${cmd.value}" does not name a decision this approval allows` +
+                ` (${prompt.options.map((o) => o.decision).join('/')}) — ignored`,
+            );
+            return true;
+          }
+          this.resolveApproval(prompt, decision);
         }
         return true;
       }
 
       case 'select_option': {
         debug('adapter:openclaw', `select_option: idx=${cmd.index}`);
-        // Permission prompts: index 0 = Allow, index 1 = Deny
-        if (this.pendingApprovalId) {
-          const decision = cmd.index === 0 ? 'allow' : 'deny';
-          this.rpcCall('exec.approval.resolve', {
-            id: this.pendingApprovalId,
-            decision,
-          }).catch((err) => {
-            debug('adapter:openclaw', `exec.approval.resolve failed: ${err}`);
-          });
-          this.pendingApprovalId = null;
+        const prompt = this.pendingApproval;
+        if (prompt) {
+          // The index names an option in the list the device was DISPLAYING.
+          // `question` echoes that list's headline; a press aimed at an
+          // approval the Gateway has already moved past must be dropped rather
+          // than applied to the new one — approving the wrong command is the
+          // single worst outcome this path can produce.
+          if (cmd.question && !this.approvalEchoMatches(prompt, cmd.question)) {
+            logError(
+              '[adapter:openclaw] select_option dropped: question echo does not match the pending approval',
+            );
+            this.rebroadcastPendingApproval();
+            return true;
+          }
+          const decision = decisionForOptionIndex(prompt, cmd.index);
+          if (!decision) {
+            logError(`[adapter:openclaw] select_option index ${cmd.index} out of range — ignored`);
+            return true;
+          }
+          this.resolveApproval(prompt, decision);
         }
         return true;
       }
@@ -645,6 +819,10 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
       debug('adapter:openclaw', 'Gateway disconnected');
       const wasAlive = this.alive;
       this.alive = false;
+      // Pending approvals are Gateway-process state: a reconnect issues new
+      // ids, so holding the old one would offer buttons that resolve to
+      // "unknown or expired approval id".
+      this.abandonPendingApprovalForTurnEnd('gateway disconnected');
 
       if (wasAlive) {
         this.emitAdapterEvent({ source: 'connection', status: 'disconnected' });
@@ -981,6 +1159,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
             this.lastPrompt = null;
             this.accumulatedResponse = '';
             this.currentRunId = null;
+            this.abandonPendingApprovalForTurnEnd('turn ended');
             this.emitAdapterEvent({ source: 'parser', event: 'idle' });
             break;
           }
@@ -1013,6 +1192,10 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
             this.lastPrompt = null;
             this.accumulatedResponse = '';
             this.currentRunId = null;
+            // A run cancelled while an approval was outstanding is the shape
+            // that stranded the deck on PERMIT?: the Gateway drops the approval
+            // silently, so this is the only place that can close it.
+            this.abandonPendingApprovalForTurnEnd('run cancelled');
             this.emitAdapterEvent({ source: 'parser', event: 'idle' });
             break;
           }
@@ -1069,6 +1252,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
             this.accumulatedResponse = '';
             this.currentRunId = null;
             debug('adapter:openclaw', `Chat error: ${errLabel}`);
+            this.abandonPendingApprovalForTurnEnd('turn failed');
             this.emitAdapterEvent({ source: 'parser', event: 'idle' });
             break;
           }
@@ -1078,37 +1262,44 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
 
       // ===== Tool approval =====
       case 'exec.approval.requested': {
-        const approvalId = payload.id as string;
-        const command = payload.command as string;
-        const ask = payload.ask as string | undefined;
-
-        this.pendingApprovalId = approvalId;
+        // The Gateway nests everything under `request` and describes the
+        // permitted decisions per-request. Both facts are handled in the shared
+        // parser — reading this payload flat here is what left every approval
+        // rendered as a bare "Approve tool execution?" with no command on it.
+        const prompt = parseExecApprovalRequest(payload, Date.now());
+        if (!prompt) {
+          logError('[adapter:openclaw] exec.approval.requested without a usable id — ignored');
+          break;
+        }
+        this.setPendingApproval(prompt);
 
         // Track tool for chat summary
-        const toolName = command?.split(' ')[0] || 'tool';
+        const toolName = prompt.command.split(/\s+/)[0] || 'tool';
         this.chatToolCount++;
         if (!this.chatToolNames.includes(toolName)) {
           this.chatToolNames.push(toolName);
         }
 
-        const toolRaw = ask ? `${command}: ${ask}` : (command || 'Approve tool execution?');
-        const toolRequestRaw = toolRaw.length > 500 ? toolRaw.slice(0, 497) + '...' : toolRaw;
-        const toolRequestDetail = ask && ask.length > 100 ? (ask.length > 1000 ? ask.slice(0, 997) + '...' : ask) : undefined;
+        const toolRequestRaw = prompt.question.length > 500
+          ? prompt.question.slice(0, 497) + '...'
+          : prompt.question;
+        const toolRequestDetail = prompt.detail && prompt.detail.length > 1000
+          ? prompt.detail.slice(0, 997) + '...'
+          : prompt.detail;
         this.emitTimelineEntry({
           ts: Date.now(), type: 'tool_request', raw: toolRequestRaw,
           ...(toolRequestDetail ? { detail: toolRequestDetail } : {}),
-          approvalId, status: 'pending',
+          approvalId: prompt.id, status: 'pending',
         });
 
         this.emitAdapterEvent({
           source: 'parser',
           event: 'permission_prompt',
           data: {
-            question: ask || command || 'Approve tool execution?',
-            options: [
-              { index: 0, label: 'Allow', shortcut: 'y' },
-              { index: 1, label: 'Deny', shortcut: 'n' },
-            ],
+            question: prompt.question,
+            options: prompt.options.map((o) => ({
+              index: o.index, label: o.label, shortcut: o.shortcut,
+            })),
             navigable: false,
             cursorIndex: 0,
           },
@@ -1117,21 +1308,34 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
       }
 
       case 'exec.approval.resolved': {
-        // Approval resolved (by us or another client) → processing continues
-        const resolvedId = this.pendingApprovalId;
-        const decision = (payload.decision as string) || 'allow';
-        this.pendingApprovalId = null;
+        // Resolved by us or by another operator client. Key off the payload's
+        // own id, not our pending pointer: a resolution can arrive for an
+        // approval we already dropped (expiry, abort), and treating it as
+        // "whatever we last saw" mislabels an unrelated row.
+        const resolvedId = typeof payload.id === 'string' && payload.id
+          ? payload.id
+          : this.pendingApproval?.id;
+        const decision = typeof payload.decision === 'string' ? payload.decision : '';
+        const allowed = execApprovalAllows(decision);
+        if (this.pendingApproval && resolvedId === this.pendingApproval.id) {
+          this.clearPendingApproval();
+        }
 
         if (resolvedId) {
           this.emitTimelineEntry({
             ts: Date.now(), type: 'tool_resolved',
-            raw: decision === 'allow' ? 'Approved' : 'Denied',
+            // `decision` is allow-once / allow-always / deny. Comparing it to
+            // 'allow' (as this did) labeled every real approval "Denied".
+            raw: decision === 'allow-always' ? 'Approved (always)'
+              : allowed ? 'Approved' : 'Denied',
             approvalId: resolvedId,
-            status: decision === 'allow' ? 'approved' : 'denied',
+            status: allowed ? 'approved' : 'denied',
           });
         }
 
-        this.emitAdapterEvent({ source: 'parser', event: 'spinner_start' });
+        // Denial does not resume the turn — the tool call fails and the agent
+        // either recovers or ends. Only an allow means work continues.
+        this.emitAdapterEvent({ source: 'parser', event: allowed ? 'spinner_start' : 'idle' });
         break;
       }
 
@@ -1267,6 +1471,14 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
 
         // Fetch model catalog (async, non-blocking)
         this.emitModelCatalog().catch(err => debug('adapter:openclaw', `emitModelCatalog error: ${err}`));
+
+        // Catch up on approvals that were already waiting. `exec.approval.requested`
+        // is a broadcast and is never replayed, so without this read a daemon
+        // restart (or any Gateway reconnect) leaves the agent blocked on an
+        // approval that exists on exactly one side: the user sees an idle deck
+        // and the agent never moves.
+        this.adoptPendingApprovals().catch(err =>
+          debug('adapter:openclaw', `adoptPendingApprovals error: ${err}`));
       },
       reject: (err) => {
         debug('adapter:openclaw', `Handshake failed: ${err.message}`);

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -3672,6 +3672,11 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       projectName: 'OpenClaw',
       modelName: gatewayModelName,
       controlMode: 'managed',
+      // Read live from the adapter rather than cached alongside
+      // `gatewaySessionState`: the two would drift, and a row that says
+      // "awaiting_permission" while carrying no options is exactly the
+      // dead end this fixes.
+      approval: gatewayAdapter?.getPendingApproval() ?? null,
     });
   });
 
@@ -3729,6 +3734,14 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           if (evt.event === 'spinner_start') gatewaySessionState = 'processing';
           else if (evt.event === 'idle') gatewaySessionState = 'idle';
           else if (evt.event === 'permission_prompt') gatewaySessionState = 'awaiting_permission';
+          // The virtual Gateway row carries the approval's question/options, so
+          // a prompt appearing or clearing changes `sessions_list` — not just
+          // the state event. Devices read their option cells from that list; a
+          // state-only broadcast left them showing the previous prompt (or
+          // none) until some unrelated event forced a refresh.
+          if (evt.event === 'spinner_start' || evt.event === 'idle' || evt.event === 'permission_prompt') {
+            core.broadcastSessionsList().catch(() => {});
+          }
           // The OpenClaw adapter emits the real model via a model_info parser
           // event, but it only ever updated the display StateMachine — the APME
           // run was never told, so every openclaw run persisted model_id=NULL.
@@ -3779,6 +3792,17 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             if (evt.upsert) core.bridgeTimeline.upsertEntry(enriched);
             else core.bridgeTimeline.addEntry(enriched);
             if (enriched.type === 'tool_request') bridgeLogStream.trackToolRequest(enriched.raw);
+            // Flip the matching `tool_request` row off `pending`. The resolution
+            // has always been emitted as its own row, so the request row kept
+            // `status: 'pending'` forever — an approval answered minutes ago
+            // still read as outstanding in the timeline. `updateEntryStatus`
+            // existed for exactly this and had no production caller.
+            if (enriched.type === 'tool_resolved' && enriched.approvalId) {
+              core.bridgeTimeline.updateEntryStatus(
+                enriched.approvalId,
+                enriched.status === 'approved' ? 'approved' : 'denied',
+              );
+            }
           }
           break;
         case 'connection': {

--- a/bridge/src/openclaw-session.ts
+++ b/bridge/src/openclaw-session.ts
@@ -5,6 +5,7 @@
  * drift. Mirror of Swift `buildSessionsListEvent`.
  */
 import { isOpenClawSessionActive, hasOpenClawSession } from '@agentdeck/shared';
+import type { OpenClawApprovalPrompt } from '@agentdeck/shared';
 import type { EnrichedSession } from './session-aggregator.js';
 
 /**
@@ -22,6 +23,15 @@ export interface InjectOpenClawOptions {
   projectName?: string;
   modelName?: string;
   controlMode?: 'managed';
+  /**
+   * The exec approval the Gateway is blocked on, when there is one. Every deck
+   * surface already renders `question`/`options` off the session row and only
+   * falls back to the dead-end "PERMIT? / answer in terminal" tile when they are
+   * absent — which they always were, because this row never carried them. The
+   * Gateway session has no terminal to answer in, so that fallback left the user
+   * with no route at all.
+   */
+  approval?: OpenClawApprovalPrompt | null;
 }
 
 /**
@@ -46,5 +56,17 @@ export function injectOpenClawSession(
   if (opts.state !== undefined) injected.state = opts.state;
   if (opts.modelName !== undefined) injected.modelName = opts.modelName;
   if (opts.controlMode !== undefined) injected.controlMode = opts.controlMode;
+  if (opts.approval) {
+    injected.question = opts.approval.question;
+    injected.options = opts.approval.options.map((o) => ({
+      index: o.index, label: o.label, shortcut: o.shortcut,
+    }));
+    injected.promptType = 'yes_no_always';
+    // The daemon can deliver this answer over the Gateway RPC, so the option
+    // cells are live rather than display-only. `requestId` stays absent: it
+    // makes surfaces render a binary Allow/Deny gate over a list that may carry
+    // three real choices.
+    injected.liveAnswerable = true;
+  }
   return [...sessions, injected];
 }

--- a/bridge/src/session-aggregator.ts
+++ b/bridge/src/session-aggregator.ts
@@ -29,6 +29,10 @@ export interface EnrichedSession {
   requestId?: string;
   promptType?: 'yes_no' | 'yes_no_always' | 'multi_select' | 'diff_review';
   options?: PromptOption[];
+  /** A device press on `options` reaches this session's real answer path
+   *  (observed steering, or the OpenClaw Gateway's approval RPC). Without it the
+   *  option cells render display-only. Mirrors `SessionInfo.liveAnswerable`. */
+  liveAnswerable?: boolean;
   /** Seconds since startedAt — derived at broadcast time so NTP-less devices (ESP32) render elapsed per session. */
   elapsedSec?: number;
   /** Daemon-synthesized "what is this agent doing right now" one-liner (heuristic,

--- a/generated/protocol/GatewayFrame.kt
+++ b/generated/protocol/GatewayFrame.kt
@@ -15,15 +15,15 @@ private fun <T> Klaxon.convert(k: kotlin.reflect.KClass<*>, fromJson: (JsonValue
     })
 
 private val klaxon = Klaxon()
-    .convert(GatewayEventName::class,            { GatewayEventName.fromValue(it.string!!) },            { "\"${it.value}\"" })
-    .convert(GatewayMethodName::class,           { GatewayMethodName.fromValue(it.string!!) },           { "\"${it.value}\"" })
-    .convert(Mode::class,                        { Mode.fromValue(it.string!!) },                        { "\"${it.value}\"" })
-    .convert(GatewayMethodParamsDecision::class, { GatewayMethodParamsDecision.fromValue(it.string!!) }, { "\"${it.value}\"" })
-    .convert(PayloadDecision::class,             { PayloadDecision.fromValue(it.string!!) },             { "\"${it.value}\"" })
-    .convert(State::class,                       { State.fromValue(it.string!!) },                       { "\"${it.value}\"" })
-    .convert(Status::class,                      { Status.fromValue(it.string!!) },                      { "\"${it.value}\"" })
-    .convert(PayloadType::class,                 { PayloadType.fromValue(it.string!!) },                 { "\"${it.value}\"" })
-    .convert(GatewayFrameType::class,            { GatewayFrameType.fromValue(it.string!!) },            { "\"${it.value}\"" })
+    .convert(GatewayEventName::class,     { GatewayEventName.fromValue(it.string!!) },     { "\"${it.value}\"" })
+    .convert(GatewayMethodName::class,    { GatewayMethodName.fromValue(it.string!!) },    { "\"${it.value}\"" })
+    .convert(Mode::class,                 { Mode.fromValue(it.string!!) },                 { "\"${it.value}\"" })
+    .convert(ExecApprovalDecision::class, { ExecApprovalDecision.fromValue(it.string!!) }, { "\"${it.value}\"" })
+    .convert(State::class,                { State.fromValue(it.string!!) },                { "\"${it.value}\"" })
+    .convert(Status::class,               { Status.fromValue(it.string!!) },               { "\"${it.value}\"" })
+    .convert(ConnectResultType::class,    { ConnectResultType.fromValue(it.string!!) },    { "\"${it.value}\"" })
+    .convert(GatewayFrameType::class,     { GatewayFrameType.fromValue(it.string!!) },     { "\"${it.value}\"" })
+    .convert(GatewayMethodResult::class,  { GatewayMethodResult.fromJson(it) },            { it.toJson() }, true)
 
 /**
  * Client → Gateway: RPC request.
@@ -39,7 +39,7 @@ data class GatewayFrame (
     val type: GatewayFrameType,
     val error: GatewayError? = null,
     val ok: Boolean? = null,
-    val payload: Gateway? = null,
+    val payload: GatewayMethodResult? = null,
     val event: GatewayEventName? = null,
 
     /**
@@ -102,6 +102,7 @@ enum class GatewayMethodName(val value: String) {
     ChatAbort("chat.abort"),
     ChatSend("chat.send"),
     Connect("connect"),
+    ExecApprovalList("exec.approval.list"),
     ExecApprovalResolve("exec.approval.resolve"),
     Health("health"),
     LogsTail("logs.tail"),
@@ -116,6 +117,7 @@ enum class GatewayMethodName(val value: String) {
             "chat.abort"                  -> ChatAbort
             "chat.send"                   -> ChatSend
             "connect"                     -> Connect
+            "exec.approval.list"          -> ExecApprovalList
             "exec.approval.resolve"       -> ExecApprovalResolve
             "health"                      -> Health
             "logs.tail"                   -> LogsTail
@@ -172,7 +174,7 @@ data class GatewayMethodParams (
     @Json(name = "runId")
     val runID: String? = null,
 
-    val decision: GatewayMethodParamsDecision? = null,
+    val decision: ExecApprovalDecision? = null,
     val id: String? = null,
     val kind: String? = null,
     val key: String? = null
@@ -218,15 +220,22 @@ enum class Mode(val value: String) {
     }
 }
 
-enum class GatewayMethodParamsDecision(val value: String) {
-    Allow("allow"),
+/**
+ * The decisions the Gateway will accept for an exec approval. Mirror of OpenClaw's
+ * `isApprovalDecision` / `DEFAULT_EXEC_APPROVAL_DECISIONS`. `'allow'` is NOT a member —
+ * sending it is rejected as an invalid decision.
+ */
+enum class ExecApprovalDecision(val value: String) {
+    AllowAlways("allow-always"),
+    AllowOnce("allow-once"),
     Deny("deny");
 
     companion object {
-        public fun fromValue(value: String): GatewayMethodParamsDecision = when (value) {
-            "allow" -> Allow
-            "deny"  -> Deny
-            else    -> throw IllegalArgumentException()
+        public fun fromValue(value: String): ExecApprovalDecision = when (value) {
+            "allow-always" -> AllowAlways
+            "allow-once"   -> AllowOnce
+            "deny"         -> Deny
+            else           -> throw IllegalArgumentException()
         }
     }
 }
@@ -243,16 +252,152 @@ data class DeviceAuth (
     val signedAt: Double
 )
 
-data class Gateway (
+sealed class GatewayMethodResult {
+    class ConnectResultValue(val value: ConnectResult)                                          : GatewayMethodResult()
+    class ExecApprovalRequestedPayloadArrayValue(val value: List<ExecApprovalRequestedPayload>) : GatewayMethodResult()
+
+    public fun toJson(): String = klaxon.toJsonString(when (this) {
+        is ConnectResultValue                     -> this.value
+        is ExecApprovalRequestedPayloadArrayValue -> this.value
+    })
+
+    companion object {
+        public fun fromJson(jv: JsonValue): GatewayMethodResult = when (jv.inside) {
+            is JsonObject   -> ConnectResultValue(jv.obj?.let { klaxon.parseFromJsonObject<ConnectResult>(it) }!!)
+            is JsonArray<*> -> ExecApprovalRequestedPayloadArrayValue(jv.array?.let { klaxon.parseFromJsonArray<ExecApprovalRequestedPayload>(it) }!!)
+            else            -> throw IllegalArgumentException()
+        }
+    }
+}
+
+/**
+ * Same element shape as the requested event, minus the envelope.
+ *
+ * `exec.approval.requested` payload. The nested `request` is the real shape; the flat
+ * fields are tolerated so a future/legacy Gateway that inlines them still parses instead of
+ * silently producing an empty prompt.
+ */
+data class ExecApprovalRequestedPayload (
+    @Json(name = "agentId")
+    val agentID: String? = null,
+
+    /**
+     * Decisions this specific request permits (policy may drop allow-always).
+     */
+    val allowedDecisions: List<String>? = null,
+
+    /**
+     * Approval POLICY ("on-miss" | "always" | …), never a question.
+     */
+    val ask: String? = null,
+
+    /**
+     * Sanitized command display text — the thing the user is approving.
+     */
+    val command: String? = null,
+
+    /**
+     * Gateway-side static analysis summary of the command.
+     */
+    val commandAnalysis: String? = null,
+
+    val commandArgv: List<String>? = null,
+
+    /**
+     * Non-node hosts send a preview instead of the full command.
+     */
+    val commandPreview: String? = null,
+
+    @Json(name = "createdAtMs")
+    val createdAtMS: Double? = null,
+
+    val cwd: String? = null,
+
+    @Json(name = "expiresAtMs")
+    val expiresAtMS: Double? = null,
+
+    val host: String? = null,
+    val id: String,
+    val request: ExecApprovalRequestBody? = null,
+    val resolvedPath: String? = null,
+    val security: String? = null,
+    val sessionKey: String? = null,
+    val unavailableDecisions: List<String>? = null,
+
+    /**
+     * Human-readable risk note, when the Gateway produced one.
+     */
+    val warningText: String? = null
+)
+
+/**
+ * The `request` body OpenClaw nests inside the requested event.
+ */
+data class ExecApprovalRequestBody (
+    @Json(name = "agentId")
+    val agentID: String? = null,
+
+    /**
+     * Decisions this specific request permits (policy may drop allow-always).
+     */
+    val allowedDecisions: List<String>? = null,
+
+    /**
+     * Approval POLICY ("on-miss" | "always" | …), never a question.
+     */
+    val ask: String? = null,
+
+    /**
+     * Sanitized command display text — the thing the user is approving.
+     */
+    val command: String? = null,
+
+    /**
+     * Gateway-side static analysis summary of the command.
+     */
+    val commandAnalysis: String? = null,
+
+    val commandArgv: List<String>? = null,
+
+    /**
+     * Non-node hosts send a preview instead of the full command.
+     */
+    val commandPreview: String? = null,
+
+    val cwd: String? = null,
+    val host: String? = null,
+    val resolvedPath: String? = null,
+    val security: String? = null,
+    val sessionKey: String? = null,
+    val unavailableDecisions: List<String>? = null,
+
+    /**
+     * Human-readable risk note, when the Gateway produced one.
+     */
+    val warningText: String? = null
+)
+
+/**
+ * The Gateway answers `{ ok: true }`; `resolved` is kept for older builds.
+ *
+ * Same element shape as the requested event, minus the envelope.
+ *
+ * `exec.approval.requested` payload. The nested `request` is the real shape; the flat
+ * fields are tolerated so a future/legacy Gateway that inlines them still parses instead of
+ * silently producing an empty prompt.
+ *
+ * `exec.approval.resolved` payload (`buildResolvedEvent` in exec-approval).
+ */
+data class ConnectResult (
     val accepted: Boolean? = null,
-    val auth: PayloadAuth? = null,
+    val auth: ConnectResultAuth? = null,
     val expiresAt: Double? = null,
     val features: Features? = null,
     val policy: Policy? = null,
     val protocol: Double? = null,
     val server: Server? = null,
     val sessionToken: String? = null,
-    val type: PayloadType? = null,
+    val type: ConnectResultType? = null,
     val checks: List<Check>? = null,
 
     @Json(name = "durationMs")
@@ -337,15 +482,59 @@ data class Gateway (
     val output: Any? = null,
     val tool: String? = null,
     val reason: String? = null,
-    val command: String? = null,
-    val id: String? = null,
+
+    @Json(name = "agentId")
+    val agentID: String? = null,
 
     /**
-     * Options surfaced to the user (default: allow/deny).
+     * Decisions this specific request permits (policy may drop allow-always).
      */
-    val options: List<Option>? = null,
+    val allowedDecisions: List<String>? = null,
 
-    val decision: PayloadDecision? = null,
+    /**
+     * Approval POLICY ("on-miss" | "always" | …), never a question.
+     */
+    val ask: String? = null,
+
+    /**
+     * Sanitized command display text — the thing the user is approving.
+     */
+    val command: String? = null,
+
+    /**
+     * Gateway-side static analysis summary of the command.
+     */
+    val commandAnalysis: String? = null,
+
+    val commandArgv: List<String>? = null,
+
+    /**
+     * Non-node hosts send a preview instead of the full command.
+     */
+    val commandPreview: String? = null,
+
+    @Json(name = "createdAtMs")
+    val createdAtMS: Double? = null,
+
+    val cwd: String? = null,
+
+    @Json(name = "expiresAtMs")
+    val expiresAtMS: Double? = null,
+
+    val host: String? = null,
+    val id: String? = null,
+    val request: ExecApprovalRequestBody? = null,
+    val resolvedPath: String? = null,
+    val security: String? = null,
+    val unavailableDecisions: List<String>? = null,
+
+    /**
+     * Human-readable risk note, when the Gateway produced one.
+     */
+    val warningText: String? = null,
+
+    val decision: String? = null,
+    val resolvedBy: String? = null,
 
     @Json(name = "clientId")
     val clientID: String? = null,
@@ -359,7 +548,7 @@ data class Gateway (
     val restartAt: Double? = null
 )
 
-data class PayloadAuth (
+data class ConnectResultAuth (
     val deviceToken: String,
     val deviceTokens: List<DeviceToken>? = null,
 
@@ -386,21 +575,6 @@ data class Check (
     val name: String? = null,
     val status: String? = null
 )
-
-enum class PayloadDecision(val value: String) {
-    Allow("allow"),
-    Deny("deny"),
-    Timeout("timeout");
-
-    companion object {
-        public fun fromValue(value: String): PayloadDecision = when (value) {
-            "allow"   -> Allow
-            "deny"    -> Deny
-            "timeout" -> Timeout
-            else      -> throw IllegalArgumentException()
-        }
-    }
-}
 
 data class GatewayPresenceEntry (
     @Json(name = "clientId")
@@ -430,11 +604,6 @@ data class OpenClawModel (
     val provider: String? = null,
     val tags: List<String>? = null,
     val title: String? = null
-)
-
-data class Option (
-    val key: String,
-    val label: String
 )
 
 data class Policy (
@@ -502,11 +671,11 @@ enum class Status(val value: String) {
     }
 }
 
-enum class PayloadType(val value: String) {
+enum class ConnectResultType(val value: String) {
     HelloOk("hello-ok");
 
     companion object {
-        public fun fromValue(value: String): PayloadType = when (value) {
+        public fun fromValue(value: String): ConnectResultType = when (value) {
             "hello-ok" -> HelloOk
             else       -> throw IllegalArgumentException()
         }

--- a/generated/protocol/GatewayFrame.swift
+++ b/generated/protocol/GatewayFrame.swift
@@ -18,7 +18,7 @@ struct ADGatewayFrame: Codable {
     var type: ADGatewayFrameType
     var error: ADGatewayError?
     var ok: Bool?
-    var payload: ADGateway?
+    var payload: ADGatewayMethodResult?
     var event: ADGatewayEventName?
     /// Monotonic sequence number (optional, used for ordering on reconnect).
     var seq: String?
@@ -64,7 +64,7 @@ extension ADGatewayFrame {
         type: ADGatewayFrameType? = nil,
         error: ADGatewayError?? = nil,
         ok: Bool?? = nil,
-        payload: ADGateway?? = nil,
+        payload: ADGatewayMethodResult?? = nil,
         event: ADGatewayEventName?? = nil,
         seq: String?? = nil,
         stateVersion: String?? = nil
@@ -163,6 +163,7 @@ enum ADGatewayMethodName: String, Codable {
     case chatAbort = "chat.abort"
     case chatSend = "chat.send"
     case connect = "connect"
+    case execApprovalList = "exec.approval.list"
     case execApprovalResolve = "exec.approval.resolve"
     case health = "health"
     case logsTail = "logs.tail"
@@ -200,7 +201,7 @@ struct ADGatewayMethodParams: Codable {
     var message: String?
     var sessionKey: String?
     var runId: String?
-    var decision: ADGatewayMethodParamsDecision?
+    var decision: ADExecApprovalDecision?
     var id: String?
     var kind: String?
     var key: String?
@@ -272,7 +273,7 @@ extension ADGatewayMethodParams {
         message: String?? = nil,
         sessionKey: String?? = nil,
         runId: String?? = nil,
-        decision: ADGatewayMethodParamsDecision?? = nil,
+        decision: ADExecApprovalDecision?? = nil,
         id: String?? = nil,
         kind: String?? = nil,
         key: String?? = nil
@@ -446,8 +447,12 @@ enum ADMode: String, Codable {
     case node = "node"
 }
 
-enum ADGatewayMethodParamsDecision: String, Codable {
-    case allow = "allow"
+/// The decisions the Gateway will accept for an exec approval. Mirror of OpenClaw's
+/// `isApprovalDecision` / `DEFAULT_EXEC_APPROVAL_DECISIONS`. `'allow'` is NOT a member —
+/// sending it is rejected as an invalid decision.
+enum ADExecApprovalDecision: String, Codable {
+    case allowAlways = "allow-always"
+    case allowOnce = "allow-once"
     case deny = "deny"
 }
 
@@ -513,17 +518,280 @@ extension ADDeviceAuth {
     }
 }
 
-// MARK: - ADGateway
-struct ADGateway: Codable {
+enum ADGatewayMethodResult: Codable {
+    case adConnectResult(ADConnectResult)
+    case adExecApprovalRequestedPayloadArray([ADExecApprovalRequestedPayload])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let x = try? container.decode([ADExecApprovalRequestedPayload].self) {
+            self = .adExecApprovalRequestedPayloadArray(x)
+            return
+        }
+        if let x = try? container.decode(ADConnectResult.self) {
+            self = .adConnectResult(x)
+            return
+        }
+        throw DecodingError.typeMismatch(ADGatewayMethodResult.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for ADGatewayMethodResult"))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .adConnectResult(let x):
+            try container.encode(x)
+        case .adExecApprovalRequestedPayloadArray(let x):
+            try container.encode(x)
+        }
+    }
+}
+
+/// Same element shape as the requested event, minus the envelope.
+///
+/// `exec.approval.requested` payload. The nested `request` is the real shape; the flat
+/// fields are tolerated so a future/legacy Gateway that inlines them still parses instead of
+/// silently producing an empty prompt.
+// MARK: - ADExecApprovalRequestedPayload
+struct ADExecApprovalRequestedPayload: Codable {
+    var agentId: String?
+    /// Decisions this specific request permits (policy may drop allow-always).
+    var allowedDecisions: [String]?
+    /// Approval POLICY ("on-miss" | "always" | …), never a question.
+    var ask: String?
+    /// Sanitized command display text — the thing the user is approving.
+    var command: String?
+    /// Gateway-side static analysis summary of the command.
+    var commandAnalysis: String?
+    var commandArgv: [String]?
+    /// Non-node hosts send a preview instead of the full command.
+    var commandPreview: String?
+    var createdAtMs: Double?
+    var cwd: String?
+    var expiresAtMs: Double?
+    var host: String?
+    var id: String
+    var request: ADExecApprovalRequestBody?
+    var resolvedPath: String?
+    var security: String?
+    var sessionKey: String?
+    var unavailableDecisions: [String]?
+    /// Human-readable risk note, when the Gateway produced one.
+    var warningText: String?
+
+    enum CodingKeys: String, CodingKey {
+        case agentId = "agentId"
+        case allowedDecisions = "allowedDecisions"
+        case ask = "ask"
+        case command = "command"
+        case commandAnalysis = "commandAnalysis"
+        case commandArgv = "commandArgv"
+        case commandPreview = "commandPreview"
+        case createdAtMs = "createdAtMs"
+        case cwd = "cwd"
+        case expiresAtMs = "expiresAtMs"
+        case host = "host"
+        case id = "id"
+        case request = "request"
+        case resolvedPath = "resolvedPath"
+        case security = "security"
+        case sessionKey = "sessionKey"
+        case unavailableDecisions = "unavailableDecisions"
+        case warningText = "warningText"
+    }
+}
+
+// MARK: ADExecApprovalRequestedPayload convenience initializers and mutators
+
+extension ADExecApprovalRequestedPayload {
+    init(data: Data) throws {
+        self = try newJSONDecoder().decode(ADExecApprovalRequestedPayload.self, from: data)
+    }
+
+    init(_ json: String, using encoding: String.Encoding = .utf8) throws {
+        guard let data = json.data(using: encoding) else {
+            throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+        }
+        try self.init(data: data)
+    }
+
+    init(fromURL url: URL) throws {
+        try self.init(data: try Data(contentsOf: url))
+    }
+
+    func with(
+        agentId: String?? = nil,
+        allowedDecisions: [String]?? = nil,
+        ask: String?? = nil,
+        command: String?? = nil,
+        commandAnalysis: String?? = nil,
+        commandArgv: [String]?? = nil,
+        commandPreview: String?? = nil,
+        createdAtMs: Double?? = nil,
+        cwd: String?? = nil,
+        expiresAtMs: Double?? = nil,
+        host: String?? = nil,
+        id: String? = nil,
+        request: ADExecApprovalRequestBody?? = nil,
+        resolvedPath: String?? = nil,
+        security: String?? = nil,
+        sessionKey: String?? = nil,
+        unavailableDecisions: [String]?? = nil,
+        warningText: String?? = nil
+    ) -> ADExecApprovalRequestedPayload {
+        return ADExecApprovalRequestedPayload(
+            agentId: agentId ?? self.agentId,
+            allowedDecisions: allowedDecisions ?? self.allowedDecisions,
+            ask: ask ?? self.ask,
+            command: command ?? self.command,
+            commandAnalysis: commandAnalysis ?? self.commandAnalysis,
+            commandArgv: commandArgv ?? self.commandArgv,
+            commandPreview: commandPreview ?? self.commandPreview,
+            createdAtMs: createdAtMs ?? self.createdAtMs,
+            cwd: cwd ?? self.cwd,
+            expiresAtMs: expiresAtMs ?? self.expiresAtMs,
+            host: host ?? self.host,
+            id: id ?? self.id,
+            request: request ?? self.request,
+            resolvedPath: resolvedPath ?? self.resolvedPath,
+            security: security ?? self.security,
+            sessionKey: sessionKey ?? self.sessionKey,
+            unavailableDecisions: unavailableDecisions ?? self.unavailableDecisions,
+            warningText: warningText ?? self.warningText
+        )
+    }
+
+    func jsonData() throws -> Data {
+        return try newJSONEncoder().encode(self)
+    }
+
+    func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
+        return String(data: try self.jsonData(), encoding: encoding)
+    }
+}
+
+/// The `request` body OpenClaw nests inside the requested event.
+// MARK: - ADExecApprovalRequestBody
+struct ADExecApprovalRequestBody: Codable {
+    var agentId: String?
+    /// Decisions this specific request permits (policy may drop allow-always).
+    var allowedDecisions: [String]?
+    /// Approval POLICY ("on-miss" | "always" | …), never a question.
+    var ask: String?
+    /// Sanitized command display text — the thing the user is approving.
+    var command: String?
+    /// Gateway-side static analysis summary of the command.
+    var commandAnalysis: String?
+    var commandArgv: [String]?
+    /// Non-node hosts send a preview instead of the full command.
+    var commandPreview: String?
+    var cwd: String?
+    var host: String?
+    var resolvedPath: String?
+    var security: String?
+    var sessionKey: String?
+    var unavailableDecisions: [String]?
+    /// Human-readable risk note, when the Gateway produced one.
+    var warningText: String?
+
+    enum CodingKeys: String, CodingKey {
+        case agentId = "agentId"
+        case allowedDecisions = "allowedDecisions"
+        case ask = "ask"
+        case command = "command"
+        case commandAnalysis = "commandAnalysis"
+        case commandArgv = "commandArgv"
+        case commandPreview = "commandPreview"
+        case cwd = "cwd"
+        case host = "host"
+        case resolvedPath = "resolvedPath"
+        case security = "security"
+        case sessionKey = "sessionKey"
+        case unavailableDecisions = "unavailableDecisions"
+        case warningText = "warningText"
+    }
+}
+
+// MARK: ADExecApprovalRequestBody convenience initializers and mutators
+
+extension ADExecApprovalRequestBody {
+    init(data: Data) throws {
+        self = try newJSONDecoder().decode(ADExecApprovalRequestBody.self, from: data)
+    }
+
+    init(_ json: String, using encoding: String.Encoding = .utf8) throws {
+        guard let data = json.data(using: encoding) else {
+            throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+        }
+        try self.init(data: data)
+    }
+
+    init(fromURL url: URL) throws {
+        try self.init(data: try Data(contentsOf: url))
+    }
+
+    func with(
+        agentId: String?? = nil,
+        allowedDecisions: [String]?? = nil,
+        ask: String?? = nil,
+        command: String?? = nil,
+        commandAnalysis: String?? = nil,
+        commandArgv: [String]?? = nil,
+        commandPreview: String?? = nil,
+        cwd: String?? = nil,
+        host: String?? = nil,
+        resolvedPath: String?? = nil,
+        security: String?? = nil,
+        sessionKey: String?? = nil,
+        unavailableDecisions: [String]?? = nil,
+        warningText: String?? = nil
+    ) -> ADExecApprovalRequestBody {
+        return ADExecApprovalRequestBody(
+            agentId: agentId ?? self.agentId,
+            allowedDecisions: allowedDecisions ?? self.allowedDecisions,
+            ask: ask ?? self.ask,
+            command: command ?? self.command,
+            commandAnalysis: commandAnalysis ?? self.commandAnalysis,
+            commandArgv: commandArgv ?? self.commandArgv,
+            commandPreview: commandPreview ?? self.commandPreview,
+            cwd: cwd ?? self.cwd,
+            host: host ?? self.host,
+            resolvedPath: resolvedPath ?? self.resolvedPath,
+            security: security ?? self.security,
+            sessionKey: sessionKey ?? self.sessionKey,
+            unavailableDecisions: unavailableDecisions ?? self.unavailableDecisions,
+            warningText: warningText ?? self.warningText
+        )
+    }
+
+    func jsonData() throws -> Data {
+        return try newJSONEncoder().encode(self)
+    }
+
+    func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
+        return String(data: try self.jsonData(), encoding: encoding)
+    }
+}
+
+/// The Gateway answers `{ ok: true }`; `resolved` is kept for older builds.
+///
+/// Same element shape as the requested event, minus the envelope.
+///
+/// `exec.approval.requested` payload. The nested `request` is the real shape; the flat
+/// fields are tolerated so a future/legacy Gateway that inlines them still parses instead of
+/// silently producing an empty prompt.
+///
+/// `exec.approval.resolved` payload (`buildResolvedEvent` in exec-approval).
+// MARK: - ADConnectResult
+struct ADConnectResult: Codable {
     var accepted: Bool?
-    var auth: ADPayloadAuth?
+    var auth: ADConnectResultAuth?
     var expiresAt: Double?
     var features: ADFeatures?
     var policy: ADPolicy?
-    var gatewayProtocol: Double?
+    var connectResultProtocol: Double?
     var server: ADServer?
     var sessionToken: String?
-    var type: ADPayloadType?
+    var type: ADConnectResultType?
     var checks: [ADCheck]?
     var durationMs: Double?
     var ok: Bool?
@@ -573,11 +841,31 @@ struct ADGateway: Codable {
     var output: JSONAny?
     var tool: String?
     var reason: String?
+    var agentId: String?
+    /// Decisions this specific request permits (policy may drop allow-always).
+    var allowedDecisions: [String]?
+    /// Approval POLICY ("on-miss" | "always" | …), never a question.
+    var ask: String?
+    /// Sanitized command display text — the thing the user is approving.
     var command: String?
+    /// Gateway-side static analysis summary of the command.
+    var commandAnalysis: String?
+    var commandArgv: [String]?
+    /// Non-node hosts send a preview instead of the full command.
+    var commandPreview: String?
+    var createdAtMs: Double?
+    var cwd: String?
+    var expiresAtMs: Double?
+    var host: String?
     var id: String?
-    /// Options surfaced to the user (default: allow/deny).
-    var options: [ADOption]?
-    var decision: ADPayloadDecision?
+    var request: ADExecApprovalRequestBody?
+    var resolvedPath: String?
+    var security: String?
+    var unavailableDecisions: [String]?
+    /// Human-readable risk note, when the Gateway produced one.
+    var warningText: String?
+    var decision: String?
+    var resolvedBy: String?
     var clientId: String?
     var connected: Bool?
     var deviceId: String?
@@ -590,7 +878,7 @@ struct ADGateway: Codable {
         case expiresAt = "expiresAt"
         case features = "features"
         case policy = "policy"
-        case gatewayProtocol = "protocol"
+        case connectResultProtocol = "protocol"
         case server = "server"
         case sessionToken = "sessionToken"
         case type = "type"
@@ -635,10 +923,25 @@ struct ADGateway: Codable {
         case output = "output"
         case tool = "tool"
         case reason = "reason"
+        case agentId = "agentId"
+        case allowedDecisions = "allowedDecisions"
+        case ask = "ask"
         case command = "command"
+        case commandAnalysis = "commandAnalysis"
+        case commandArgv = "commandArgv"
+        case commandPreview = "commandPreview"
+        case createdAtMs = "createdAtMs"
+        case cwd = "cwd"
+        case expiresAtMs = "expiresAtMs"
+        case host = "host"
         case id = "id"
-        case options = "options"
+        case request = "request"
+        case resolvedPath = "resolvedPath"
+        case security = "security"
+        case unavailableDecisions = "unavailableDecisions"
+        case warningText = "warningText"
         case decision = "decision"
+        case resolvedBy = "resolvedBy"
         case clientId = "clientId"
         case connected = "connected"
         case deviceId = "deviceId"
@@ -647,11 +950,11 @@ struct ADGateway: Codable {
     }
 }
 
-// MARK: ADGateway convenience initializers and mutators
+// MARK: ADConnectResult convenience initializers and mutators
 
-extension ADGateway {
+extension ADConnectResult {
     init(data: Data) throws {
-        self = try newJSONDecoder().decode(ADGateway.self, from: data)
+        self = try newJSONDecoder().decode(ADConnectResult.self, from: data)
     }
 
     init(_ json: String, using encoding: String.Encoding = .utf8) throws {
@@ -667,14 +970,14 @@ extension ADGateway {
 
     func with(
         accepted: Bool?? = nil,
-        auth: ADPayloadAuth?? = nil,
+        auth: ADConnectResultAuth?? = nil,
         expiresAt: Double?? = nil,
         features: ADFeatures?? = nil,
         policy: ADPolicy?? = nil,
-        gatewayProtocol: Double?? = nil,
+        connectResultProtocol: Double?? = nil,
         server: ADServer?? = nil,
         sessionToken: String?? = nil,
-        type: ADPayloadType?? = nil,
+        type: ADConnectResultType?? = nil,
         checks: [ADCheck]?? = nil,
         durationMs: Double?? = nil,
         ok: Bool?? = nil,
@@ -716,23 +1019,38 @@ extension ADGateway {
         output: JSONAny?? = nil,
         tool: String?? = nil,
         reason: String?? = nil,
+        agentId: String?? = nil,
+        allowedDecisions: [String]?? = nil,
+        ask: String?? = nil,
         command: String?? = nil,
+        commandAnalysis: String?? = nil,
+        commandArgv: [String]?? = nil,
+        commandPreview: String?? = nil,
+        createdAtMs: Double?? = nil,
+        cwd: String?? = nil,
+        expiresAtMs: Double?? = nil,
+        host: String?? = nil,
         id: String?? = nil,
-        options: [ADOption]?? = nil,
-        decision: ADPayloadDecision?? = nil,
+        request: ADExecApprovalRequestBody?? = nil,
+        resolvedPath: String?? = nil,
+        security: String?? = nil,
+        unavailableDecisions: [String]?? = nil,
+        warningText: String?? = nil,
+        decision: String?? = nil,
+        resolvedBy: String?? = nil,
         clientId: String?? = nil,
         connected: Bool?? = nil,
         deviceId: String?? = nil,
         serverTime: Double?? = nil,
         restartAt: Double?? = nil
-    ) -> ADGateway {
-        return ADGateway(
+    ) -> ADConnectResult {
+        return ADConnectResult(
             accepted: accepted ?? self.accepted,
             auth: auth ?? self.auth,
             expiresAt: expiresAt ?? self.expiresAt,
             features: features ?? self.features,
             policy: policy ?? self.policy,
-            gatewayProtocol: gatewayProtocol ?? self.gatewayProtocol,
+            connectResultProtocol: connectResultProtocol ?? self.connectResultProtocol,
             server: server ?? self.server,
             sessionToken: sessionToken ?? self.sessionToken,
             type: type ?? self.type,
@@ -777,10 +1095,25 @@ extension ADGateway {
             output: output ?? self.output,
             tool: tool ?? self.tool,
             reason: reason ?? self.reason,
+            agentId: agentId ?? self.agentId,
+            allowedDecisions: allowedDecisions ?? self.allowedDecisions,
+            ask: ask ?? self.ask,
             command: command ?? self.command,
+            commandAnalysis: commandAnalysis ?? self.commandAnalysis,
+            commandArgv: commandArgv ?? self.commandArgv,
+            commandPreview: commandPreview ?? self.commandPreview,
+            createdAtMs: createdAtMs ?? self.createdAtMs,
+            cwd: cwd ?? self.cwd,
+            expiresAtMs: expiresAtMs ?? self.expiresAtMs,
+            host: host ?? self.host,
             id: id ?? self.id,
-            options: options ?? self.options,
+            request: request ?? self.request,
+            resolvedPath: resolvedPath ?? self.resolvedPath,
+            security: security ?? self.security,
+            unavailableDecisions: unavailableDecisions ?? self.unavailableDecisions,
+            warningText: warningText ?? self.warningText,
             decision: decision ?? self.decision,
+            resolvedBy: resolvedBy ?? self.resolvedBy,
             clientId: clientId ?? self.clientId,
             connected: connected ?? self.connected,
             deviceId: deviceId ?? self.deviceId,
@@ -798,8 +1131,8 @@ extension ADGateway {
     }
 }
 
-// MARK: - ADPayloadAuth
-struct ADPayloadAuth: Codable {
+// MARK: - ADConnectResultAuth
+struct ADConnectResultAuth: Codable {
     var deviceToken: String
     var deviceTokens: [ADDeviceToken]?
     var issuedAtMs: Double?
@@ -815,11 +1148,11 @@ struct ADPayloadAuth: Codable {
     }
 }
 
-// MARK: ADPayloadAuth convenience initializers and mutators
+// MARK: ADConnectResultAuth convenience initializers and mutators
 
-extension ADPayloadAuth {
+extension ADConnectResultAuth {
     init(data: Data) throws {
-        self = try newJSONDecoder().decode(ADPayloadAuth.self, from: data)
+        self = try newJSONDecoder().decode(ADConnectResultAuth.self, from: data)
     }
 
     init(_ json: String, using encoding: String.Encoding = .utf8) throws {
@@ -839,8 +1172,8 @@ extension ADPayloadAuth {
         issuedAtMs: Double?? = nil,
         role: String? = nil,
         scopes: [String]? = nil
-    ) -> ADPayloadAuth {
-        return ADPayloadAuth(
+    ) -> ADConnectResultAuth {
+        return ADConnectResultAuth(
             deviceToken: deviceToken ?? self.deviceToken,
             deviceTokens: deviceTokens ?? self.deviceTokens,
             issuedAtMs: issuedAtMs ?? self.issuedAtMs,
@@ -968,12 +1301,6 @@ extension ADCheck {
     func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
         return String(data: try self.jsonData(), encoding: encoding)
     }
-}
-
-enum ADPayloadDecision: String, Codable {
-    case allow = "allow"
-    case deny = "deny"
-    case timeout = "timeout"
 }
 
 // MARK: - ADGatewayPresenceEntry
@@ -1148,54 +1475,6 @@ extension ADOpenClawModel {
             provider: provider ?? self.provider,
             tags: tags ?? self.tags,
             title: title ?? self.title
-        )
-    }
-
-    func jsonData() throws -> Data {
-        return try newJSONEncoder().encode(self)
-    }
-
-    func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
-        return String(data: try self.jsonData(), encoding: encoding)
-    }
-}
-
-// MARK: - ADOption
-struct ADOption: Codable {
-    var key: String
-    var label: String
-
-    enum CodingKeys: String, CodingKey {
-        case key = "key"
-        case label = "label"
-    }
-}
-
-// MARK: ADOption convenience initializers and mutators
-
-extension ADOption {
-    init(data: Data) throws {
-        self = try newJSONDecoder().decode(ADOption.self, from: data)
-    }
-
-    init(_ json: String, using encoding: String.Encoding = .utf8) throws {
-        guard let data = json.data(using: encoding) else {
-            throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
-        }
-        try self.init(data: data)
-    }
-
-    init(fromURL url: URL) throws {
-        try self.init(data: try Data(contentsOf: url))
-    }
-
-    func with(
-        key: String? = nil,
-        label: String? = nil
-    ) -> ADOption {
-        return ADOption(
-            key: key ?? self.key,
-            label: label ?? self.label
         )
     }
 
@@ -1437,7 +1716,7 @@ enum ADStatus: String, Codable {
     case success = "success"
 }
 
-enum ADPayloadType: String, Codable {
+enum ADConnectResultType: String, Codable {
     case helloOk = "hello-ok"
 }
 

--- a/generated/protocol/gateway-frame-schema.json
+++ b/generated/protocol/gateway-frame-schema.json
@@ -436,48 +436,220 @@
       ],
       "type": "object"
     },
+    "ExecApprovalDecision": {
+      "description": "The decisions the Gateway will accept for an exec approval. Mirror of OpenClaw's `isApprovalDecision` / `DEFAULT_EXEC_APPROVAL_DECISIONS`. `'allow'` is NOT a member — sending it is rejected as an invalid decision.",
+      "enum": [
+        "allow-once",
+        "allow-always",
+        "deny"
+      ],
+      "type": "string"
+    },
+    "ExecApprovalListParams": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExecApprovalListResult": {
+      "description": "Same element shape as the requested event, minus the envelope.",
+      "items": {
+        "$ref": "#/definitions/ExecApprovalRequestedPayload"
+      },
+      "type": "array"
+    },
+    "ExecApprovalRequestBody": {
+      "additionalProperties": false,
+      "description": "The `request` body OpenClaw nests inside the requested event.",
+      "properties": {
+        "agentId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allowedDecisions": {
+          "description": "Decisions this specific request permits (policy may drop allow-always).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ask": {
+          "description": "Approval POLICY (\"on-miss\" | \"always\" | …), never a question.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "command": {
+          "description": "Sanitized command display text — the thing the user is approving.",
+          "type": "string"
+        },
+        "commandAnalysis": {
+          "description": "Gateway-side static analysis summary of the command.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commandArgv": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commandPreview": {
+          "description": "Non-node hosts send a preview instead of the full command.",
+          "type": "string"
+        },
+        "cwd": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resolvedPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "security": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sessionKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unavailableDecisions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "warningText": {
+          "description": "Human-readable risk note, when the Gateway produced one.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ExecApprovalRequestedPayload": {
       "additionalProperties": false,
+      "description": "`exec.approval.requested` payload. The nested `request` is the real shape; the flat fields are tolerated so a future/legacy Gateway that inlines them still parses instead of silently producing an empty prompt.",
       "properties": {
+        "agentId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allowedDecisions": {
+          "description": "Decisions this specific request permits (policy may drop allow-always).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ask": {
+          "description": "Approval POLICY (\"on-miss\" | \"always\" | …), never a question.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "command": {
+          "description": "Sanitized command display text — the thing the user is approving.",
           "type": "string"
+        },
+        "commandAnalysis": {
+          "description": "Gateway-side static analysis summary of the command.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commandArgv": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commandPreview": {
+          "description": "Non-node hosts send a preview instead of the full command.",
+          "type": "string"
+        },
+        "createdAtMs": {
+          "type": "number"
+        },
+        "cwd": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiresAtMs": {
+          "type": "number"
+        },
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
         },
-        "options": {
-          "description": "Options surfaced to the user (default: allow/deny).",
+        "request": {
+          "$ref": "#/definitions/ExecApprovalRequestBody"
+        },
+        "resolvedPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "security": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sessionKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unavailableDecisions": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "label": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "key",
-              "label"
-            ],
-            "type": "object"
+            "type": "string"
           },
           "type": "array"
         },
-        "reason": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "tool": {
-          "type": "string"
+        "warningText": {
+          "description": "Human-readable risk note, when the Gateway produced one.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "id",
-        "tool"
+        "id"
       ],
       "type": "object"
     },
@@ -485,11 +657,7 @@
       "additionalProperties": false,
       "properties": {
         "decision": {
-          "enum": [
-            "allow",
-            "deny"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/ExecApprovalDecision"
         },
         "id": {
           "type": "string"
@@ -503,32 +671,45 @@
     },
     "ExecApprovalResolveResult": {
       "additionalProperties": false,
+      "description": "The Gateway answers `{ ok: true }`; `resolved` is kept for older builds.",
       "properties": {
+        "ok": {
+          "type": "boolean"
+        },
         "resolved": {
           "type": "boolean"
         }
       },
-      "required": [
-        "resolved"
-      ],
       "type": "object"
     },
     "ExecApprovalResolvedPayload": {
       "additionalProperties": false,
+      "description": "`exec.approval.resolved` payload (`buildResolvedEvent` in exec-approval).",
       "properties": {
         "decision": {
-          "enum": [
-            "allow",
-            "deny",
-            "timeout"
-          ],
-          "type": "string"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExecApprovalDecision"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "id": {
           "type": "string"
         },
-        "sessionKey": {
-          "type": "string"
+        "request": {
+          "$ref": "#/definitions/ExecApprovalRequestBody"
+        },
+        "resolvedBy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ts": {
+          "type": "number"
         }
       },
       "required": [
@@ -663,6 +844,7 @@
         "chat.send",
         "chat.abort",
         "exec.approval.resolve",
+        "exec.approval.list",
         "sessions.list",
         "sessions.subscribe",
         "sessions.messages.subscribe",
@@ -692,6 +874,9 @@
         },
         {
           "$ref": "#/definitions/ExecApprovalResolveParams"
+        },
+        {
+          "$ref": "#/definitions/ExecApprovalListParams"
         },
         {
           "$ref": "#/definitions/SessionsListParams"
@@ -729,6 +914,9 @@
         },
         {
           "$ref": "#/definitions/ExecApprovalResolveResult"
+        },
+        {
+          "$ref": "#/definitions/ExecApprovalListResult"
         },
         {
           "$ref": "#/definitions/SessionsListResult"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "generate-codex-freshness-rules": "node scripts/generate-codex-freshness-rules.mjs",
     "generate-idotmatrix-identity": "node scripts/generate-idotmatrix-identity.mjs",
     "generate-pairing-code-rules": "node scripts/generate-pairing-code-rules.mjs",
+    "generate-openclaw-approval-rules": "node scripts/generate-openclaw-approval-rules.mjs",
     "generate-streamdeck-profiles": "node scripts/generate-streamdeck-profiles.mjs",
     "verify-version": "node scripts/verify-version-sync.mjs",
     "check-preview-sync": "node scripts/check-preview-mirror-sync.mjs",

--- a/plugin/src/__tests__/session-slot-manager.test.ts
+++ b/plugin/src/__tests__/session-slot-manager.test.ts
@@ -137,6 +137,62 @@ describe('SessionSlotManager detail layout', () => {
     });
   });
 
+  it('renders the OpenClaw exec approval from the row when the relay says idle', () => {
+    // `focus_session` is answered with the daemon's GLOBAL state_update, and
+    // that machine is fed by every observed hook session — so an unrelated
+    // Claude turn ending relays IDLE for the focused Gateway session and wipes
+    // the approval out of the detail cache. The row still asserts it, and the
+    // row is the only per-session source there is.
+    const manager = new SessionSlotManager();
+    manager.updateSessions([
+      makeSession({
+        id: 'openclaw-gateway',
+        agentType: 'openclaw',
+        controlMode: 'managed',
+        state: State.AWAITING_PERMISSION,
+        question: 'rg --files-with-matches TODO src',
+        options: [
+          { index: 0, label: 'Allow once', shortcut: 'y' },
+          { index: 1, label: 'Always allow', shortcut: 'a' },
+          { index: 2, label: 'Deny', shortcut: 'n' },
+        ],
+        liveAnswerable: true,
+      }),
+    ]);
+    manager.enterDetailView('openclaw-gateway');
+    // The contaminated relay.
+    manager.updateDetailState(State.IDLE, []);
+
+    expect(manager.getSlotConfig(2, SD_PLUS_LAYOUT)).toMatchObject({
+      type: 'option', optionIndex: 0, option: { label: 'Allow once' },
+    });
+    expect(manager.getSlotConfig(3, SD_PLUS_LAYOUT)).toMatchObject({
+      type: 'option', optionIndex: 1, option: { label: 'Always allow' },
+    });
+    expect(manager.getSlotConfig(4, SD_PLUS_LAYOUT)).toMatchObject({
+      type: 'option', optionIndex: 2, option: { label: 'Deny' },
+    });
+  });
+
+  it('shows an OpenClaw approval as display-only when it is not deliverable', () => {
+    // No fabricated buttons: without `liveAnswerable` a press has nowhere to go.
+    const manager = new SessionSlotManager();
+    manager.updateSessions([
+      makeSession({
+        id: 'openclaw-gateway',
+        agentType: 'openclaw',
+        controlMode: 'managed',
+        state: State.AWAITING_PERMISSION,
+        question: 'rm -rf build',
+        options: [{ index: 0, label: 'Allow once', shortcut: 'y' }],
+      }),
+    ]);
+    manager.enterDetailView('openclaw-gateway');
+    manager.updateDetailState(State.IDLE, []);
+
+    expect(manager.getSlotConfig(2, SD_PLUS_LAYOUT)).toMatchObject({ type: 'status' });
+  });
+
   it('puts processing tool info before OpenClaw presets', () => {
     const manager = new SessionSlotManager();
     manager.updateSessions([

--- a/plugin/src/session-slot-manager.ts
+++ b/plugin/src/session-slot-manager.ts
@@ -1113,10 +1113,19 @@ export class SessionSlotManager {
     // processing from it instead of the (never-primed) detail relay state.
     const isObserved = session?.controlMode === 'observed';
     const observedState = (session?.state ?? '').toLowerCase();
-    const isAwaiting = isObserved
+    // The OpenClaw Gateway row is `managed` but has no state_update channel of
+    // its own either: `focus_session` is answered with the daemon's GLOBAL
+    // state, which every observed hook session also feeds, so an unrelated
+    // Claude turn going idle wipes the relayed detail state — and with it the
+    // approval the row is still asserting. When the row presents a prompt the
+    // relay does not, the row is the live source, exactly as for observed.
+    const rowPresentsPrompt = observedState.startsWith('awaiting')
+      && (session?.options?.length ?? 0) > 0;
+    const rowDriven = isObserved || (rowPresentsPrompt && !this.isAwaitingDetailState());
+    const isAwaiting = rowDriven
       ? observedState.startsWith('awaiting')
       : this.isAwaitingDetailState();
-    const isProcessing = isObserved
+    const isProcessing = rowDriven
       ? observedState === 'processing'
       : this._detailState === State.PROCESSING;
     const isOpenClaw = session?.agentType === 'openclaw';
@@ -1163,7 +1172,11 @@ export class SessionSlotManager {
     // Observed sessions get their own capability-aware content: gate
     // Allow/Deny while a held PreToolUse is pending, queueable directives
     // while processing, and an honest "control in terminal" tile when idle.
-    if (isObserved) {
+    // `rowDriven` also covers the Gateway's exec approval: its options live on
+    // the row, and this renderer is the one that turns them into pressable
+    // cells gated on `liveAnswerable`. Restricted to the awaiting case so an
+    // idle/processing OpenClaw row keeps its existing managed layout.
+    if (isObserved || (rowDriven && isAwaiting)) {
       return this.observedContentSlot(session, contentIdx, isAwaiting, isProcessing);
     }
 

--- a/scripts/generate-openclaw-approval-rules.mjs
+++ b/scripts/generate-openclaw-approval-rules.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// Generate the Swift mirror of the OpenClaw exec-approval SSOT
+// (shared/src/openclaw-approval.ts).
+//
+//   pnpm generate-openclaw-approval-rules            regenerate the mirror
+//   pnpm generate-openclaw-approval-rules --check    exit 1 if it drifted
+//
+// Why the whole parser is emitted rather than just the decision names: both
+// daemons TALK TO THE SAME GATEWAY, and the Gateway validates `decision`
+// against its own enum BEFORE it looks the approval id up. A mirror that
+// carried the vocabulary but re-implemented the payload walk by hand is exactly
+// how the two implementations diverged in the first place — Node read the
+// payload flat, Swift read `payload["tool"]`, and NEITHER matched
+// `buildRequestedApprovalEvent`, so on both daemons the user saw an approval
+// with no command on it and could not answer it.
+//
+// Only Swift is emitted. Android is a client: it renders `question`/`options`
+// off the session row the daemon already built and submits `select_option`. It
+// never parses a Gateway frame, so an approval parser there would be dead
+// mirror surface.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const HEADER =
+  'GENERATED FILE — DO NOT EDIT.\n' +
+  'Source of truth: shared/src/openclaw-approval.ts\n' +
+  'Regenerate: pnpm generate-openclaw-approval-rules ' +
+  '(drift gated by shared/src/__tests__/openclaw-approval-rules-sync.test.ts)';
+
+function comment(prefix) {
+  return HEADER.split('\n').map((l) => `${prefix} ${l}`).join('\n');
+}
+
+/** Pull the parts of the SSOT the mirror must embed verbatim. */
+export function rulesFrom(mod) {
+  const decisions = [...mod.EXEC_APPROVAL_DECISIONS];
+  return {
+    decisions,
+    display: Object.fromEntries(
+      decisions.map((d) => [d, { label: mod.execApprovalDecisionLabel(d) }]),
+    ),
+    // Shortcuts are not exported individually; derive them from a parsed
+    // prompt so the mirror can never disagree with what the parser emits.
+    shortcuts: Object.fromEntries(
+      mod
+        .parseExecApprovalRequest({ id: 'x', request: { command: 'c' } }, 0)
+        .options.map((o) => [o.decision, o.shortcut]),
+    ),
+  };
+}
+
+export function emitSwift(rules) {
+  const caseLines = rules.decisions
+    .map((d) => `    case ${swiftCaseName(d)} = "${d}"`)
+    .join('\n');
+  const labelLines = rules.decisions
+    .map((d) => `        case .${swiftCaseName(d)}: return "${rules.display[d].label}"`)
+    .join('\n');
+  const shortcutLines = rules.decisions
+    .map((d) => `        case .${swiftCaseName(d)}: return "${rules.shortcuts[d]}"`)
+    .join('\n');
+  const allLine = rules.decisions.map((d) => `.${swiftCaseName(d)}`).join(', ');
+
+  return `${comment('//')}
+
+import Foundation
+
+#if os(macOS)
+
+/// The decisions the OpenClaw Gateway will accept for an exec approval.
+///
+/// \`allow\` is deliberately NOT a member. The Gateway's \`isApprovalDecision\`
+/// rejects it, and it does so before the approval id is looked up — so a resolve
+/// carrying it returns INVALID_REQUEST and the approval stays pending with no
+/// visible failure anywhere.
+enum ExecApprovalDecision: String, CaseIterable, Sendable {
+${caseLines}
+
+    static let ordered: [ExecApprovalDecision] = [${allLine}]
+
+    /// Short device-facing label (Stream Deck keys, D200H cells).
+    var label: String {
+        switch self {
+${labelLines}
+        }
+    }
+
+    /// What a non-navigable \`respond\` press carries for this decision.
+    var shortcut: String {
+        switch self {
+${shortcutLines}
+        }
+    }
+
+    var allowsExecution: Bool {
+        self == .allowOnce || self == .allowAlways
+    }
+}
+
+/// One renderable choice on a deck surface. The decision rides the option so an
+/// index press is never re-derived (and mis-derived) at the answer site.
+struct ExecApprovalOption: Sendable, Equatable {
+    let index: Int
+    let label: String
+    let shortcut: String
+    let decision: ExecApprovalDecision
+}
+
+/// Normalized \`exec.approval.requested\` — what surfaces render and what an
+/// answer maps back through.
+struct OpenClawApprovalPrompt: Sendable, Equatable {
+    let id: String
+    let question: String
+    let detail: String?
+    let command: String
+    let cwd: String?
+    let options: [ExecApprovalOption]
+    let expiresAtMs: Double?
+    let requestedAtMs: Double
+    let sessionKey: String?
+}
+
+enum OpenClawApprovalRules {
+
+    /// Parse a raw \`exec.approval.requested\` payload.
+    ///
+    /// The Gateway sends \`{ id, request, createdAtMs, expiresAtMs }\` — every
+    /// display field lives under \`request\`. The flat lookup is a compatibility
+    /// path only, so a Gateway that inlines a field degrades instead of blanking
+    /// the prompt. Returns nil only when there is no usable id: a request with no
+    /// command text still yields a prompt, because the user must keep the ability
+    /// to deny something they cannot see.
+    static func parse(_ payload: [String: Any], nowMs: Double) -> OpenClawApprovalPrompt? {
+        let id = (payload["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !id.isEmpty else { return nil }
+
+        var body = payload
+        if let request = payload["request"] as? [String: Any] {
+            for (k, v) in request { body[k] = v }
+        }
+
+        let argv = (body["commandArgv"] as? [String])?.joined(separator: " ")
+        let command = firstNonEmpty([
+            body["command"] as? String,
+            body["commandPreview"] as? String,
+            argv,
+        ]) ?? ""
+
+        let cwd = firstNonEmpty([body["cwd"] as? String])
+        var detailParts: [String] = []
+        if let cwd { detailParts.append("cwd: \\(cwd)") }
+        let warning = firstNonEmpty([body["warningText"] as? String])
+        if let warning { detailParts.append(warning) }
+        if let analysis = firstNonEmpty([body["commandAnalysis"] as? String]), analysis != warning {
+            detailParts.append(analysis)
+        }
+
+        let options = resolveDecisions(body).enumerated().map { idx, decision in
+            ExecApprovalOption(
+                index: idx, label: decision.label, shortcut: decision.shortcut, decision: decision)
+        }
+
+        return OpenClawApprovalPrompt(
+            id: id,
+            question: command.isEmpty ? "Approve tool execution (command not reported)" : command,
+            detail: detailParts.isEmpty ? nil : detailParts.joined(separator: "\\n"),
+            command: command,
+            cwd: cwd,
+            options: options,
+            expiresAtMs: numeric(payload["expiresAtMs"]),
+            requestedAtMs: numeric(payload["createdAtMs"]) ?? nowMs,
+            sessionKey: firstNonEmpty([body["sessionKey"] as? String])
+        )
+    }
+
+    /// Map a \`select_option\` index onto the decision that option represents.
+    static func decision(forOptionIndex index: Int, in prompt: OpenClawApprovalPrompt)
+        -> ExecApprovalDecision?
+    {
+        prompt.options.first(where: { $0.index == index })?.decision
+    }
+
+    /// Map a \`respond\` value onto a decision. Accepts the option shortcut, the
+    /// decision name, and the y/n/a spellings hardware keys and the wake-word
+    /// assistant send. Unrecognized input returns nil — an ambiguous press must
+    /// never be guessed into an approval.
+    static func decision(forRespondValue value: String, in prompt: OpenClawApprovalPrompt)
+        -> ExecApprovalDecision?
+    {
+        let v = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !v.isEmpty else { return nil }
+        if let byDecision = prompt.options.first(where: { $0.decision.rawValue == v }) {
+            return byDecision.decision
+        }
+        if let byShortcut = prompt.options.first(where: { $0.shortcut == v }) {
+            return byShortcut.decision
+        }
+        if let byLabel = prompt.options.first(where: { $0.label.lowercased() == v }) {
+            return byLabel.decision
+        }
+        let alias: [String: ExecApprovalDecision] = [
+            "y": .allowOnce, "yes": .allowOnce, "allow": .allowOnce, "once": .allowOnce,
+            "a": .allowAlways, "always": .allowAlways,
+            "n": .deny, "no": .deny, "reject": .deny,
+        ]
+        guard let mapped = alias[v] else { return nil }
+        // Honor the request's own policy: a spoken "always" against a request
+        // that forbids allow-always must be refused, not downgraded.
+        return prompt.options.contains(where: { $0.decision == mapped }) ? mapped : nil
+    }
+
+    /// Decisions this specific request permits. The Gateway narrows them
+    /// per-request (an \`ask: "always"\` policy drops allow-always), so never
+    /// offer one it forbids. Deny is always kept: a prompt the user can only
+    /// accept is not a prompt.
+    private static func resolveDecisions(_ body: [String: Any]) -> [ExecApprovalDecision] {
+        let allowed = (body["allowedDecisions"] as? [String] ?? [])
+            .compactMap(ExecApprovalDecision.init(rawValue:))
+        let base = allowed.isEmpty ? ExecApprovalDecision.ordered : allowed
+        let unavailable = Set(body["unavailableDecisions"] as? [String] ?? [])
+        let kept = base.filter { !unavailable.contains($0.rawValue) }
+        return kept.isEmpty ? [.deny] : kept
+    }
+
+    private static func firstNonEmpty(_ values: [String?]) -> String? {
+        for value in values {
+            if let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    private static func numeric(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let n = value as? NSNumber { return n.doubleValue }
+        return nil
+    }
+}
+
+#endif
+`;
+}
+
+function swiftCaseName(decision) {
+  return decision
+    .split('-')
+    .map((part, i) => (i === 0 ? part : part[0].toUpperCase() + part.slice(1)))
+    .join('');
+}
+
+export const OUTPUTS = [
+  ['apple/AgentDeck/Daemon/Gateway/OpenClawApprovalRules.generated.swift', emitSwift],
+];
+
+async function main() {
+  const check = process.argv.includes('--check');
+  const mod = await import(path.join(projectDir, 'shared/dist/openclaw-approval.js'));
+  const rules = rulesFrom(mod);
+  let drifted = false;
+  for (const [rel, emit] of OUTPUTS) {
+    const target = path.join(projectDir, rel);
+    const next = emit(rules);
+    const current = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : null;
+    if (current === next) continue;
+    if (check) {
+      console.error(`drift: ${rel}`);
+      drifted = true;
+      continue;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, next);
+    console.log(`wrote ${rel}`);
+  }
+  if (drifted) process.exit(1);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/shared/src/__tests__/d200h-openclaw-approval.test.ts
+++ b/shared/src/__tests__/d200h-openclaw-approval.test.ts
@@ -1,0 +1,102 @@
+// The OpenClaw Gateway row on the D200H detail view.
+//
+// Two traps this pins, both of which left a real exec approval unanswerable
+// from any deck (2026-08-17):
+//
+//  1. The daemon relays its GLOBAL state_update stamped with the focused
+//     session's id. That machine is fed by every observed hook session, so an
+//     unrelated Claude turn going idle overwrites it — and the detail view,
+//     trusting `focusedSessionId`, rendered STOP/idle over a session whose own
+//     row said "awaiting, here are the options".
+//  2. The live-answer path was gated on `controlMode === 'observed'`. The
+//     Gateway row is `managed` and has no terminal, so its options rendered as
+//     an inert mirror of a prompt with nowhere to answer it.
+import { describe, it, expect } from 'vitest';
+import { buildSessionDeck, type DeckAction } from '../d200h-layout.js';
+
+const POSITIONS = ['0_0', '1_0', '2_0', '3_0', '4_0', '0_1', '1_1', '2_1'];
+const SID = 'openclaw-gateway';
+
+const APPROVAL_OPTIONS = [
+  { index: 0, label: 'Allow once', shortcut: 'y' },
+  { index: 1, label: 'Always allow', shortcut: 'a' },
+  { index: 2, label: 'Deny', shortcut: 'n' },
+];
+
+/** A gateway row mid-approval, relayed inside a global event that says idle. */
+function stateEvt(session: Record<string, unknown>, global: Record<string, unknown> = {}) {
+  return {
+    type: 'state_update',
+    // The contaminated global machine: another agent's turn ended.
+    state: 'idle',
+    focusedSessionId: SID,
+    ...global,
+    allSessions: [{
+      id: SID, port: 18789, alive: true,
+      projectName: 'OpenClaw', agentType: 'openclaw', controlMode: 'managed',
+      ...session,
+    }],
+  };
+}
+
+function detailCells(evt: unknown) {
+  return buildSessionDeck(evt, { mode: 'detail' as const, openSessionId: SID }, POSITIONS);
+}
+
+type CommandAction = Extract<NonNullable<DeckAction>, { kind: 'command' }>;
+function commandsOf(cells: Map<string, { svg: string; action: DeckAction }>) {
+  return [...cells.values()]
+    .map((c) => c.action)
+    .filter((a): a is CommandAction => a != null && a.kind === 'command')
+    .map((a) => a.command);
+}
+
+describe('D200H — OpenClaw exec approval', () => {
+  const pending = stateEvt({
+    state: 'awaiting_permission',
+    question: 'rg --files-with-matches TODO src',
+    options: APPROVAL_OPTIONS,
+    promptType: 'yes_no_always',
+    liveAnswerable: true,
+  });
+
+  it('renders the real command and its decisions, not the global idle state', () => {
+    const svgs = [...detailCells(pending).values()].map((c) => c.svg).join('');
+    expect(svgs).toContain('Allow once');
+    expect(svgs).toContain('Deny');
+    // The dead-end tile: it means "go type in a terminal", and this session
+    // does not have one.
+    expect(svgs).not.toContain('answer in terminal');
+  });
+
+  it('every decision is a pressable select_option carrying its own index', () => {
+    const cmds = commandsOf(detailCells(pending))
+      .filter((c) => c.type === 'select_option');
+    expect(cmds).toHaveLength(3);
+    expect(cmds.map((c) => c.index)).toEqual([0, 1, 2]);
+    expect(cmds.every((c) => c.sessionId === SID)).toBe(true);
+    // The echo guard: a press aimed at an approval the Gateway already moved
+    // past must be droppable rather than applied to the new one.
+    expect(cmds.every((c) => c.question === 'rg --files-with-matches TODO src')).toBe(true);
+  });
+
+  it('keeps the relayed event authoritative when IT is the one with the prompt', () => {
+    // Only ever an upgrade — a focused session whose live event carries the
+    // prompt (a PTY with a navigable cursor) must not be downgraded to the row.
+    const cells = detailCells(stateEvt(
+      { state: 'awaiting_permission', options: [], question: undefined },
+      {
+        state: 'awaiting_option',
+        question: 'Which cleanup window?',
+        options: [{ index: 0, label: '7 days' }, { index: 1, label: '14 days' }],
+      },
+    ));
+    const svgs = [...cells.values()].map((c) => c.svg).join('');
+    expect(svgs).toContain('7 days');
+  });
+
+  it('an idle gateway row still reads as idle', () => {
+    const svgs = [...detailCells(stateEvt({ state: 'idle' })).values()].map((c) => c.svg).join('');
+    expect(svgs).not.toContain('Allow once');
+  });
+});

--- a/shared/src/__tests__/openclaw-approval-rules-sync.test.ts
+++ b/shared/src/__tests__/openclaw-approval-rules-sync.test.ts
@@ -1,0 +1,53 @@
+// Drift gate for the OpenClaw exec-approval SSOT mirror
+// (shared/src/openclaw-approval.ts → Swift). A hand edit to the generated file,
+// or a skipped `pnpm generate-openclaw-approval-rules`, fails here in CI.
+//
+// The byte compare alone is not the point. What this file really pins is the
+// pair of facts a compare would happily let rot back into the shape that broke
+// the feature: the decision vocabulary the Gateway accepts (`allow` is not a
+// member), and the fact that the payload is NESTED under `request`. Both were
+// wrong in every implementation at once, so "the two mirrors agree" would have
+// been true the whole time it was broken.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as approval from '../openclaw-approval.js';
+import { OUTPUTS, emitSwift, rulesFrom } from '../../../scripts/generate-openclaw-approval-rules.mjs';
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const rules = rulesFrom(approval);
+
+describe('generated mirror in sync', () => {
+  for (const [rel, emit] of OUTPUTS) {
+    it(`${rel} matches the SSOT`, () => {
+      expect(readFileSync(`${repoRoot}${rel}`, 'utf8')).toBe(emit(rules));
+    });
+  }
+
+  it('the Swift mirror carries every decision the TS union declares', () => {
+    const swift = emitSwift(rules);
+    for (const decision of approval.EXEC_APPROVAL_DECISIONS) {
+      expect(swift).toContain(`= "${decision}"`);
+    }
+    // A decision added to TS without regenerating would otherwise only surface
+    // as a Swift compile error on a machine with Xcode.
+    const cases = swift.match(/^\s{4}case \w+ = "/gm) ?? [];
+    expect(cases.length).toBe(approval.EXEC_APPROVAL_DECISIONS.length);
+  });
+
+  it('neither side ever offers the plain "allow" the Gateway rejects', () => {
+    // The whole outage was this string. `isApprovalDecision('allow')` is false
+    // and the Gateway checks it BEFORE the id lookup, so the resolve fails and
+    // the approval stays pending with nothing surfaced anywhere.
+    expect(approval.EXEC_APPROVAL_DECISIONS as readonly string[]).not.toContain('allow');
+    expect(emitSwift(rules)).not.toMatch(/= "allow"$/m);
+  });
+
+  it('the Swift mirror reads the nested request, not flat fields', () => {
+    // `payload["tool"]` / a flat `payload["command"]` are the invented shapes
+    // that rendered every approval as a bare "Approve tool execution?".
+    const swift = emitSwift(rules);
+    expect(swift).toContain('payload["request"] as? [String: Any]');
+    expect(swift).not.toContain('payload["tool"]');
+  });
+});

--- a/shared/src/__tests__/openclaw-approval.test.ts
+++ b/shared/src/__tests__/openclaw-approval.test.ts
@@ -1,0 +1,173 @@
+// Behaviour gate for the OpenClaw exec-approval SSOT.
+//
+// Every fixture below is the shape OpenClaw's own gateway bundle produces
+// (`buildRequestedApprovalEvent` → `{ id, request, createdAtMs, expiresAtMs }`,
+// `resolveExecApprovalRequestAllowedDecisions` for the decision set). Fixtures
+// invented from what the code happens to read are how this surface shipped
+// broken in the first place — a test written against `payload.command` would
+// have passed for the entire time no user could see a command.
+import { describe, it, expect } from 'vitest';
+import {
+  parseExecApprovalRequest,
+  decisionForOptionIndex,
+  decisionForRespondValue,
+  execApprovalAllows,
+  EXEC_APPROVAL_DECISIONS,
+} from '../openclaw-approval.js';
+
+/** The real event shape: everything renderable is nested under `request`. */
+const gatewayEvent = {
+  id: 'aa2318a0-dfdb-40e2-8238-c09e7905f95e',
+  createdAtMs: 1_786_940_704_797,
+  expiresAtMs: 1_786_940_764_797,
+  request: {
+    command: 'rg --files-with-matches TODO src',
+    cwd: '/Users/dev/project',
+    ask: 'on-miss',
+    security: 'full',
+    warningText: 'Reads every file under src.',
+    allowedDecisions: ['allow-once', 'allow-always', 'deny'],
+    sessionKey: 'agent:main:eval-a03',
+  },
+};
+
+describe('parseExecApprovalRequest', () => {
+  it('reads the command out of the nested request', () => {
+    const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+    expect(prompt.command).toBe('rg --files-with-matches TODO src');
+    // The headline IS the command — this is the whole point of the fix. The
+    // previous code produced the literal "Approve tool execution?" here.
+    expect(prompt.question).toBe('rg --files-with-matches TODO src');
+    expect(prompt.question).not.toContain('Approve tool execution');
+  });
+
+  it('never renders `ask` as if it were the question', () => {
+    // `ask` is the POLICY ("on-miss" / "always"). It used to be concatenated
+    // onto the command as though it were a human-readable prompt.
+    const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+    expect(prompt.question).not.toContain('on-miss');
+    expect(prompt.detail ?? '').not.toContain('on-miss');
+  });
+
+  it('carries cwd and warning as supporting detail', () => {
+    const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+    expect(prompt.cwd).toBe('/Users/dev/project');
+    expect(prompt.detail).toContain('cwd: /Users/dev/project');
+    expect(prompt.detail).toContain('Reads every file under src.');
+  });
+
+  it('offers exactly the decisions the request allows', () => {
+    const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+    expect(prompt.options.map((o) => o.decision)).toEqual([
+      'allow-once', 'allow-always', 'deny',
+    ]);
+    expect(prompt.options.map((o) => o.index)).toEqual([0, 1, 2]);
+  });
+
+  it('drops allow-always when the policy withholds it', () => {
+    // `ask: "always"` narrows the set — offering allow-always anyway comes back
+    // as "allow-always is unavailable because the effective policy requires
+    // approval every time".
+    const prompt = parseExecApprovalRequest({
+      ...gatewayEvent,
+      request: { ...gatewayEvent.request, allowedDecisions: ['allow-once', 'deny'] },
+    }, 0)!;
+    expect(prompt.options.map((o) => o.decision)).toEqual(['allow-once', 'deny']);
+  });
+
+  it('honors unavailableDecisions on top of the allowed set', () => {
+    const prompt = parseExecApprovalRequest({
+      ...gatewayEvent,
+      request: { ...gatewayEvent.request, unavailableDecisions: ['allow-always'] },
+    }, 0)!;
+    expect(prompt.options.map((o) => o.decision)).toEqual(['allow-once', 'deny']);
+  });
+
+  it('always keeps a deny — a prompt you can only accept is not a prompt', () => {
+    const prompt = parseExecApprovalRequest({
+      ...gatewayEvent,
+      request: { ...gatewayEvent.request, allowedDecisions: [], unavailableDecisions: [...EXEC_APPROVAL_DECISIONS] },
+    }, 0)!;
+    expect(prompt.options.map((o) => o.decision)).toEqual(['deny']);
+  });
+
+  it('still produces an answerable prompt when no command was reported', () => {
+    // Degraded, not broken: the user must keep the ability to deny something
+    // the Gateway declined to describe.
+    const prompt = parseExecApprovalRequest({ id: 'x', request: {} }, 0)!;
+    expect(prompt.command).toBe('');
+    expect(prompt.question).toContain('command not reported');
+    expect(prompt.options.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to flat fields if a Gateway ever inlines them', () => {
+    const prompt = parseExecApprovalRequest({ id: 'x', command: 'ls -la' }, 0)!;
+    expect(prompt.question).toBe('ls -la');
+  });
+
+  it('falls back to argv when only that is present', () => {
+    const prompt = parseExecApprovalRequest(
+      { id: 'x', request: { commandArgv: ['git', 'status'] } }, 0)!;
+    expect(prompt.question).toBe('git status');
+  });
+
+  it('returns null only when there is no usable id', () => {
+    expect(parseExecApprovalRequest({ request: { command: 'ls' } }, 0)).toBeNull();
+    expect(parseExecApprovalRequest({ id: '  ' }, 0)).toBeNull();
+    expect(parseExecApprovalRequest(null, 0)).toBeNull();
+  });
+
+  it('carries the expiry so a stale prompt can be swept', () => {
+    const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+    expect(prompt.expiresAtMs).toBe(1_786_940_764_797);
+  });
+});
+
+describe('answering', () => {
+  const prompt = parseExecApprovalRequest(gatewayEvent, 0)!;
+
+  it('maps an option index to the decision that option carries', () => {
+    expect(decisionForOptionIndex(prompt, 0)).toBe('allow-once');
+    expect(decisionForOptionIndex(prompt, 1)).toBe('allow-always');
+    expect(decisionForOptionIndex(prompt, 2)).toBe('deny');
+  });
+
+  it('refuses an out-of-range index instead of guessing', () => {
+    expect(decisionForOptionIndex(prompt, 9)).toBeNull();
+    expect(decisionForOptionIndex(prompt, -1)).toBeNull();
+  });
+
+  it('accepts shortcuts, decision names, and the y/n/a spellings', () => {
+    expect(decisionForRespondValue(prompt, 'y')).toBe('allow-once');
+    expect(decisionForRespondValue(prompt, 'a')).toBe('allow-always');
+    expect(decisionForRespondValue(prompt, 'n')).toBe('deny');
+    expect(decisionForRespondValue(prompt, 'allow')).toBe('allow-once');
+    expect(decisionForRespondValue(prompt, 'allow-always')).toBe('allow-always');
+    expect(decisionForRespondValue(prompt, 'Deny')).toBe('deny');
+  });
+
+  it('never turns an unrecognized press into an approval', () => {
+    expect(decisionForRespondValue(prompt, 'maybe')).toBeNull();
+    expect(decisionForRespondValue(prompt, '')).toBeNull();
+  });
+
+  it('refuses "always" when the request forbids allow-always', () => {
+    // Downgrading it to a one-shot allow would silently answer a different
+    // question than the user asked.
+    const narrow = parseExecApprovalRequest({
+      ...gatewayEvent,
+      request: { ...gatewayEvent.request, allowedDecisions: ['allow-once', 'deny'] },
+    }, 0)!;
+    expect(decisionForRespondValue(narrow, 'always')).toBeNull();
+    expect(decisionForRespondValue(narrow, 'y')).toBe('allow-once');
+  });
+
+  it('classifies which decisions let the command run', () => {
+    expect(execApprovalAllows('allow-once')).toBe(true);
+    expect(execApprovalAllows('allow-always')).toBe(true);
+    expect(execApprovalAllows('deny')).toBe(false);
+    // The label bug: comparing the real decision to 'allow' marked every
+    // approval as denied.
+    expect(execApprovalAllows('allow')).toBe(false);
+  });
+});

--- a/shared/src/d200h-layout.ts
+++ b/shared/src/d200h-layout.ts
@@ -884,9 +884,27 @@ function buildDetail(
   const sess = state.allSessions.find((s) => s.id === sid);
   // Focused-session detail comes from the top-level state_update when it relays
   // this session (focusedSessionId/sessionId match); else fall back to SessionInfo.
-  const focused = stateEvt?.focusedSessionId === sid || stateEvt?.sessionId === sid;
+  const focusedEvent = stateEvt?.focusedSessionId === sid || stateEvt?.sessionId === sid;
+  // `focusedSessionId` proves the daemon RELAYED this event while the session
+  // was focused — not that the state in it came from this session. The daemon's
+  // machine is fed by every observed hook session and by the Gateway alike, so
+  // an unrelated agent going idle overwrites it and the relay still carries our
+  // id. When the session's OWN row asserts a live prompt and the relayed event
+  // does not, the row wins: a row that says "awaiting, here are the options" is
+  // information about this session; a global "idle" is not.
+  //
+  // Only ever an upgrade — where the relayed event does present a prompt it
+  // stays authoritative, because it is the fresher copy and the only one that
+  // carries a PTY's navigable cursor.
+  const rowOptions = sess?.options ?? [];
+  const eventPresentsPrompt = focusedEvent
+    && awaitingState(String(state.state).toLowerCase())
+    && (state.options?.length ?? 0) > 0;
+  const rowPresentsPrompt = awaitingState(String(sess?.state ?? '').toLowerCase())
+    && rowOptions.length > 0;
+  const focused = focusedEvent && !(rowPresentsPrompt && !eventPresentsPrompt);
   const sState = (focused ? state.state : (sess?.state ?? 'idle')).toLowerCase();
-  const options = (focused ? state.options : (sess?.options ?? [])) ?? [];
+  const options = (focused ? state.options : rowOptions) ?? [];
   // Whatever question these options belong to, echoed back on a press so the
   // daemon can tell an answer apart from one aimed at a superseded question.
   const question = (focused ? (state.question ?? sess?.question) : sess?.question) || undefined;
@@ -974,9 +992,14 @@ function buildDetail(
       // the cells stay display-only. Always select_option when answerable (the
       // observed route acts on that command only); a shortcut-`respond` has no
       // observed meaning.
-      const observedAnswerable = isObserved && Boolean(sess?.liveAnswerable);
+      // `liveAnswerable` means "the daemon can deliver this answer" — it is not
+      // an observed-only concept. The OpenClaw Gateway row sets it too (the
+      // daemon resolves the approval over the Gateway RPC), and it has no
+      // terminal, so gating the live path on `isObserved` left its options
+      // rendering as an inert mirror of a prompt nobody could reach.
+      const answerable = Boolean(sess?.liveAnswerable);
       options.forEach((opt, i) => {
-        const command: ButtonCommand = (navigable || observedAnswerable)
+        const command: ButtonCommand = (navigable || answerable)
           // The question echo lets the daemon drop a press aimed at a question
           // a multi-group AskUserQuestion has already moved past, instead of
           // applying its index to the new option list.
@@ -989,7 +1012,7 @@ function buildDetail(
           : { type: 'respond', value: opt.shortcut || opt.label?.charAt(0)?.toLowerCase() || String(i + 1) };
         cells.push({
           svg: renderOptionButton(opt, i),
-          action: (isObserved && !observedAnswerable) ? null : { kind: 'command', command },
+          action: (isObserved && !answerable) ? null : { kind: 'command', command },
         });
       });
     } else if (isObserved && gateRequestId) {

--- a/shared/src/gateway-protocol.ts
+++ b/shared/src/gateway-protocol.ts
@@ -10,6 +10,12 @@
  * under `generated/protocol/`, ensuring protocol parity across the three implementations.
  */
 
+import type {
+  ExecApprovalDecision,
+  ExecApprovalRequestedPayload,
+  ExecApprovalResolvedPayload,
+} from './openclaw-approval.js';
+
 // ===== Protocol version =====
 
 /** Protocol major version. Bridge rejects mismatched Gateway versions. */
@@ -69,6 +75,7 @@ export type GatewayMethodName =
   | 'chat.send'
   | 'chat.abort'
   | 'exec.approval.resolve'
+  | 'exec.approval.list'
   | 'sessions.list'
   | 'sessions.subscribe'
   | 'sessions.messages.subscribe'
@@ -82,6 +89,7 @@ export type GatewayMethodParams =
   | ChatSendParams
   | ChatAbortParams
   | ExecApprovalResolveParams
+  | ExecApprovalListParams
   | SessionsListParams
   | SessionsSubscribeParams
   | SessionsMessagesSubscribeParams
@@ -95,6 +103,7 @@ export type GatewayMethodResult =
   | ChatSendResult
   | ChatAbortResult
   | ExecApprovalResolveResult
+  | ExecApprovalListResult
   | SessionsListResult
   | SessionsSubscribeResult
   | SessionsMessagesSubscribeResult
@@ -245,15 +254,34 @@ export interface ChatAbortResult {
   aborted: boolean;
 }
 
-// exec.approval.resolve — allow/deny a tool execution approval
+// exec.approval.resolve — resolve a pending tool execution approval.
+//
+// `decision` is NOT free-form: the Gateway validates it against
+// `isApprovalDecision` BEFORE it looks the id up, so an unsupported spelling
+// (notably the plain `'allow'` this type used to declare) is rejected with
+// INVALID_REQUEST and the approval stays pending forever. The vocabulary lives
+// in `openclaw-approval.ts` and is derived from OpenClaw's own bundle.
 export interface ExecApprovalResolveParams {
   id: string;
-  decision: 'allow' | 'deny';
+  decision: ExecApprovalDecision;
 }
 
+/** The Gateway answers `{ ok: true }`; `resolved` is kept for older builds. */
 export interface ExecApprovalResolveResult {
-  resolved: boolean;
+  ok?: boolean;
+  resolved?: boolean;
 }
+
+// exec.approval.list — the approvals currently waiting for a decision.
+//
+// `exec.approval.requested` is a broadcast, never replayed: a client that
+// connects while an approval is already outstanding hears nothing about it. So
+// a daemon restart or a Gateway reconnect used to leave the agent blocked with
+// an empty deck and no way to find out. This is the catch-up read.
+export interface ExecApprovalListParams {}
+
+/** Same element shape as the requested event, minus the envelope. */
+export type ExecApprovalListResult = ExecApprovalRequestedPayload[];
 
 // sessions.list — enumerate active Gateway sessions
 export interface SessionsListParams {
@@ -313,6 +341,7 @@ export interface GatewayMethodMap {
   'chat.send': { params: ChatSendParams; result: ChatSendResult };
   'chat.abort': { params: ChatAbortParams; result: ChatAbortResult };
   'exec.approval.resolve': { params: ExecApprovalResolveParams; result: ExecApprovalResolveResult };
+  'exec.approval.list': { params: ExecApprovalListParams; result: ExecApprovalListResult };
   'sessions.list': { params: SessionsListParams; result: SessionsListResult };
   'sessions.subscribe': { params: SessionsSubscribeParams; result: SessionsSubscribeResult };
   'sessions.messages.subscribe': { params: SessionsMessagesSubscribeParams; result: SessionsMessagesSubscribeResult };
@@ -384,21 +413,12 @@ export interface ChatToolInvocation {
   status?: 'pending' | 'success' | 'error';
 }
 
-export interface ExecApprovalRequestedPayload {
-  id: string;
-  sessionKey?: string;
-  tool: string;
-  command?: string;
-  reason?: string;
-  /** Options surfaced to the user (default: allow/deny). */
-  options?: Array<{ key: string; label: string }>;
-}
-
-export interface ExecApprovalResolvedPayload {
-  id: string;
-  decision: 'allow' | 'deny' | 'timeout';
-  sessionKey?: string;
-}
+// `ExecApprovalRequestedPayload` / `ExecApprovalResolvedPayload` are defined in
+// `openclaw-approval.ts` alongside the parser that normalizes them. They used to
+// be declared here from an assumed shape (`tool`, `reason`, a flat `command`,
+// `options:[{key,label}]`) — none of which the Gateway sends — which is why the
+// approval prompt reached every device with no command text on it.
+export type { ExecApprovalRequestedPayload, ExecApprovalResolvedPayload };
 
 export interface GatewayPresenceEntry {
   connected: boolean;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './states.js';
 export * from './protocol.js';
+export * from './openclaw-approval.js';
 export * from './gateway-protocol.js';
 export * from './command-builders.js';
 export * from './adapter.js';

--- a/shared/src/openclaw-approval.ts
+++ b/shared/src/openclaw-approval.ts
@@ -1,0 +1,276 @@
+/**
+ * openclaw-approval.ts — SSOT for OpenClaw exec-approval prompts.
+ *
+ * WHY THIS FILE EXISTS. The approval surface was originally typed from an
+ * assumption rather than from OpenClaw's own SDK, and every part of that guess
+ * was wrong in a way that failed silently:
+ *
+ *  - The `exec.approval.requested` event was read as a FLAT payload
+ *    (`payload.command` / `payload.ask`). The Gateway actually nests the whole
+ *    thing under `request` (`buildRequestedApprovalEvent` →
+ *    `{ id, request, createdAtMs, expiresAtMs }`), so every field read as
+ *    `undefined` and the prompt collapsed to the literal fallback string
+ *    "Approve tool execution?" — the user could see that something wanted
+ *    approval but never WHAT.
+ *  - `ask` is the approval POLICY ("on-miss" / "always"), not a question. It
+ *    was being rendered as if it were the human-readable ask.
+ *  - The decision vocabulary was typed as `'allow' | 'deny'`. The Gateway
+ *    accepts only `'allow-once' | 'allow-always' | 'deny'` (its
+ *    `isApprovalDecision`), and validates the decision BEFORE it looks the
+ *    approval id up — so every "allow" AgentDeck ever sent came back
+ *    INVALID_REQUEST and the approval stayed pending. The wrong vocabulary was
+ *    baked into the shared TypeScript type, so the compiler actively enforced
+ *    the unusable value.
+ *
+ * The lesson that keeps this file honest: the requested format lives in THEIR
+ * SDK. Everything below is derived from the OpenClaw gateway bundle
+ * (`approval-shared`, `exec-approval`, `exec-approvals`), not from inference.
+ *
+ * Parsing is pure and lives here so the Node adapter, the Swift daemon mirror,
+ * and the tests all agree on one normalization.
+ */
+
+/**
+ * The decisions the Gateway will accept for an exec approval.
+ * Mirror of OpenClaw's `isApprovalDecision` / `DEFAULT_EXEC_APPROVAL_DECISIONS`.
+ * `'allow'` is NOT a member — sending it is rejected as an invalid decision.
+ */
+export type ExecApprovalDecision = 'allow-once' | 'allow-always' | 'deny';
+
+/** Full decision set, in the order the Gateway lists them. */
+export const EXEC_APPROVAL_DECISIONS: readonly ExecApprovalDecision[] = [
+  'allow-once',
+  'allow-always',
+  'deny',
+];
+
+export function isExecApprovalDecision(value: unknown): value is ExecApprovalDecision {
+  return value === 'allow-once' || value === 'allow-always' || value === 'deny';
+}
+
+/** `true` for the decisions that let the command run. */
+export function execApprovalAllows(decision: string | null | undefined): boolean {
+  return decision === 'allow-once' || decision === 'allow-always';
+}
+
+/**
+ * Device-facing labels. Kept short because they land on 72×72 Stream Deck keys
+ * and D200H cells; `shortcut` is what a non-navigable `respond` press carries.
+ */
+const DECISION_DISPLAY: Record<ExecApprovalDecision, { label: string; shortcut: string }> = {
+  'allow-once': { label: 'Allow once', shortcut: 'y' },
+  'allow-always': { label: 'Always allow', shortcut: 'a' },
+  deny: { label: 'Deny', shortcut: 'n' },
+};
+
+export function execApprovalDecisionLabel(decision: ExecApprovalDecision): string {
+  return DECISION_DISPLAY[decision].label;
+}
+
+/** The `request` body OpenClaw nests inside the requested event. */
+export interface ExecApprovalRequestBody {
+  /** Sanitized command display text — the thing the user is approving. */
+  command?: string;
+  /** Non-node hosts send a preview instead of the full command. */
+  commandPreview?: string;
+  commandArgv?: string[];
+  cwd?: string | null;
+  host?: string | null;
+  /** Approval POLICY ("on-miss" | "always" | …), never a question. */
+  ask?: string | null;
+  security?: string | null;
+  /** Human-readable risk note, when the Gateway produced one. */
+  warningText?: string | null;
+  /** Gateway-side static analysis summary of the command. */
+  commandAnalysis?: string | null;
+  /** Decisions this specific request permits (policy may drop allow-always). */
+  allowedDecisions?: string[];
+  unavailableDecisions?: string[];
+  agentId?: string | null;
+  sessionKey?: string | null;
+  resolvedPath?: string | null;
+}
+
+/**
+ * `exec.approval.requested` payload. The nested `request` is the real shape;
+ * the flat fields are tolerated so a future/legacy Gateway that inlines them
+ * still parses instead of silently producing an empty prompt.
+ */
+export interface ExecApprovalRequestedPayload extends Partial<ExecApprovalRequestBody> {
+  id: string;
+  request?: ExecApprovalRequestBody;
+  createdAtMs?: number;
+  expiresAtMs?: number;
+}
+
+/** `exec.approval.resolved` payload (`buildResolvedEvent` in exec-approval). */
+export interface ExecApprovalResolvedPayload {
+  id: string;
+  decision: ExecApprovalDecision | string;
+  resolvedBy?: string | null;
+  ts?: number;
+  request?: ExecApprovalRequestBody;
+}
+
+/** One renderable choice on a deck surface. */
+export interface ExecApprovalOption {
+  index: number;
+  label: string;
+  shortcut: string;
+  decision: ExecApprovalDecision;
+}
+
+/**
+ * Normalized prompt — what every surface renders and what an answer maps back
+ * through. Deliberately carries the decision on each option so an index press
+ * can never be re-derived (and mis-derived) at the answer site.
+ */
+export interface OpenClawApprovalPrompt {
+  id: string;
+  /** Headline: the command itself, so the user knows what they are approving. */
+  question: string;
+  /** Supporting lines (cwd, warning, analysis) for surfaces with room. */
+  detail?: string;
+  /** Raw command text, unprefixed — for the timeline row. */
+  command: string;
+  cwd?: string;
+  options: ExecApprovalOption[];
+  /** Wall-clock expiry, when the Gateway set one. */
+  expiresAtMs?: number;
+  requestedAtMs: number;
+  sessionKey?: string;
+}
+
+function firstNonEmpty(...values: Array<unknown>): string | undefined {
+  for (const v of values) {
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Which decisions this request permits. The Gateway computes `allowedDecisions`
+ * per-request (an `ask: "always"` policy drops `allow-always`), so honor what it
+ * sent and fall back to the full set only when it sent nothing — never invent a
+ * decision the request forbids, which comes back as
+ * "allow-always is unavailable because the effective policy requires approval
+ * every time".
+ */
+function resolveDecisions(body: ExecApprovalRequestBody): ExecApprovalDecision[] {
+  const allowed = Array.isArray(body.allowedDecisions)
+    ? body.allowedDecisions.filter(isExecApprovalDecision)
+    : [];
+  const base = allowed.length > 0 ? allowed : [...EXEC_APPROVAL_DECISIONS];
+  const unavailable = new Set(
+    Array.isArray(body.unavailableDecisions) ? body.unavailableDecisions : [],
+  );
+  const kept = base.filter((d) => !unavailable.has(d));
+  // Deny must always be offered: a prompt the user can only accept is not a
+  // prompt. If the policy filtering emptied the set, fall back to deny alone.
+  return kept.length > 0 ? kept : ['deny'];
+}
+
+/**
+ * Normalize a raw `exec.approval.requested` payload. Returns `null` only when
+ * the payload carries no usable id — a request with no command text still
+ * produces a prompt (labeled as unknown) so the user keeps the ability to deny.
+ */
+export function parseExecApprovalRequest(
+  payload: ExecApprovalRequestedPayload | Record<string, unknown> | null | undefined,
+  nowMs: number,
+): OpenClawApprovalPrompt | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const raw = payload as ExecApprovalRequestedPayload;
+  const id = typeof raw.id === 'string' ? raw.id.trim() : '';
+  if (!id) return null;
+
+  // Nested `request` is authoritative; the flat spread is the compatibility
+  // path only. Merging (rather than picking one) means a Gateway that moves a
+  // field between the two levels degrades instead of blanking the prompt.
+  const body: ExecApprovalRequestBody = { ...raw, ...(raw.request ?? {}) };
+
+  const command = firstNonEmpty(
+    body.command,
+    body.commandPreview,
+    Array.isArray(body.commandArgv) ? body.commandArgv.join(' ') : undefined,
+  ) ?? '';
+
+  const cwd = firstNonEmpty(body.cwd ?? undefined);
+  const detailParts: string[] = [];
+  if (cwd) detailParts.push(`cwd: ${cwd}`);
+  const warning = firstNonEmpty(body.warningText ?? undefined);
+  if (warning) detailParts.push(warning);
+  const analysis = firstNonEmpty(body.commandAnalysis ?? undefined);
+  if (analysis && analysis !== warning) detailParts.push(analysis);
+
+  const options: ExecApprovalOption[] = resolveDecisions(body).map((decision, index) => ({
+    index,
+    label: DECISION_DISPLAY[decision].label,
+    shortcut: DECISION_DISPLAY[decision].shortcut,
+    decision,
+  }));
+
+  return {
+    id,
+    // No command text is a degraded prompt, not a broken one — say so plainly
+    // rather than falling back to a string that reads like a normal ask.
+    question: command || 'Approve tool execution (command not reported)',
+    ...(detailParts.length > 0 ? { detail: detailParts.join('\n') } : {}),
+    command,
+    ...(cwd ? { cwd } : {}),
+    options,
+    ...(typeof raw.expiresAtMs === 'number' ? { expiresAtMs: raw.expiresAtMs } : {}),
+    requestedAtMs: typeof raw.createdAtMs === 'number' ? raw.createdAtMs : nowMs,
+    ...(firstNonEmpty(body.sessionKey ?? undefined)
+      ? { sessionKey: firstNonEmpty(body.sessionKey ?? undefined) }
+      : {}),
+  };
+}
+
+/** Map a `select_option` index onto the decision that option represents. */
+export function decisionForOptionIndex(
+  prompt: OpenClawApprovalPrompt,
+  index: number,
+): ExecApprovalDecision | null {
+  const byIndex = prompt.options.find((o) => o.index === index);
+  return byIndex ? byIndex.decision : null;
+}
+
+/**
+ * Map a `respond` value onto a decision. Accepts the option shortcut, the
+ * decision name itself, and the y/n/a spellings a hardware key or the wake-word
+ * assistant sends. Anything unrecognized returns `null` — an ambiguous press
+ * must never be guessed into an approval.
+ */
+export function decisionForRespondValue(
+  prompt: OpenClawApprovalPrompt,
+  value: string,
+): ExecApprovalDecision | null {
+  const v = value.trim().toLowerCase();
+  if (!v) return null;
+  const byDecision = prompt.options.find((o) => o.decision === v);
+  if (byDecision) return byDecision.decision;
+  const byShortcut = prompt.options.find((o) => o.shortcut === v);
+  if (byShortcut) return byShortcut.decision;
+  const byLabel = prompt.options.find((o) => o.label.toLowerCase() === v);
+  if (byLabel) return byLabel.decision;
+  const alias: Record<string, ExecApprovalDecision> = {
+    y: 'allow-once',
+    yes: 'allow-once',
+    allow: 'allow-once',
+    once: 'allow-once',
+    a: 'allow-always',
+    always: 'allow-always',
+    n: 'deny',
+    no: 'deny',
+    reject: 'deny',
+  };
+  const mapped = alias[v];
+  if (!mapped) return null;
+  // Honor the request's own policy: if it forbids allow-always, a spoken
+  // "always" must not silently become a one-shot allow either — refuse.
+  return prompt.options.some((o) => o.decision === mapped) ? mapped : null;
+}


### PR DESCRIPTION
An OpenClaw exec approval pinned every deck on `PERMIT?` with nothing on it and no button that worked. Three independent defects, each silent, all from one root: **the approval surface was typed from an assumption instead of from OpenClaw's SDK.**

## What was broken

**1. The payload was read flat.** `exec.approval.requested` nests everything under `request` (`buildRequestedApprovalEvent` → `{id, request, createdAtMs, expiresAtMs}`). The adapter read `payload.command` / `payload.ask`, so every field was `undefined` and the prompt collapsed to the literal `"Approve tool execution?"`. `ask` is the *policy* (`on-miss`/`always`), never a question, and was being concatenated on as though it were one. `ExecApprovalRequestedPayload` declared `tool`, `reason`, `options:[{key,label}]` — none of which the Gateway sends.

**2. The decision was a value the Gateway rejects.** It accepts `allow-once` / `allow-always` / `deny`, and validates the decision **before** it looks the id up. We sent `'allow'`, so every press from every surface came back `INVALID_REQUEST` — into a `debug()` line that is off by default. The unusable spelling was baked into the shared TS type, so the compiler enforced it. Swift was worse: it forwarded the raw device command (`{type:"select_option", index:0}`) as the RPC params, with no `decision` at all.

**3. A cancelled run stranded the prompt.** A run cancelled under an outstanding approval emits no `exec.approval.resolved`, so nothing ever closed the prompt or the `tool_request` row. The mirror image also happened: the turn ending set the row to idle while the approval still blocked the agent.

Two more holes the fix exposed:

**4. No catch-up on reconnect.** `exec.approval.requested` is a broadcast and is never replayed, so a daemon restart under a pending approval left the agent blocked and the deck empty. `exec.approval.list` is the catch-up read, now on both daemons.

**5. The deck read a contaminated global state.** The detail view trusted `focusedSessionId` on the daemon's GLOBAL `state_update`; that machine is fed by every observed hook session, so an unrelated Claude turn going idle erased the approval from the screen. And the pressable-option path was gated on `controlMode === 'observed'`, so the `managed` Gateway row rendered its options as a dead mirror — of a prompt with no terminal to fall back to.

## The fix

- **`shared/src/openclaw-approval.ts` is the SSOT.** Parses the real payload, honors the request's own `allowedDecisions` (a policy may withhold `allow-always`), always keeps a deny, and maps an index or a shortcut onto a decision. `pnpm generate-openclaw-approval-rules` emits the Swift mirror. The drift gate pins both the vocabulary and the nesting — "the two mirrors agree" was true the entire time they were both wrong.
- **The virtual `openclaw-gateway` row carries `question` / `options` / `liveAnswerable`**, which every deck already knows how to render. `liveAnswerable` stops being observed-only: it means "the daemon can deliver this answer", and the Gateway row qualifies.
- **A failed resolve keeps the prompt up and says so**, instead of clearing optimistically and stranding both the user and the agent.
- **`updateEntryStatus` gets its first production caller**, so an answered approval stops reading as pending forever.

## Verification

Live, on the running daemon: after a restart, an approval outstanding **since before the restart** was adopted on connect and surfaced with its full command text and the two decisions that request actually permitted (`allow-always` correctly withheld by policy — the old code hardcoded Allow/Deny regardless).

- vitest **3153 passed | 1 skipped**, 197 files (46 new tests; every fixture is a real Gateway frame shape)
- macOS and iOS Xcode targets: `BUILD SUCCEEDED`
- `docs:check`, `verify-version`, `design-system:check` pass; generators are idempotent

## Note

The daemon-side fix is what makes the approval readable and answerable. The Stream Deck and Ulanzi plugins ship their own bundled builds, so the renderer change in (5) lands for them on their next plugin release; the row already carries the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)