### PR TITLE
Draw Kiro as Kiro, or as nothing — never as Claude

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,86 @@
 
 ---
 
+## 2026-08-17 — Kiro 는 어디에 반영되었나: 표면별 실측과 세 가지 결함
+
+### 계기
+
+"Kiro CLI 가 기기별로 다 반영되었나? macOS Dashboard 만 거의 제대로 나오는 것 같은데."
+표면별로 에이전트 종류를 열거하는 지점을 전수 비교했다(`opencode` 가 있는데 `kiro` 가
+없는 파일). 답은 **아니오**였고, 결함은 세 종류로 갈렸다.
+
+### 1. 잘못 표시 — TUI 가 Kiro 를 Claude 문어로 그렸다
+
+`bridge/src/tui/terrarium.ts` 의 `setOctopi` 가 **거부목록**이었다:
+
+```ts
+sessions.filter(s => s.agentType !== 'daemon' && ... !== 'opencode')
+```
+
+"이 다섯이 아니면 전부 Claude 문어"라는 뜻이므로, 그 뒤에 추가된 에이전트는 **전부**
+Claude 로 헤엄쳤다 — Kiro 두 종류와 Antigravity 가 그랬다. CLAUDE.md 가 명시한 폴백
+극성 규칙("미지의 agentType 은 아무것도 아니거나 중립으로 — 절대 남의 정체성으로")의
+정확한 위반이고, 2026-08-16 에 Kiro 를 머지하며 Stream Deck·Pixoo·양쪽 앱은 고쳤지만
+TUI 한 곳이 남아 있었다.
+
+허용목록(`=== 'claude-code'`)으로 뒤집었다. 결과적으로 Kiro/Antigravity 는 TUI 수조에서
+**안 보이게** 되는데, 그게 옳다 — 틀린 정체성보다 없는 편이 낫다.
+
+기존 테스트가 이걸 못 잡은 이유도 같이 고쳤다: fixture 가 `agentType` 을 **아예 안 넘겼다**.
+코드가 분기하는 필드를 fixture 가 비워두면 어느 쪽으로 고쳐도 green 이다. 실제 모양
+(데몬은 항상 agentType 을 보낸다)으로 바꾸고, **극성을 고정하는** 게이트를 넣었다 —
+멤버십이 아니라 극성이라 진짜 에이전트를 추가할 때 테스트를 고칠 필요가 없다.
+
+### 2. 안 보임 — Kiro 세션의 타임라인이 양쪽 앱에서 비어 있었다
+
+관측 세션은 `sessions_list` 와 기기에서 `observed:<agent>:<uuid>` 로, 타임라인 행·훅
+페이로드·transcript 에서는 **맨 uuid** 로 키잉된다. `session-utils.ts` 의 SSOT 주석은
+이미 이렇게 적고 있었다 — *"같은 정규식이 네 곳에 인라인돼 세 가지 다른 에이전트 목록으로
+갈라졌다. 에이전트는 호출 지점이 아니라 여기에 추가하라."*
+
+그 "호출 지점이 아니라"가 모바일 두 곳에는 닿지 않았다. `canonicalTimelineSessionId` 가
+Swift(`Model/Timeline.swift`)와 Kotlin(`state/TimelineDisplay.kt`)에 손으로 미러돼 있었고,
+**둘 다 Kiro 두 키가 없었다.** 그래서 Kiro 세션을 선택하면 접두어가 안 벗겨져 어떤 행과도
+매칭되지 않고 상세 화면이 텅 비었다. 사용자가 "macOS 만 거의 제대로"라고 느낀 "거의"가 이것이다.
+
+같은 부류로 관측 `tool_exec` 억제 목록(4미러 규칙)도 Swift `TimelineStripView` 와 Kotlin
+`TimelineDisplay` 에서 Kiro 가 빠져 있었다 — Kiro 턴의 도구 행이 자기 프롬프트·응답 행을
+바운디드 버퍼에서 밀어낸다.
+
+두 목록 다 **생성기로 옮겼다**(`shared` → `pnpm generate-observed-agent-rules` →
+Swift/Kotlin, vitest 드리프트 게이트). 목록이 짧아서 손 미러가 공짜처럼 보이지만, 비용은
+**에이전트를 추가할 때마다 조용해지는 표면 하나**다. 게이트는 호출 지점에 멤버십이 다시
+적히는 것도 잡는다.
+
+### 3. 중립이지만 안 보임 — ESP32
+
+극성은 **옳다**(허용목록 + 중립 폴백). 다만 Kiro 는:
+
+- ticker / pocket: `agentColor` 폴백 `HUDDim` → 회색 행(라벨은 `agent_label.h` 덕에 "Kiro CLI" 로 정확)
+- IPS10 hud_bar: `ips10AgentGlyph` → `nullptr` → 글리프 대신 점
+- LED matrix: `matrix_pages.cpp` 가 `continue` → **행 자체가 안 나옴**
+- 수조(terrarium): Kiro 크리처 없음
+
+반대로 office 씬 / knob / e-ink 는 Kiro 색·라벨·글리프(KIRO_A8)를 이미 갖고 있다.
+펌웨어 변경은 OTA 컷 + 하드웨어 검증이 필요해 별도 작업으로 남긴다.
+
+### 이미 맞던 곳
+
+shared SSOT 전부(라벨·색·로고/크리처 아이콘·정렬 가중치·adapter 타입), Apple 앱
+(`KiroCreature.swift` + 라벨 4곳), Stream Deck, Ulanzi D200H(둘 다 공용 `renderSessionSlot`
+경유), Pixoo/Timebox/iDotMatrix(마스크·색·크리처 레이아웃).
+
+### 교훈
+
+- **"머지했다"는 표면별 질문이다.** Kiro 관측은 8월 16일에 머지됐지만, 그건 데몬이 Kiro 를
+  *본다*는 뜻이었지 열 개 표면이 그걸 *그린다*는 뜻이 아니었다. 새 에이전트는 열거 지점의
+  수만큼 반영 작업이 있다.
+- **거부목록으로 쓴 폴백은 미래의 모든 에이전트를 남의 정체성으로 만든다.** 극성은 멤버십과
+  달리 테스트로 고정할 수 있고, 그래야 한다.
+- **SSOT 주석에 "여기에 추가하라"라고 적는 것만으로는 손 미러가 안 따라온다.** 게이트가 없는
+  규칙은 규칙이 아니라 희망이다.
+
+---
 ## 2026-08-17 — "같은 머신"과 "나"는 다른 질문이다 (로드맵 P0 1~5)
 
 ### 문제

