### PR TITLE
Read Kiro's own transcript, because nothing else ever fills its timeline

### DIFF
--- a/bridge/src/__tests__/kiro-transcript-timeline.test.ts
+++ b/bridge/src/__tests__/kiro-transcript-timeline.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Detail-view rows for an observed Kiro session.
+ *
+ * The fixtures below are TRANSCRIBED from a real Kiro CLI v3 transcript
+ * (`~/.kiro/sessions/cli/<uuid>.jsonl`, read 2026-08-17), not imagined. This
+ * repo has a specific history of Kiro parsers written against invented shapes
+ * that passed their own tests and matched nothing on disk — every one of the
+ * five was caught only by going back to real data. So the two properties that
+ * an invented fixture would have got wrong are asserted explicitly:
+ *
+ *   - `meta.timestamp` is in SECONDS (1786933404 → 2026-08-17T02:23Z)
+ *   - only `Prompt` carries a timestamp; `AssistantMessage` has none at all
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { kiroTimelineForSession } from '../kiro-transcript-timeline.js';
+
+const UUID = '6b3d3a27-f18e-4276-9438-3491fffe27e7';
+
+/** Verbatim record shapes from the measured transcript. */
+const PROMPT = (text: string, tsSeconds: number) => JSON.stringify({
+  version: 'v1',
+  kind: 'Prompt',
+  data: {
+    message_id: 'a6081b46-6ef1-4824-88d4-1c3c0408d278',
+    content: [{ kind: 'text', data: text }],
+    meta: { timestamp: tsSeconds },
+  },
+});
+
+const ASSISTANT = (text: string) => JSON.stringify({
+  version: 'v1',
+  kind: 'AssistantMessage',
+  data: {
+    message_id: '66649d17-50f1-490d-9fe7-befd3777dd9f',
+    // A `thinking` block precedes the text block in every real record, and it
+    // carries an OBJECT, not a string — a parser that assumed `data` is always
+    // a string would concatenate "[object Object]" into the row.
+    content: [
+      { kind: 'thinking', data: { text: '', signature: null, redactedContent: null } },
+      { kind: 'text', data: text },
+    ],
+  },
+});
+
+const TOOL_RESULTS = JSON.stringify({
+  version: 'v1',
+  kind: 'ToolResults',
+  data: { content: [{ kind: 'toolResult', data: { toolUseId: 'tooluse_e6zfT83FyPlU7fK1T' } }] },
+});
+
+describe('kiroTimelineForSession', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kiro-sessions-'));
+    mkdirSync(join(root, 'cli'), { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function writeTranscript(lines: string[], dir = 'cli'): void {
+    mkdirSync(join(root, dir), { recursive: true });
+    writeFileSync(join(root, dir, `${UUID}.jsonl`), lines.join('\n') + '\n');
+  }
+
+  it('turns a real transcript into paired chat rows', () => {
+    writeTranscript([
+      PROMPT('hello', 1786897401),
+      ASSISTANT('Hello! How can I help you with AgentDeck today?'),
+      PROMPT('hi', 1786933404),
+      ASSISTANT('Hi! 무엇을 도와드릴까요?'),
+    ]);
+    const rows = kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root });
+    expect(rows.map((r) => [r.type, r.raw])).toEqual([
+      ['chat_start', 'hello'],
+      ['chat_response', 'Hello! How can I help you with AgentDeck today?'],
+      ['chat_start', 'hi'],
+      ['chat_response', 'Hi! 무엇을 도와드릴까요?'],
+    ]);
+    expect(rows.every((r) => r.agentType === 'kiro-cli')).toBe(true);
+    // Keyed by the BARE uuid, because that is what the timeline compares
+    // against after `rawSessionId` — the whole point of #216.
+    expect(rows.every((r) => r.sessionId === UUID)).toBe(true);
+  });
+
+  it('reads the timestamp as seconds, not milliseconds', () => {
+    // 1786933404 is 2026-08-17. Read as milliseconds it would be 1970-01-21,
+    // which sorts before everything and silently vanishes under any `since`.
+    writeTranscript([PROMPT('hi', 1786933404), ASSISTANT('Hi!')]);
+    const [prompt, response] = kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root });
+    expect(new Date(prompt.ts).toISOString()).toBe('2026-08-17T02:23:24.000Z');
+    // The assistant record carries NO timestamp, so it takes its prompt's —
+    // nudged so it cannot sort before the thing it answers.
+    expect(response.ts).toBe(prompt.ts + 1);
+  });
+
+  it('keeps thinking blocks and tool results out of the rows', () => {
+    writeTranscript([PROMPT('ls -la 해줘', 1786898236), TOOL_RESULTS, ASSISTANT('현재 디렉토리 내용')]);
+    const rows = kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root });
+    expect(rows).toHaveLength(2);
+    expect(JSON.stringify(rows)).not.toContain('object Object');
+    expect(JSON.stringify(rows)).not.toContain('toolUseId');
+  });
+
+  it('honours since and limit against the row timestamps', () => {
+    writeTranscript([
+      PROMPT('old', 1786897401), ASSISTANT('old reply'),
+      PROMPT('new', 1786933404), ASSISTANT('new reply'),
+    ]);
+    const since = 1786900000 * 1000;
+    expect(kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root, since })
+      .map((r) => r.raw)).toEqual(['new', 'new reply']);
+    expect(kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root, limit: 1 })
+      .map((r) => r.raw)).toEqual(['new reply']);
+  });
+
+  it('returns nothing rather than guessing when it cannot read', () => {
+    // No transcript (a v2 session keeps its conversation in SQLite), an
+    // unknown session, and a half-written tail line all resolve to "no rows",
+    // which the caller renders as "no recent activity".
+    expect(kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root })).toEqual([]);
+    writeTranscript([PROMPT('hi', 1786933404), '{"kind":"AssistantMessage","data":{"con']);
+    expect(kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root })
+      .map((r) => r.raw)).toEqual(['hi']);
+    expect(kiroTimelineForSession('observed:kiro:', { sessionsRoot: root })).toEqual([]);
+  });
+
+  it('finds a session under a workspace-hash directory, not just cli/', () => {
+    // v3 keys sessions by workspace hash; `cli` is only one of the directories.
+    writeTranscript([PROMPT('hi', 1786933404), ASSISTANT('Hi!')], 'a6cb67a906f608db');
+    expect(kiroTimelineForSession(`observed:kiro:${UUID}`, { sessionsRoot: root })).toHaveLength(2);
+  });
+});

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -168,6 +168,7 @@ import {
   transcriptTimelineForSession, lastAssistantTextFromTranscript,
   lastAssistantTextForSession,
 } from './session-transcript-timeline.js';