--- a/android/app/src/main/kotlin/dev/agentdeck/state/ObservedAgentRules.generated.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/state/ObservedAgentRules.generated.kt
@@ -1,0 +1,42 @@
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: shared/src/session-utils.ts (OBSERVED_SESSION_AGENT_KEYS)
+//                  shared/src/timeline.ts      (TOOL_EXEC_SUPPRESSED_AGENTS)
+// Regenerate: pnpm generate-observed-agent-rules (drift gated by shared/src/__tests__/observed-agent-rules.test.ts)
+package dev.agentdeck.state
+
+/**
+ * Observed-session id prefixes and the agents whose observed tool rows stay out
+ * of the timeline. See the TypeScript sources for why these are generated
+ * rather than written twice.
+ */
+object ObservedAgentRules {
+    /** A passively-observed session is keyed `observed:<agent>:<uuid>` in
+     *  `sessions_list` and on devices, while timeline rows, hook payloads and
+     *  transcripts use the bare uuid. */
+    val SESSION_PREFIXES: List<String> = listOf(
+        "observed:claude:",
+        "observed:codex:",
+        "observed:codex-app:",
+        "observed:opencode:",
+        "observed:antigravity:",
+        "observed:kiro:",
+        "observed:kiro-ide:",
+    )
+
+    /** Agents whose observed per-tool rows would drown their own prompt and
+     *  response rows in the bounded timeline buffer. */
+    val TOOL_EXEC_SUPPRESSED: Set<String> = setOf(
+        "codex-cli",
+        "codex-app",
+        "opencode",
+        "antigravity",
+        "kiro-cli",
+        "kiro-ide",
+    )
+
+    /** Bare id form — unchanged when the id carries no observed prefix. */
+    fun rawSessionId(value: String): String {
+        val prefix = SESSION_PREFIXES.firstOrNull { value.startsWith(it) } ?: return value
+        return value.removePrefix(prefix)
+    }
+}

--- a/android/app/src/main/kotlin/dev/agentdeck/state/TimelineDisplay.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/state/TimelineDisplay.kt
@@ -162,7 +162,7 @@ internal fun isLowSignalEntry(entry: TimelineEntry): Boolean {
     // included forward-compat (the observed-hook classifier already accepts
     // antigravity_* events).
     val isSubagentLifecycle = entry.type == "tool_exec" && entry.summary.trimStart().startsWith("Subagent ")
-    if (!isSubagentLifecycle && (entry.agentType == "codex-cli" || entry.agentType == "codex-app" || entry.agentType == "opencode" || entry.agentType == "antigravity") && entry.type == "tool_exec") {
+    if (!isSubagentLifecycle && ObservedAgentRules.TOOL_EXEC_SUPPRESSED.contains(entry.agentType) && entry.type == "tool_exec") {
         return true
     }
     // Real signal in detail → keep regardless of placeholder raw. The
@@ -377,6 +377,8 @@ data class TimelineSessionFilter(
                 "codex-app" -> "Codex App"
                 "opencode" -> "OpenCode"
                 "antigravity" -> "Antigravity"
+                "kiro-cli" -> "Kiro CLI"
+                "kiro-ide" -> "Kiro IDE"
                 else -> sessionId
             }
         }
@@ -388,14 +390,10 @@ data class TimelineSessionFilter(
  * `canonicalTimelineSessionId` and Node `getHistoryForSession`. */
 fun canonicalTimelineSessionId(value: String?): String? {
     val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-    val prefixes = listOf(
-        "observed:claude:",
-        "observed:codex:",
-        "observed:codex-app:",
-        "observed:opencode:",
-        "observed:antigravity:",
-    )
-    val prefix = prefixes.firstOrNull { trimmed.startsWith(it) } ?: return trimmed
+    // Generated from the TypeScript source rather than written here: this list
+    // was hand-mirrored and drifted, missing both Kiro keys, so selecting a
+    // Kiro session matched no rows and its timeline came up empty.
+    val prefix = ObservedAgentRules.SESSION_PREFIXES.firstOrNull { trimmed.startsWith(it) } ?: return trimmed
     return trimmed.removePrefix(prefix).trim().takeIf { it.isNotEmpty() }
 }
 

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/eink/EinkEventLog.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/eink/EinkEventLog.kt
@@ -182,6 +182,8 @@ private fun sourceTag(entry: TimelineEntry): String {
         "codex-app" -> "Codex App "
         "opencode" -> "OpenCode "
         "antigravity" -> "Antigravity "
+        "kiro-cli" -> "Kiro CLI "
+        "kiro-ide" -> "Kiro IDE "
         null -> ""
         else -> "Agent "
     }

--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		441CE4E0A61236F1346DAFFC /* DevicePreviewShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46AB7A0263C3AFB217C9DF13 /* DevicePreviewShared.swift */; };
 		447BEA00A4A2B8DA5DEC15AF /* TimelineStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F37E295246F5931D533E31 /* TimelineStripView.swift */; };
 		4492EC65271E1C630601393F /* UsageAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBD731AC01994F5C7C1A78A /* UsageAPIClient.swift */; };
+		44DF8C2AE35CEC24AC9C2460 /* ObservedAgentRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12945AF4A45F5245F2FC6672 /* ObservedAgentRules.generated.swift */; };
 		4578F976C71274F3C7C2620C /* InkDeckPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8404D4037BF665BA54E03F0 /* InkDeckPreview.swift */; };
 		45C2A8320BF4C10E8106CF6B /* OpenClawToolNoiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BC4C62CBEEE99555CED707 /* OpenClawToolNoiseTests.swift */; };
 		45F924FE8D817EB16CA71345 /* DaemonActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69470A0782BDF6A29012E9F0 /* DaemonActor.swift */; };
@@ -292,6 +293,7 @@
 		A8293F557BD8D3FB91BF4CF4 /* StateTimelineGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C2485BC8700CBDD9EDE70E /* StateTimelineGenerator.swift */; };
 		A869C24476DAE485D0B950EC /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6B05AD3CC720BD76A681F9 /* QRScannerView.swift */; };
 		AA5C41BFDE43A8EDC2C85AA3 /* TerrariumRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF3CC89437DF95538AA2AE5 /* TerrariumRules.generated.swift */; };
+		AB96439EFAFE10B03D547935 /* ObservedAgentRules.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12945AF4A45F5245F2FC6672 /* ObservedAgentRules.generated.swift */; };
 		ABE80C830C69CB0A2D03A767 /* LightRaySystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4A08898B95CB592E133A /* LightRaySystem.swift */; };
 		ABEE4D6EFD64ECCBDBCD843B /* AntigravityCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB382D6E482410C30E597EC /* AntigravityCreature.swift */; };
 		AC658605D32EEDED79556598 /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6B05AD3CC720BD76A681F9 /* QRScannerView.swift */; };
@@ -486,6 +488,7 @@
 		0F083DDE39507B6693AED227 /* ApmeCategoryE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApmeCategoryE2ETests.swift; sourceTree = "<group>"; };
 		118F64508CC1FE2827516440 /* LocalCodexAppObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCodexAppObserver.swift; sourceTree = "<group>"; };
 		125A43BCFF7E55A34B4C5FC1 /* AgentDeckLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDeckLogo.swift; sourceTree = "<group>"; };
+		12945AF4A45F5245F2FC6672 /* ObservedAgentRules.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedAgentRules.generated.swift; sourceTree = "<group>"; };
 		15083D65B8571C662DD6E2CE /* PortDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortDiagnostics.swift; sourceTree = "<group>"; };
 		1603E1F58E35F85044D7913A /* MicroGlyphs.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroGlyphs.generated.swift; sourceTree = "<group>"; };
 		165E4184E24C198326D600A6 /* HookIdleTTLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookIdleTTLTests.swift; sourceTree = "<group>"; };
@@ -1165,6 +1168,7 @@
 				979988BB4CB2A4B5948FD360 /* Adapter.swift */,
 				F15F55435772A15B8F0E92C1 /* AgentState.swift */,
 				9DC487120E810897B3BF0FC4 /* CodexFreshnessRules.generated.swift */,
+				12945AF4A45F5245F2FC6672 /* ObservedAgentRules.generated.swift */,
 				9C75E7B3676BD283B9A4BE27 /* PairingCodeRules.generated.swift */,
 				E532E5457B6DFDE324D8F11C /* Protocol.swift */,
 				BBAB8DFED8E277FFB6136742 /* SessionGrouping.swift */,
@@ -1590,6 +1594,7 @@
 				F5B2BB7991E7283F4B99902F /* MonitorHUD.swift in Sources */,
 				DCDA12FC8E9B9961BA2D8182 /* MonitorScreen.swift in Sources */,
 				385B3F4A96DFFFBC72851371 /* NotificationPermission.swift in Sources */,
+				AB96439EFAFE10B03D547935 /* ObservedAgentRules.generated.swift in Sources */,
 				4D747DC11E54E8A60894D481 /* ObservedSteering.swift in Sources */,
 				4B34D6CBC040FE9BE5E51856 /* OctopusCreature.swift in Sources */,
 				F1C357A840E59D7A188C808B /* OnboardingScreen.swift in Sources */,
@@ -1776,6 +1781,7 @@
 				DEBCF013EEAB22462CF0044C /* MonitorHUD.swift in Sources */,
 				A50EA56C00F6A51F498DD20E /* MonitorScreen.swift in Sources */,
 				0ED91B65645B05541D82E446 /* NotificationPermission.swift in Sources */,
+				44DF8C2AE35CEC24AC9C2460 /* ObservedAgentRules.generated.swift in Sources */,
 				48B83035D9FC3732361014F8 /* ObservedSteering.swift in Sources */,
 				CCB2A2848DDAADBEB6F7BB53 /* OctopusCreature.swift in Sources */,
 				BF6E216F74A8205677B8B82B /* OnboardingScreen.swift in Sources */,