+import { kiroTimelineForSession } from './kiro-transcript-timeline.js';
 import {
   DeviceVoiceReplyRouter, speakableReply, spokenDigest, pcmFromWav, type ReplySink,
 } from './device-voice-reply.js';
@@ -4128,6 +4129,16 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         if (entries.length === 0) {
           try {
             entries = transcriptTimelineForSession(sessionId, { since: sinceMs });
+          } catch { /* read-only best effort */ }
+        }
+        // Kiro keeps its transcript in its OWN store, so the Claude reader
+        // above can never find one — and no `kiro_*` hook has ever reached
+        // this daemon (v2 has no global hook surface at all), so the timeline
+        // store is empty for it too. Without this branch an observed Kiro
+        // session's Detail view is empty whatever it does.
+        if (entries.length === 0 && sessionId.startsWith('observed:kiro')) {
+          try {
+            entries = kiroTimelineForSession(sessionId, { since: sinceMs });
           } catch { /* read-only best effort */ }
         }
         const historyEvent = buildCappedTimelineHistory(entries, undefined, { sessionId });

--- a/bridge/src/kiro-transcript-timeline.ts
+++ b/bridge/src/kiro-transcript-timeline.ts
@@ -1,0 +1,177 @@
+/**
+ * Detail-view timeline rows for a passively-observed Kiro session, read from
+ * Kiro's own transcript.
+ *
+ * Why this exists: an observed Kiro session shows up in `sessions_list` (so the
+ * deck and the boards can render it) but produces **no timeline rows at all**.
+ * Two independent reasons, both measured on 2026-08-17:
+ *
+ *  - No `kiro_*` hook has ever reached this daemon. The v3 hook file is
+ *    installed, but the count in the daemon log is zero — v2 has no global
+ *    standalone hook surface at all, so a v2 session is process/store observed
+ *    and silent by construction.
+ *  - The existing fallback (`transcriptTimelineForSession`) searches
+ *    `~/.claude/projects/**` only, so for a Kiro session it can never hit.
+ *
+ * The result was a Detail view that stayed empty no matter what the session
+ * did. Fixing the id normalization (#216) was necessary and not sufficient:
+ * ids matched afterwards, and there was still nothing to match them against.
+ *
+ * Scope: Kiro CLI **v3**, whose sessions are JSONL under
+ * `KIRO_HOME/sessions/**\/<uuid>.jsonl`. v2 keeps its conversations in
+ * `kiro-cli/data.sqlite3` and is NOT read here — a v2 session returns nothing,
+ * exactly as before, rather than a guess.
+ *
+ * The record shapes below were read off a real transcript, never invented.
+ * This repo has a specific history of Kiro parsers written against imagined
+ * fixtures that passed their tests and matched nothing real, so the test file
+ * for this module pins the measured shape:
+ *
+ *   {"version":"v1","kind":"Prompt","data":{"message_id":…,
+ *     "content":[{"kind":"text","data":"hi"}],"meta":{"timestamp":1786933404}}}
+ *   {"version":"v1","kind":"AssistantMessage","data":{"message_id":…,
+ *     "content":[{"kind":"thinking",…},{"kind":"text","data":"Hi! …"}]}}
+ *   {"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult",…}]}}
+ *
+ * Two properties of that shape drive the code:
+ *  - `meta.timestamp` is in **SECONDS**, and TimelineEntry.ts is milliseconds.
+ *  - Only `Prompt` carries a timestamp. An `AssistantMessage` has none, so its
+ *    row is stamped with the prompt it answers — the turn's time, which is the
+ *    only defensible reading — plus a 1 ms nudge so it sorts after it.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import type { TimelineEntry } from '@agentdeck/shared';
+import { rawSessionId } from '@agentdeck/shared';
+import { kiroV3SessionsRoot } from './kiro-session.js';
+import { debug } from './logger.js';
+
+/** Cap on transcript bytes read, matching the Claude reader's posture. */
+const MAX_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
+/** Directories scanned under the sessions root (workspace-hash dirs + `cli`). */
+const MAX_SCAN_DIRS = 250;
+
+export interface KiroTimelineOptions {
+  /** Epoch-ms lower bound; rows at or before it are dropped. */
+  since?: number;
+  /** Newest N rows kept. */
+  limit?: number;
+  /** Injectable for tests. */
+  sessionsRoot?: string;
+}
+
+/** Locate `<uuid>.jsonl` under the v3 sessions root. */
+function locateKiroTranscript(uuid: string, root: string): string | null {
+  let entries: Array<{ name: string; isDirectory(): boolean; isSymbolicLink(): boolean }>;
+  try {
+    entries = readdirSync(root, { withFileTypes: true, encoding: 'utf-8' }).slice(0, MAX_SCAN_DIRS);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const candidate = join(root, entry.name, `${uuid}.jsonl`);
+    try {
+      const st = statSync(candidate);
+      if (st.isFile() && st.size <= MAX_TRANSCRIPT_BYTES) return candidate;
+    } catch {
+      // not in this directory
+    }
+  }
+  return null;
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as { kind?: string; data?: unknown };
+    // `thinking` blocks carry an object and are not user-facing; `text` blocks
+    // carry the string. Anything else (toolResult…) is not a chat row.
+    if (b.kind === 'text' && typeof b.data === 'string') parts.push(b.data);
+  }
+  return parts.join('\n').trim();
+}
+
+function firstLine(text: string, cap = 120): string {
+  const line = text.replace(/\s+/g, ' ').trim();
+  return line.length > cap ? `${line.slice(0, cap - 1)}…` : line;
+}
+
+/**
+ * Chat rows for one Kiro session, oldest-first. Returns `[]` for anything it
+ * cannot read — a missing transcript, a v2 session, an unparseable line — so
+ * the caller falls back to "no recent activity" rather than to a guess.
+ */
+export function kiroTimelineForSession(
+  sessionId: string,
+  opts: KiroTimelineOptions = {},
+): TimelineEntry[] {
+  const uuid = rawSessionId(sessionId);
+  if (!uuid) return [];
+  const root = opts.sessionsRoot ?? kiroV3SessionsRoot();
+  const path = locateKiroTranscript(uuid, root);
+  if (!path) {
+    debug('daemon', `kiro-timeline: no v3 transcript for ${uuid}`);
+    return [];
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    debug('daemon', `kiro-timeline read failed: ${String(err)}`);
+    return [];
+  }
+
+  const rows: TimelineEntry[] = [];
+  // Carried across records: an AssistantMessage has no timestamp of its own, so
+  // it is stamped with the prompt it answers.
+  let turnTs = 0;
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let rec: { kind?: string; data?: { content?: unknown; meta?: { timestamp?: unknown } } };
+    try {
+      rec = JSON.parse(line);
+    } catch {
+      continue; // a truncated tail line is normal on a live session
+    }
+    const content = rec.data?.content;
+    if (rec.kind === 'Prompt') {
+      const stamp = rec.data?.meta?.timestamp;
+      // Seconds on the wire, milliseconds in TimelineEntry.
+      if (typeof stamp === 'number' && Number.isFinite(stamp)) turnTs = stamp * 1000;
+      const text = textOf(content);
+      if (!turnTs || !text) continue;
+      rows.push({
+        ts: turnTs,
+        type: 'chat_start',
+        raw: firstLine(text),
+        detail: text.slice(0, 4000),
+        agentType: 'kiro-cli',
+        sessionId: uuid,
+      });
+    } else if (rec.kind === 'AssistantMessage') {
+      const text = textOf(content);
+      if (!turnTs || !text) continue;
+      rows.push({
+        ts: turnTs + 1, // sorts after its prompt; the record carries no time
+        type: 'chat_response',
+        raw: firstLine(text),
+        detail: text.slice(0, 4000),
+        agentType: 'kiro-cli',
+        sessionId: uuid,
+        summaryKind: 'heuristic',
+      });
+    }
+  }
+
+  const since = opts.since;
+  const filtered = since == null ? rows : rows.filter((r) => r.ts > since);
+  filtered.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  const limit = opts.limit ?? 16;
+  return filtered.slice(-limit);
+}


### PR DESCRIPTION
Verifying #216 against a **live** Kiro session found the half that fix could not reach.

## What the check actually showed

The ids match now. The Detail view was still empty — because there was nothing to match against:

```
query_session_timeline  observed:kiro:6b3d3a27-…   →  (no reply at all)
```

Two independent causes, both measured rather than assumed:

| cause | evidence |
|---|---|
| No `kiro_*` hook has **ever** reached this daemon | `grep -c "kiro_" daemon-stderr.log` → **0**, with the v3 hook file installed since Aug 15. v2 has no global standalone hook surface at all, so a v2 session is process/store observed and silent by construction. |
| The existing fallback is Claude-only | `transcriptTimelineForSession` → `locateTranscript` searches `~/.claude/projects/**`. For a Kiro session it can never hit. |

Meanwhile Kiro's own store had the conversation the whole time — 10 records including real prompts and replies.

So an observed Kiro session showed up in `sessions_list` (deck and boards rendered it) while its timeline stayed empty no matter what it did. **Fixing the id normalization in #216 was necessary and not sufficient**, and I had told the user otherwise; this is the correction.

## Change

`kiroTimelineForSession` reads the v3 JSONL (`KIRO_HOME/sessions/**/<uuid>.jsonl`) and pairs `Prompt` / `AssistantMessage` records into chat rows. Kiro **v2** (SQLite `conversations`) is *not* read — it returns nothing, exactly as before, rather than a guess.

## The fixtures came off a real transcript

This repo has a history here: five previous Kiro parsers were written against imagined shapes, passed their own tests, and matched nothing on disk. The two things an invented fixture gets wrong are asserted explicitly:

- **`meta.timestamp` is in SECONDS.** Read as milliseconds it lands in January 1970 — sorting before everything and vanishing under any `since`.
- **Only `Prompt` carries a timestamp.** An `AssistantMessage` has none at all, so its row takes the prompt's, nudged 1 ms so it cannot sort before the thing it answers.

A `thinking` block also carries an **object**, not a string — a careless parser concatenates `[object Object]` into the row. Pinned too.

## Verified on live data

The real session's Detail view went from *no reply* to 9 rows spanning two days:

```
08-16T16:23 chat_start     | hello
08-16T16:23 chat_response  | Hello! How can I help you with AgentDeck today?
08-16T16:32 chat_start     | README.md 읽어보자
…
08-17T02:23 chat_start     | hi
08-17T02:23 chat_response  | Hi! 무엇을 도와드릴까요?
```

`npx vitest run` — 3207 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)