--- a/apple/AgentDeck/Model/ObservedAgentRules.generated.swift
+++ b/apple/AgentDeck/Model/ObservedAgentRules.generated.swift
@@ -1,0 +1,44 @@
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: shared/src/session-utils.ts (OBSERVED_SESSION_AGENT_KEYS)
+//                  shared/src/timeline.ts      (TOOL_EXEC_SUPPRESSED_AGENTS)
+// Regenerate: pnpm generate-observed-agent-rules (drift gated by shared/src/__tests__/observed-agent-rules.test.ts)
+
+import Foundation
+
+/// Observed-session id prefixes and the agents whose observed tool rows stay
+/// out of the timeline. See the TypeScript sources for why these are generated
+/// rather than written twice.
+enum ObservedAgentRules {
+    /// A passively-observed session is keyed `observed:<agent>:<uuid>` in
+    /// `sessions_list` and on devices, while timeline rows, hook payloads and
+    /// transcripts use the bare uuid — so anything comparing one against the
+    /// other must strip this first.
+    static let sessionPrefixes: [String] = [
+        "observed:claude:",
+        "observed:codex:",
+        "observed:codex-app:",
+        "observed:opencode:",
+        "observed:antigravity:",
+        "observed:kiro:",
+        "observed:kiro-ide:",
+    ]
+
+    /// Agents whose observed per-tool rows would drown their own prompt and
+    /// response rows in the bounded timeline buffer.
+    static let toolExecSuppressed: Set<String> = [
+        "codex-cli",
+        "codex-app",
+        "opencode",
+        "antigravity",
+        "kiro-cli",
+        "kiro-ide",
+    ]
+
+    /// Bare id form — unchanged when the id carries no observed prefix.
+    static func rawSessionId(_ value: String) -> String {
+        for prefix in sessionPrefixes where value.hasPrefix(prefix) {
+            return String(value.dropFirst(prefix.count))
+        }
+        return value
+    }
+}

--- a/apple/AgentDeck/Model/Timeline.swift
+++ b/apple/AgentDeck/Model/Timeline.swift
@@ -447,14 +447,10 @@ private func sameTimelineContext(_ a: TimelineEntry, _ b: TimelineEntry) -> Bool
 /// and Node `BridgeTimelineStore.getHistoryForSession`.
 func canonicalTimelineSessionId(_ value: String?) -> String? {
     guard let value = timelineNonBlank(value) else { return nil }
-    let prefixes = [
-        "observed:claude:",
-        "observed:codex:",
-        "observed:codex-app:",
-        "observed:opencode:",
-        "observed:antigravity:",
-    ]
-    for prefix in prefixes where value.hasPrefix(prefix) {
+    // Generated from the TypeScript source rather than written here: this list
+    // was hand-mirrored and drifted, missing both Kiro keys, so selecting a
+    // Kiro session matched no rows and its timeline came up empty.
+    for prefix in ObservedAgentRules.sessionPrefixes where value.hasPrefix(prefix) {
         return timelineNonBlank(String(value.dropFirst(prefix.count)))
     }
     return value

--- a/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
+++ b/apple/AgentDeck/Rendering/TUITerrariumRenderer.swift
@@ -9,7 +9,7 @@
 // Sync pin — verified by `scripts/check-preview-mirror-sync.mjs` (CI). When the
 // origin changes, re-port (or confirm no visual impact given the deliberate
 // simplifications below) and bump the pin in the same commit.
-// SYNC-HASH bridge/src/tui/terrarium.ts 47a475ebde15a4333b3395deeb67f83cc00a2290
+// SYNC-HASH bridge/src/tui/terrarium.ts 3a3fd52739be3d60647ac6d15deb01e720fbeea4
 //
 // Scope / deliberate simplifications (vs the TS original):
 //   - No Braille sprites: creatures render as 3-char ASCII glyphs colored by
@@ -33,8 +33,10 @@ import SwiftUI
 /// Configuration for a single static/animated frame of the TUI terrarium preview.
 struct TerrariumPreviewConfig: Equatable {
     /// Agent identifiers, one per creature. Accepts:
-    ///   "claude-code", "codex-cli", "opencode", "openclaw"
-    /// Unknown strings render as the default octopus glyph.
+    ///   "claude-code", "codex-cli", "opencode", "openclaw", "antigravity",
+    ///   "kiro-cli", "kiro-ide"
+    /// An identifier this build does not know renders as a NEUTRAL marker,
+    /// never as Claude's octopus — see `glyph(for:state:)`.
     var agents: [String]
     /// Parallel to `agents`. Accepts canonical state strings:
     ///   "idle", "processing", "awaiting_permission", "awaiting_option",

--- a/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
+++ b/apple/AgentDeck/UI/Monitor/TimelineStripView.swift
@@ -1777,7 +1777,7 @@ func timelineIsLowSignalEntry(_ entry: TimelineEntry) -> Bool {
     // flooded its own turn with tool rows while Codex read clean. Antigravity
     // is included forward-compat (the observed-hook classifier already accepts
     // antigravity_* events).
-    if (entry.agentType == "codex-cli" || entry.agentType == "codex-app" || entry.agentType == "opencode" || entry.agentType == "antigravity"), entry.type == .toolExec {
+    if ObservedAgentRules.toolExecSuppressed.contains(entry.agentType ?? ""), entry.type == .toolExec {
         return true
     }
     // Real signal in detail → keep regardless of placeholder raw.

--- a/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
@@ -25,7 +25,7 @@
 // current `git hash-object` of each file and fails CI when the origin drifts
 // ahead of this mirror. Update them whenever you re-port.
 // SYNC-HASH shared/src/d200h-layout.ts 74445bade8a9ad9656d623d0724fb8b69683b6d9
-// SYNC-HASH shared/src/session-utils.ts e3963a0fe056d7d4e92046763078999a8a3d4e88
+// SYNC-HASH shared/src/session-utils.ts 3f6629cd69bd4d77f380cb5e37972f28863058e7
 //
 // INTENTIONALLY OMITTED (not needed by a read-only preview):
 //   • Actual SVG rasterization. The TS engine emits per-key SVG strings via the

--- a/bridge/src/__tests__/tui-terrarium-snapshots.test.ts
+++ b/bridge/src/__tests__/tui-terrarium-snapshots.test.ts
@@ -85,12 +85,32 @@ describe('TUI terrarium snapshots', () => {
   it('setOctopi configures octopus instances', () => {
     const ctx = initTerrarium();
     setOctopi(ctx, [
-      { id: 'a', state: 'idle', name: 'TestProject' },
-      { id: 'b', state: 'processing', name: 'AgentDeck' },
+      { id: 'a', state: 'idle', name: 'TestProject', agentType: 'claude-code' },
+      { id: 'b', state: 'processing', name: 'AgentDeck', agentType: 'claude-code' },
     ]);
     expect(ctx.octopi).toHaveLength(2);
     expect(ctx.octopi[0].name).toBe('TestProject');
     expect(ctx.octopi[1].state).toBe('processing');
+  });
+
+  it('draws an octopus for Claude and for nobody else', () => {
+    // The filter used to be a deny-list — "everything that is not one of these
+    // five is a Claude octopus" — so every agent added after it was written
+    // swam as Claude. Kiro and Antigravity sessions were drawn with Claude's
+    // creature here while the Stream Deck, Pixoo and both apps had them right.
+    //
+    // This pins the POLARITY, not the membership: adding a real agent needs no
+    // edit here, but spelling the filter as an exclusion again fails.
+    const ctx = initTerrarium();
+    setOctopi(ctx, [
+      { id: 'claude', state: 'idle', name: 'Claude', agentType: 'claude-code' },
+      { id: 'kiro', state: 'idle', name: 'Kiro', agentType: 'kiro-cli' },
+      { id: 'kiro-ide', state: 'idle', name: 'KiroIDE', agentType: 'kiro-ide' },
+      { id: 'agy', state: 'idle', name: 'Antigravity', agentType: 'antigravity' },
+      { id: 'future', state: 'idle', name: 'NotYetInvented', agentType: 'some-2027-agent' },
+      { id: 'none', state: 'idle', name: 'NoType' },
+    ]);
+    expect(ctx.octopi.map(o => o.name)).toEqual(['Claude']);
   });
 
   it('setCrayfish configures crayfish state', () => {
@@ -127,7 +147,7 @@ describe('TUI terrarium snapshots', () => {
 
   it('renderTerrariumFrame with idle octopus', () => {
     const ctx = initTerrarium();
-    setOctopi(ctx, [{ id: 'a', state: 'idle', name: 'Test' }]);
+    setOctopi(ctx, [{ id: 'a', state: 'idle', name: 'Test', agentType: 'claude-code' }]);
     updateTerrarium(ctx, 0);
     const lines = renderTerrariumFrame(ctx, 80, 20, 0);
     expect(lines.length).toBeGreaterThan(0);
@@ -136,7 +156,7 @@ describe('TUI terrarium snapshots', () => {
 
   it('renderTerrariumFrame with processing octopus', () => {
     const ctx = initTerrarium();
-    setOctopi(ctx, [{ id: 'a', state: 'processing', name: 'AgentDeck' }]);
+    setOctopi(ctx, [{ id: 'a', state: 'processing', name: 'AgentDeck', agentType: 'claude-code' }]);
     updateTerrarium(ctx, 10);
     const lines = renderTerrariumFrame(ctx, 80, 20, 10);
     expect(lines).toMatchSnapshot();

--- a/bridge/src/tui/terrarium.ts
+++ b/bridge/src/tui/terrarium.ts
@@ -489,13 +489,16 @@ export function setOctopi(
   ctx: TerrariumContext,
   sessions: Array<{ id?: string; state: string; name?: string; agentType?: string }>,
 ): void {
-  const octSessions = sessions.filter(s =>
-    (s.agentType as string) !== 'daemon' &&
-    (s.agentType as string) !== 'openclaw' &&
-    (s.agentType as string) !== 'codex-cli' &&
-    (s.agentType as string) !== 'codex-app' &&
-    (s.agentType as string) !== 'opencode'
-  );
+  // Allow-list, not a deny-list. Spelled the other way round this read
+  // "everything that isn't one of these five is a Claude octopus", so every
+  // agent added after it was written swam as Claude: antigravity and both Kiro
+  // types were drawn with Claude's creature in the TUI aquarium. A wrong
+  // identity is worse than a missing one — an unknown agent renders as nothing
+  // here, which is the documented polarity (CLAUDE.md, "An unknown agentType
+  // renders as nothing or as a neutral default — never as another agent").
+  // Mirrors `isOctopusAgent` (Swift) / `isOctopusAgentType` (Kotlin) and
+  // `CODING_AGENTS` in bridge/src/pixoo/pixoo-renderer.ts.
+  const octSessions = sessions.filter(s => (s.agentType as string) === 'claude-code');
   const count = octSessions.length;
   // Count name occurrences to number duplicates
   const nameCounts = new Map<string, number>();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate-idotmatrix-identity": "node scripts/generate-idotmatrix-identity.mjs",
     "generate-pairing-code-rules": "node scripts/generate-pairing-code-rules.mjs",
     "generate-mdns-identity": "node scripts/generate-mdns-identity.mjs",
+    "generate-observed-agent-rules": "node scripts/generate-observed-agent-rules.mjs",
     "generate-openclaw-approval-rules": "node scripts/generate-openclaw-approval-rules.mjs",
     "generate-streamdeck-profiles": "node scripts/generate-streamdeck-profiles.mjs",
     "verify-version": "node scripts/verify-version-sync.mjs",

--- a/scripts/generate-observed-agent-rules.mjs
+++ b/scripts/generate-observed-agent-rules.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Generate the Swift/Kotlin mirrors of two observed-agent lists:
+//   - shared/src/session-utils.ts  OBSERVED_SESSION_AGENT_KEYS
+//   - shared/src/timeline.ts       TOOL_EXEC_SUPPRESSED_AGENTS
+//
+//   pnpm generate-observed-agent-rules            regenerate the mirrors
+//   pnpm generate-observed-agent-rules --check    exit 1 if any mirror drifted
+//
+// Both lists were hand-mirrored, and both drifted the same way: Kiro was added
+// to the TypeScript source and to nothing else. The consequences were not
+// cosmetic — a Kiro session's id keeps its `observed:kiro:` prefix, so the
+// mobile canonicalizers matched it against nothing and the session's timeline
+// came up empty; and its per-tool rows were never suppressed, so a Kiro turn
+// drowned its own prompt/response rows.
+//
+// The lists are small enough that hand-mirroring looks free. It is not: what
+// they cost is one silent surface per agent added.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const HEADER =
+  'GENERATED FILE — DO NOT EDIT.\n' +
+  'Source of truth: shared/src/session-utils.ts (OBSERVED_SESSION_AGENT_KEYS)\n' +
+  '                 shared/src/timeline.ts      (TOOL_EXEC_SUPPRESSED_AGENTS)\n' +
+  'Regenerate: pnpm generate-observed-agent-rules (drift gated by shared/src/__tests__/observed-agent-rules.test.ts)';
+
+function comment(prefix) {
+  return HEADER.split('\n').map((l) => `${prefix} ${l}`).join('\n');
+}
+
+export function emitSwift(rules) {
+  const prefixes = rules.prefixes.map((p) => `        "${p}",`).join('\n');
+  const suppressed = rules.suppressed.map((a) => `        "${a}",`).join('\n');
+  return `${comment('//')}
+
+import Foundation
+
+/// Observed-session id prefixes and the agents whose observed tool rows stay
+/// out of the timeline. See the TypeScript sources for why these are generated
+/// rather than written twice.
+enum ObservedAgentRules {
+    /// A passively-observed session is keyed \`observed:<agent>:<uuid>\` in
+    /// \`sessions_list\` and on devices, while timeline rows, hook payloads and
+    /// transcripts use the bare uuid — so anything comparing one against the
+    /// other must strip this first.
+    static let sessionPrefixes: [String] = [
+${prefixes}
+    ]
+
+    /// Agents whose observed per-tool rows would drown their own prompt and
+    /// response rows in the bounded timeline buffer.
+    static let toolExecSuppressed: Set<String> = [
+${suppressed}
+    ]
+
+    /// Bare id form — unchanged when the id carries no observed prefix.
+    static func rawSessionId(_ value: String) -> String {
+        for prefix in sessionPrefixes where value.hasPrefix(prefix) {
+            return String(value.dropFirst(prefix.count))
+        }
+        return value
+    }
+}
+`;
+}
+
+export function emitKotlin(rules) {
+  const prefixes = rules.prefixes.map((p) => `        "${p}",`).join('\n');
+  const suppressed = rules.suppressed.map((a) => `        "${a}",`).join('\n');
+  return `${comment('//')}
+package dev.agentdeck.state
+
+/**
+ * Observed-session id prefixes and the agents whose observed tool rows stay out
+ * of the timeline. See the TypeScript sources for why these are generated
+ * rather than written twice.
+ */
+object ObservedAgentRules {
+    /** A passively-observed session is keyed \`observed:<agent>:<uuid>\` in
+     *  \`sessions_list\` and on devices, while timeline rows, hook payloads and
+     *  transcripts use the bare uuid. */
+    val SESSION_PREFIXES: List<String> = listOf(
+${prefixes}
+    )
+
+    /** Agents whose observed per-tool rows would drown their own prompt and
+     *  response rows in the bounded timeline buffer. */
+    val TOOL_EXEC_SUPPRESSED: Set<String> = setOf(
+${suppressed}
+    )
+
+    /** Bare id form — unchanged when the id carries no observed prefix. */
+    fun rawSessionId(value: String): String {
+        val prefix = SESSION_PREFIXES.firstOrNull { value.startsWith(it) } ?: return value
+        return value.removePrefix(prefix)
+    }
+}
+`;
+}
+
+export const OUTPUTS = [
+  ['apple/AgentDeck/Model/ObservedAgentRules.generated.swift', emitSwift],
+  ['android/app/src/main/kotlin/dev/agentdeck/state/ObservedAgentRules.generated.kt', emitKotlin],
+];
+
+async function main() {
+  let rules;
+  try {
+    const sessionUtils = await import('../shared/dist/session-utils.js');
+    const timeline = await import('../shared/dist/timeline.js');
+    rules = {
+      prefixes: [...sessionUtils.OBSERVED_SESSION_PREFIXES],
+      suppressed: [...timeline.TOOL_EXEC_SUPPRESSED_AGENTS],
+    };
+  } catch {
+    console.error('shared/dist not found — run `pnpm --filter @agentdeck/shared build` first');
+    process.exit(1);
+  }
+  const check = process.argv.includes('--check');
+  let drifted = false;
+  for (const [rel, emit] of OUTPUTS) {
+    const abs = path.join(projectDir, rel);
+    const next = emit(rules);
+    const prev = fs.existsSync(abs) ? fs.readFileSync(abs, 'utf8') : null;
+    if (check) {
+      if (prev !== next) {
+        console.error(`DRIFT: ${rel}`);
+        drifted = true;
+      }
+    } else if (prev !== next) {
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, next);
+      console.log(`wrote ${rel}`);
+    } else {
+      console.log(`up-to-date ${rel}`);
+    }
+  }
+  if (check) {
+    console.log(drifted ? 'observed agent rule mirrors DRIFTED' : 'observed agent rule mirrors in sync');
+    process.exit(drifted ? 1 : 0);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) await main();

--- a/shared/src/__tests__/observed-agent-rules.test.ts
+++ b/shared/src/__tests__/observed-agent-rules.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The two observed-agent lists, and the gate that keeps their Swift/Kotlin
+ * mirrors from drifting away from this source again.
+ *
+ * Both drifted the same way and neither failure was visible: Kiro was added to
+ * the TypeScript source and to nothing else, so on iOS/macOS and Android a Kiro
+ * session's id kept its `observed:kiro:` prefix, matched no timeline rows, and
+ * its detail view came up empty — while its per-tool rows, unsuppressed,
+ * drowned the prompt and response rows they were meant to sit beside.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  OBSERVED_SESSION_AGENT_KEYS,
+  OBSERVED_SESSION_PREFIXES,
+  OBSERVED_SESSION_PREFIX_RE,
+  rawSessionId,
+  sameSession,
+} from '../session-utils.js';
+import { TOOL_EXEC_SUPPRESSED_AGENTS, isToolExecSuppressedAgent } from '../timeline.js';
+import { OUTPUTS } from '../../../scripts/generate-observed-agent-rules.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+describe('observed session ids', () => {
+  it('strips every advertised prefix, Kiro included', () => {
+    // `observed:kiro:` / `observed:kiro-ide:` are what passive-observer.ts
+    // actually emits; a client that cannot strip them shows an empty timeline.
+    for (const key of OBSERVED_SESSION_AGENT_KEYS) {
+      expect(rawSessionId(`observed:${key}:abc-123`)).toBe('abc-123');
+    }
+    expect(sameSession('observed:kiro:abc-123', 'abc-123')).toBe(true);
+    expect(sameSession('observed:kiro-ide:abc-123', 'abc-123')).toBe(true);
+  });
+
+  it('keeps the regex and the list from disagreeing about which agents exist', () => {
+    // The regex is built FROM the list, so this is a statement about the
+    // construction rather than a second copy of the membership.
+    for (const prefix of OBSERVED_SESSION_PREFIXES) {
+      expect(OBSERVED_SESSION_PREFIX_RE.test(`${prefix}x`)).toBe(true);
+    }
+    expect(OBSERVED_SESSION_PREFIX_RE.test('observed:not-an-agent:x')).toBe(false);
+    // A bare id is returned unchanged, not mangled.
+    expect(rawSessionId('abc-123')).toBe('abc-123');
+  });
+});
+
+describe('observed tool_exec suppression', () => {
+  it('covers every observed agent whose tool rows are a firehose', () => {
+    expect(isToolExecSuppressedAgent('kiro-cli')).toBe(true);
+    expect(isToolExecSuppressedAgent('kiro-ide')).toBe(true);
+    // Claude is deliberately absent: its tool rows are the signal the managed
+    // timeline strip is built around.
+    expect(isToolExecSuppressedAgent('claude-code')).toBe(false);
+    expect(isToolExecSuppressedAgent(undefined)).toBe(false);
+    expect(isToolExecSuppressedAgent('some-2027-agent')).toBe(false);
+  });
+});
+
+describe('generated mirrors', () => {
+  it('match this source', () => {
+    const rules = {
+      prefixes: [...OBSERVED_SESSION_PREFIXES],
+      suppressed: [...TOOL_EXEC_SUPPRESSED_AGENTS],
+    };
+    for (const [rel, emit] of OUTPUTS as Array<[string, (r: unknown) => string]>) {
+      const onDisk = readFileSync(join(repoRoot, rel), 'utf8');
+      expect(onDisk, `${rel} drifted — run pnpm generate-observed-agent-rules`).toBe(emit(rules));
+    }
+  });
+
+  it('leaves no hand-written copy of either list behind', () => {
+    // The point of generating them is that there is one list. A call site that
+    // spells the membership out again is the drift this replaced, so it fails
+    // here rather than silently on one platform.
+    for (const rel of [
+      'apple/AgentDeck/Model/Timeline.swift',
+      'android/app/src/main/kotlin/dev/agentdeck/state/TimelineDisplay.kt',
+      'apple/AgentDeck/UI/Monitor/TimelineStripView.swift',
+    ]) {
+      const src = readFileSync(join(repoRoot, rel), 'utf8');
+      expect(src, `${rel} still hand-lists observed prefixes`).not.toContain('"observed:codex-app:"');
+    }
+  });
+});

--- a/shared/src/session-utils.ts
+++ b/shared/src/session-utils.ts
@@ -20,9 +20,28 @@
  * fifth site that skipped stripping altogether silently never matched: a spoken
  * reply was armed under the prefixed id and looked up under the bare one, so the
  * reply was synthesized for nobody. Add agents here, not at the call sites.
+ *
+ * "Not at the call sites" did not reach the two mobile ones, which kept their
+ * own hand-written arrays and both missed Kiro — so selecting a Kiro session on
+ * iOS/macOS or Android matched no timeline rows at all and its detail view came
+ * up empty. They are generated from this list now
+ * (`pnpm generate-observed-agent-rules`, vitest drift gate).
+ *
+ * These are the id KEYS, which are not always the agentType: Claude Code is
+ * `claude-code` as an agent and `observed:claude:` as an id.
  */
+export const OBSERVED_SESSION_AGENT_KEYS = [
+  'claude', 'codex', 'codex-app', 'opencode', 'antigravity', 'kiro', 'kiro-ide',
+] as const;
+
+/** `observed:<key>:` for every key above — the form clients actually match. */
+export const OBSERVED_SESSION_PREFIXES: readonly string[] =
+  OBSERVED_SESSION_AGENT_KEYS.map((k) => `observed:${k}:`);
+
+// Built from the list rather than written beside it, so the regex and the
+// array cannot disagree about which agents exist.
 export const OBSERVED_SESSION_PREFIX_RE =
-  /^observed:(?:claude|codex|codex-app|opencode|antigravity|kiro|kiro-ide):/;
+  new RegExp(`^observed:(?:${OBSERVED_SESSION_AGENT_KEYS.join('|')}):`);
 
 /** Bare uuid form of a session id — unchanged when it has no observed prefix. */
 export function rawSessionId(sessionId: string): string {

--- a/shared/src/timeline.ts
+++ b/shared/src/timeline.ts
@@ -395,6 +395,28 @@ export function summarizeOpenClawCronPrompt(text?: string): string {
   return `자동 작업 \u00b7 ${capped}`;
 }
 
+/**
+ * Agents whose OBSERVED per-tool rows are kept out of the user-facing timeline.
+ *
+ * A list rather than an inline chain because it is mirrored on four surfaces
+ * (Swift `TimelineStripView`, Kotlin `TimelineDisplay`, and the device
+ * renderers) and the chain drifted: Kiro was added here and to nothing else, so
+ * a Kiro turn drowned its own prompt/response rows on iOS/macOS and Android
+ * while reading clean on the deck. Generated outward by
+ * `pnpm generate-observed-agent-rules` (vitest drift gate).
+ *
+ * Claude is deliberately absent: its tool rows are the managed-session signal
+ * the strip is built around.
+ */
+export const TOOL_EXEC_SUPPRESSED_AGENTS = [
+  'codex-cli', 'codex-app', 'opencode', 'antigravity', 'kiro-cli', 'kiro-ide',
+] as const;
+
+/** True when this agent's observed `tool_exec` rows must not be persisted. */
+export function isToolExecSuppressedAgent(agentType: string | undefined): boolean {
+  return (TOOL_EXEC_SUPPRESSED_AGENTS as readonly string[]).includes(agentType ?? '');
+}
+
 export function shouldDropLowSignalTimelineEntry(entry: TimelineEntry): boolean {
   if (isTaskNotificationChatStart(entry)) return true;
   if (isOpenClawLowSignalResponse(entry)) return true;
@@ -415,15 +437,7 @@ export function shouldDropLowSignalTimelineEntry(entry: TimelineEntry): boolean 
   // included forward-compat: `classifyObservedHookEvent` already accepts
   // `antigravity_*` hooks, so if an AGY observer producer lands its tool rows
   // must not flood the strip either.
-  if (
-    (entry.agentType === 'codex-cli' ||
-      entry.agentType === 'codex-app' ||
-      entry.agentType === 'opencode' ||
-      entry.agentType === 'antigravity' ||
-      entry.agentType === 'kiro-cli' ||
-      entry.agentType === 'kiro-ide') &&
-    entry.type === 'tool_exec'
-  ) {
+  if (isToolExecSuppressedAgent(entry.agentType) && entry.type === 'tool_exec') {
     return true;
   }
   if (detailHasRealSignal(entry.detail)) return false;


### PR DESCRIPTION
Asked: *"is Kiro CLI reflected on every device? only the macOS Dashboard seems to render it properly."*

Audited it by comparing every file that enumerates agent types against the ones that enumerate `opencode`. The answer is no, and the gaps fall into three kinds — only one of which is cosmetic.

## 1. Misattributed — the TUI drew Kiro as Claude

`bridge/src/tui/terrarium.ts` filtered with a **deny-list**:

```ts
sessions.filter(s => s.agentType !== 'daemon' && … !== 'opencode')
```

which means *"anything that is not one of these five is a Claude octopus"* — so every agent added after it was written swam as Claude. Both Kiro types and Antigravity did. This is the exact polarity CLAUDE.md forbids ("An unknown `agentType` renders as nothing or as a neutral default — never as another agent"), and it survived the Kiro merge because the Stream Deck, Pixoo and both apps were fixed while this one was missed.

Now an allow-list, so Kiro is **invisible** in the TUI tank rather than misattributed — the documented preference.

The existing tests could not have caught it: their fixtures omitted `agentType` entirely — the field the filter branches on — so either polarity passed. They carry the real shape now, plus a gate that pins the **polarity** (a real new agent needs no test edit; spelling the filter as an exclusion again fails).

## 2. Invisible — a Kiro session's timeline was empty on iOS, macOS *and* Android

Observed sessions are keyed `observed:<agent>:<uuid>` in `sessions_list` and by bare uuid in timeline rows. `canonicalTimelineSessionId` is hand-mirrored into Swift and Kotlin, and **both were missing the two Kiro keys** — so selecting a Kiro session stripped nothing, matched nothing, and the detail view came up empty. That is the "거의" in "only macOS is *almost* right".

The SSOT comment already said *"add agents here, not at the call sites"*. The call sites it meant were the two it could not reach.

Same story for the observed `tool_exec` suppression list (the documented 4-mirror rule): Kiro missing from Swift `TimelineStripView` and Kotlin `TimelineDisplay`, so a Kiro turn's tool rows evict its own prompt and response from the bounded buffer.

Both lists are **generated** now — `pnpm generate-observed-agent-rules` → Swift + Kotlin, vitest drift gate, including a check that no call site has quietly written the membership out again. Short lists make hand-mirroring look free; what it costs is one silent surface per agent added.

## 3. Neutral but blank — ESP32 (left for a firmware change)

Polarity is **correct** everywhere on the boards (allow-lists with neutral fallbacks), but Kiro currently:

| surface | today |
|---|---|
| ticker / pocket | grey `HUDDim` row — label is right (`agent_label.h` has Kiro) |
| IPS10 hud_bar | a dot instead of a glyph |
| LED matrix | `continue` — the row is skipped entirely |
| terrarium | no Kiro creature |
| office scene / knob / e-ink | ✅ already correct (colour, label, `KIRO_A8`) |

Firmware costs an OTA cut and hardware verification, so it stays its own change. The audit is written down in DEVELOPMENT_LOG.md.

## Already correct

Every shared SSOT (label, colour, logo/creature icon, sort weight, adapter type), the Apple app (`KiroCreature.swift` + all four label maps), Stream Deck, Ulanzi D200H (both via the shared `renderSessionSlot`), and Pixoo / Timebox / iDotMatrix (mask, colour, creature layout).

## Verified

- `npx vitest run` — 3184 passed (200 files)
- `./gradlew testDebugUnitTest` — pass
- `xcodebuild` macOS **and** iOS — both `BUILD SUCCEEDED`
- `pnpm docs:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)