### PR TITLE
Hide the Dock icon while no AgentDeck window is open

### DIFF
--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		19CDAF0B79C1F843366192C0 /* DevicePreviewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */; };
 		1A25F581608D3C282D70FAF5 /* GaugeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE70EEDDCA2199E894D275 /* GaugeBar.swift */; };
 		1BE430CE7A81C3C2B7160250 /* StateColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB2E51F6EFD29341EB6127 /* StateColors.swift */; };
+		1BE9D6DCA23672DBE8540704 /* DockVisibilityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66C7EEA9726686205AF8EC /* DockVisibilityController.swift */; };
 		1CB839431F35EF9304A1EEBF /* AttentionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3124B9668030FDF0A9CE513F /* AttentionNotifier.swift */; };
 		1D193B9524AA5E561A899882 /* Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979988BB4CB2A4B5948FD360 /* Adapter.swift */; };
 		1D406D25862B20792A8293F3 /* DevicePreviewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */; };
@@ -142,6 +143,7 @@
 		4D4A0A6C0120C440966AEFB3 /* DisplaySyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F9A134A1BC3EDEE8309695 /* DisplaySyncService.swift */; };
 		4D747DC11E54E8A60894D481 /* ObservedSteering.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4AC33AE24184BF90D4CAFE /* ObservedSteering.swift */; };
 		4D7595686B60FDBDE4A5210D /* AdbModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83589BA4C41B89C8EF1A46FD /* AdbModule.swift */; };
+		4E3E8F33089962383FF83309 /* DockVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */; };
 		4EC0E953449451FC7C10AEBC /* AppPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E42A4F5681EFB215B43645 /* AppPreferences.swift */; };
 		4F534C59020FE00D6FA87610 /* ProcessEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CE020EB705544FFD580DD9 /* ProcessEnumerator.swift */; };
 		4F6DEDF8FD3A71AFD059278D /* TimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7847FA7381FB8075331B0F12 /* TimelineTests.swift */; };
@@ -178,6 +180,7 @@
 		5E3FCF09BE50281AE6749762 /* ESP32WifiForwardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C671E2324E45E6745813C681 /* ESP32WifiForwardTests.swift */; };
 		5F62235C4D677989E2B7972D /* MiniToml.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F61897614FBE52B61AB8B4 /* MiniToml.swift */; };
 		5FBCFE8F4EBDCB7937FECA50 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D2F35C5E4DF5DAE1C93F54B /* Assets.xcassets */; };
+		62713ABC87653D9FE99C3830 /* DockVisibilityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66C7EEA9726686205AF8EC /* DockVisibilityController.swift */; };
 		62D5FBB2899D2690B43FF0C5 /* DemoPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8A40550B31856011EBBCB7 /* DemoPlayback.swift */; };
 		62F20845F1953514EFB1C11B /* SingletonGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5C866AF54937CD8E433F49 /* SingletonGuard.swift */; };
 		634EEC168E46C62A2DBD1ACA /* FormatUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2994478DEFAA4A1CC8EC54D /* FormatUtils.swift */; };
@@ -259,6 +262,7 @@
 		8DE4D71A8BA18D7373FA3147 /* ApmeParseJudgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB04CEEDD6C769AD9056561 /* ApmeParseJudgeTests.swift */; };
 		8E47C081C0CF3F45715D6E45 /* AnthropicAdminApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB4C24732A9A2DB27CC5F7C0 /* AnthropicAdminApiClient.swift */; };
 		8FAFF0B6F124FB2FBA4B25B0 /* TimeboxModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8655DDFFAFB655DEABF213F5 /* TimeboxModule.swift */; };
+		8FE3D8A54EF01D4165144E0E /* DockVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */; };
 		91FD7626FCF73226181BD900 /* ProjectNameResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7897FE76F480951CD34749 /* ProjectNameResolver.swift */; };
 		93AB7595B2EC62D78A09A58F /* DeskPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D5CE0F7637C0913938BA6B /* DeskPreviews.swift */; };
 		942417AA37DAD475B023BED1 /* PairingWindowStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F0B91327EB48703713A68C /* PairingWindowStore.swift */; };
@@ -516,6 +520,7 @@
 		2B5C866AF54937CD8E433F49 /* SingletonGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingletonGuard.swift; sourceTree = "<group>"; };
 		2B6B05AD3CC720BD76A681F9 /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
 		2D2F35C5E4DF5DAE1C93F54B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2D66C7EEA9726686205AF8EC /* DockVisibilityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockVisibilityController.swift; sourceTree = "<group>"; };
 		2DB04CEEDD6C769AD9056561 /* ApmeParseJudgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApmeParseJudgeTests.swift; sourceTree = "<group>"; };
 		2DC38F54A1C54AB134DB0535 /* PixooPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixooPreview.swift; sourceTree = "<group>"; };
 		2E37B7FE721FDD18B11DAC32 /* AgentCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AgentCommand.swift; path = ../../generated/protocol/AgentCommand.swift; sourceTree = "<group>"; };
@@ -647,6 +652,7 @@
 		B120CABC9029C801CF0A77A2 /* SquatterCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquatterCleaner.swift; sourceTree = "<group>"; };
 		B1853443C348441BF748662A /* AttentionTheaterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttentionTheaterView.swift; sourceTree = "<group>"; };
 		B1F43DCAC6100C73B98139EA /* DisplayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMonitor.swift; sourceTree = "<group>"; };
+		B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockVisibilityPolicyTests.swift; sourceTree = "<group>"; };
 		B6E0B3C7EBBFFD8C2EB08F11 /* HookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstaller.swift; sourceTree = "<group>"; };
 		B857A690693DD802AA05429D /* DaemonServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonServer.swift; sourceTree = "<group>"; };
 		B9841FBF8AFC5D5C65809F8B /* UsageAPIClientThreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClientThreadingTests.swift; sourceTree = "<group>"; };
@@ -790,6 +796,7 @@
 				6675586368BA1D73919FA7E0 /* DaemonPostureTests.swift */,
 				95997D1E19933CBB5A3F400D /* DeviceApprovalGateTests.swift */,
 				4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */,
+				B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */,
 				C671E2324E45E6745813C681 /* ESP32WifiForwardTests.swift */,
 				234CFF4B2832E6B1CA98AF10 /* GatewayParityTests.swift */,
 				165E4184E24C198326D600A6 /* HookIdleTTLTests.swift */,
@@ -987,6 +994,7 @@
 				A0B6AFDC194533BFA388DECA /* AppReviewPrompt.swift */,
 				3124B9668030FDF0A9CE513F /* AttentionNotifier.swift */,
 				5200B4548DFE9F98AEE8D504 /* ContentView.swift */,
+				2D66C7EEA9726686205AF8EC /* DockVisibilityController.swift */,
 				DC62763B9E0E57235CFDACED /* NotificationPermission.swift */,
 				2B5C866AF54937CD8E433F49 /* SingletonGuard.swift */,
 			);
@@ -1425,6 +1433,7 @@
 				37AB2DCA4C89195958B01709 /* DaemonPostureTests.swift in Sources */,
 				1DA82A36B17B48756691D2CD /* DeviceApprovalGateTests.swift in Sources */,
 				1D406D25862B20792A8293F3 /* DevicePreviewSnapshotTests.swift in Sources */,
+				8FE3D8A54EF01D4165144E0E /* DockVisibilityPolicyTests.swift in Sources */,
 				AECF975059EA0A725DB1A3E7 /* ESP32WifiForwardTests.swift in Sources */,
 				D369DAE31A2E86FD08922453 /* GatewayParityTests.swift in Sources */,
 				136F28B1F6B5E4729ADA92EC /* HTTPServerMainThreadStallTests.swift in Sources */,
@@ -1474,6 +1483,7 @@
 				D130F3747ED283214E599734 /* DaemonPostureTests.swift in Sources */,
 				53D37B6B6CCF9EFD0013F153 /* DeviceApprovalGateTests.swift in Sources */,
 				19CDAF0B79C1F843366192C0 /* DevicePreviewSnapshotTests.swift in Sources */,
+				4E3E8F33089962383FF83309 /* DockVisibilityPolicyTests.swift in Sources */,
 				5E3FCF09BE50281AE6749762 /* ESP32WifiForwardTests.swift in Sources */,
 				5E39A0DA9E8B9E175292E84D /* GatewayParityTests.swift in Sources */,
 				DDB79DF8FFBAF3367C0399EF /* HTTPServerMainThreadStallTests.swift in Sources */,
@@ -1579,6 +1589,7 @@
 				F781DA13FBEBEBD70F5ED73A /* DevicePreviewShared.swift in Sources */,
 				CBB9FC921D8EFD210A80BC6D /* DisplayMonitor.swift in Sources */,
 				431FF24E1C1FB9F18ECC8FD2 /* DisplaySyncService.swift in Sources */,
+				62713ABC87653D9FE99C3830 /* DockVisibilityController.swift in Sources */,
 				B5F1B816437285A73378C234 /* ESP32ProvisionSheet.swift in Sources */,
 				D4EA545B7FD41B8A5032F515 /* ESP32Serial.swift in Sources */,
 				7167DBACC477145FD5B446C5 /* ESP32WifiOta.swift in Sources */,
@@ -1768,6 +1779,7 @@
 				441CE4E0A61236F1346DAFFC /* DevicePreviewShared.swift in Sources */,
 				FCF0A9C4BC88D7255023D2F7 /* DisplayMonitor.swift in Sources */,
 				4D4A0A6C0120C440966AEFB3 /* DisplaySyncService.swift in Sources */,
+				1BE9D6DCA23672DBE8540704 /* DockVisibilityController.swift in Sources */,
 				C68C5F90DA83B7DFE263289D /* ESP32ProvisionSheet.swift in Sources */,
 				C71587998379ED779ADFF54F /* ESP32Serial.swift in Sources */,
 				52277012C5AE29828E911577 /* ESP32WifiOta.swift in Sources */,

--- a/apple/AgentDeck/App/AgentDeckApp.swift
+++ b/apple/AgentDeck/App/AgentDeckApp.swift
@@ -35,7 +35,6 @@ struct AgentDeckApp: App {
                 .environmentObject(stateHolder)
                 .environmentObject(preferences)
                 .environmentObject(daemonService)
-                .task { configureDaemonConnection() }
                 // First-launch onboarding sheet. Shown once per install; the
                 // xctest guard in AppPreferences ensures tests never block
                 // on a modal. Safe to render unconditionally — the sheet
@@ -137,6 +136,8 @@ struct AgentDeckApp: App {
         .commands {
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {
+                    // Promote BEFORE the window exists — see prepareToShowWindow().
+                    DockVisibilityController.shared.prepareToShowWindow()
                     NSApp.activate(ignoringOtherApps: true)
                     openWindow(id: "settings")
                 }
@@ -154,13 +155,26 @@ struct AgentDeckApp: App {
                 bridgeConnected: stateHolder.state.bridgeConnected,
                 style: preferences.menuBarIconStyle
             )
+            .onAppear {
+                DockVisibilityController.shared.openDashboard = { openWindow(id: "dashboard") }
+                configureDaemonConnection()
+            }
         }
         .menuBarExtraStyle(.window)
         #endif
     }
 
     #if os(macOS)
+    /// `configureDaemonConnection()` used to ride the Dashboard's `.task`, so it
+    /// ran exactly once because the window opened exactly once. Its new host is
+    /// the MenuBarExtra label's `.onAppear`, which SwiftUI may call again when
+    /// the label re-renders — hence an explicit one-shot.
+    @MainActor private static var didConfigureDaemonConnection = false
+
     private func configureDaemonConnection() {
+        guard !Self.didConfigureDaemonConnection else { return }
+        Self.didConfigureDaemonConnection = true
+
         // Wire AppDelegate to daemon service for clean shutdown
         appDelegate.daemonService = daemonService
         appDelegate.stateHolder = stateHolder
@@ -180,9 +194,21 @@ struct AgentDeckApp: App {
             DispatchQueue.main.async { stateHolder.clearRelayedUsageState() }
         }
 
+        // SwiftUI ALWAYS shows the first `Window` scene at launch, and
+        // `.defaultLaunchBehavior(.suppressed)` does not apply to it — measured
+        // 2026-08-18 with no saved application state present, the Dashboard's
+        // NSWindow is created and `isVisible` regardless. So the preference
+        // could not be honoured by declining to open the window; it has to
+        // close the one macOS opened for us. `ControlTowerPanel.closeDashboard()`
+        // already closes this window the same way and SwiftUI reopens the scene
+        // cleanly afterwards.
         if preferences.openDashboardOnLaunch {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 openWindow(id: "dashboard")
+            }
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                NSApp.windows.first { $0.identifier?.rawValue == "dashboard" }?.close()
             }
         }
 
@@ -196,8 +222,13 @@ struct AgentDeckApp: App {
         // bypasses early under xctest, so the poll loop is safe.
         Task { @MainActor in
             let isXCTest = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-            while !preferences.hasSeenOnboarding && !isXCTest {
+            // Bounded: the onboarding sheet rides the Dashboard window, which
+            // a menu-bar-only user may never open. An unbounded poll would
+            // then tick every 500 ms for the life of the process.
+            var waited = 0
+            while !preferences.hasSeenOnboarding && !isXCTest && waited < 120 {
                 try? await Task.sleep(for: .milliseconds(500))
+                waited += 1
             }
             try? await Task.sleep(for: .seconds(1))
             await NotificationPermission.requestIfNeeded()
@@ -219,6 +250,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Foreground-banner presentation for attention notifications
         // (see UNUserNotificationCenterDelegate extension below).
         UNUserNotificationCenter.current().delegate = self
+
+        // "Menu bar only" mode (issue #221) — no-op unless the preference is on.
+        DockVisibilityController.shared.start(preferences: AppPreferences.shared)
+
+        // A second instance can't raise us by activation alone once the Dock
+        // icon is gone, so SingletonGuard hands the request over as a
+        // distributed notification instead. Name-only: App Sandbox strips
+        // userInfo from distributed notifications and we don't need any.
+        DistributedNotificationCenter.default().addObserver(
+            forName: DockVisibilityController.showDashboardNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                DockVisibilityController.shared.prepareToShowWindow()
+                DockVisibilityController.shared.openDashboard?()
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        }
     }
 
     /// Intercept termination to run daemon cleanup without blocking the main

--- a/apple/AgentDeck/App/AppPreferences.swift
+++ b/apple/AgentDeck/App/AppPreferences.swift
@@ -72,6 +72,13 @@ final class AppPreferences: ObservableObject, @unchecked Sendable {
     @Published var menuBarIconStyle: MenuBarIconStyle {
         didSet { defaults.set(menuBarIconStyle.rawValue, forKey: Keys.menuBarIconStyle) }
     }
+    /// "Menu bar only" — hide the Dock icon while no AgentDeck window is open
+    /// (issue #221). Applied at runtime by `DockVisibilityController`; see that
+    /// file for why this is not a permanent `.accessory` policy and not an
+    /// Info.plist `LSUIElement`. Default off — existing behavior unchanged.
+    @Published var menuBarOnlyMode: Bool {
+        didSet { defaults.set(menuBarOnlyMode, forKey: Keys.menuBarOnlyMode) }
+    }
     @Published var showSessionList: Bool {
         didSet { defaults.set(showSessionList, forKey: Keys.showSessionList) }
     }
@@ -290,6 +297,7 @@ final class AppPreferences: ObservableObject, @unchecked Sendable {
         self.daemonNoDeviceModules = defaults.object(forKey: Keys.daemonNoDeviceModules) as? Bool ?? false
         self.openDashboardOnLaunch = defaults.object(forKey: Keys.openDashboardOnLaunch) as? Bool ?? true
         self.menuBarIconStyle = MenuBarIconStyle(rawValue: defaults.string(forKey: Keys.menuBarIconStyle) ?? "") ?? .status
+        self.menuBarOnlyMode = defaults.object(forKey: Keys.menuBarOnlyMode) as? Bool ?? false
         self.showSessionList = defaults.object(forKey: Keys.showSessionList) as? Bool ?? true
         self.showTankStatus = defaults.object(forKey: Keys.showTankStatus) as? Bool ?? true
         self.showDeviceDiagnostic = defaults.object(forKey: Keys.showDeviceDiagnostic) as? Bool ?? true
@@ -929,6 +937,7 @@ final class AppPreferences: ObservableObject, @unchecked Sendable {
         static let daemonNoDeviceModules = "prefs.daemonNoDeviceModules"
         static let openDashboardOnLaunch = "prefs.openDashboardOnLaunch"
         static let menuBarIconStyle = "prefs.menuBarIconStyle"
+        static let menuBarOnlyMode = "prefs.menuBarOnlyMode"
         static let showSessionList = "prefs.showSessionList"
         static let showTankStatus = "prefs.showTankStatus"
         static let showDeviceDiagnostic = "prefs.showDeviceDiagnostic"

--- a/apple/AgentDeck/App/DockVisibilityController.swift
+++ b/apple/AgentDeck/App/DockVisibilityController.swift
@@ -1,0 +1,223 @@
+#if os(macOS)
+// DockVisibilityController.swift — "Menu bar only" mode (issue #221).
+//
+// Runs AgentDeck without a Dock icon while no AgentDeck window is open, and
+// restores the icon while one is. Deliberately NOT a permanent `.accessory`
+// policy and deliberately NOT an Info.plist `LSUIElement`:
+//
+//   * The Dashboard is a full 1280×840 app window (session list, tank status,
+//     device diagnostics, timeline strip) and for App Store users running
+//     without the Node CLI it IS the app. A permanent accessory policy drops
+//     that window out of ⌘Tab and Mission Control, so the moment it goes
+//     behind another app the only way back is the menu bar icon — a failure
+//     that reads as "AgentDeck is broken in ⌘Tab", not as "the setting I
+//     enabled". Permanent accessory suits utilities whose only window is a
+//     preferences sheet; this isn't one.
+//   * `LSUIElement` cannot be toggled without a relaunch and would default the
+//     behavior on, which contradicts the issue's "default off" requirement.
+//
+// While in the hidden state macOS also removes the global menu bar, so Quit /
+// Settings / Start at Login are reachable only from the menu bar panel. All
+// three already live in ControlTowerPanel, which is why the menu bar icon
+// itself stays non-hideable — it is the escape hatch.
+
+import AppKit
+import Combine
+import Foundation
+
+/// Pure decision layer, split out from the AppKit plumbing so the policy is
+/// testable without a running NSApplication.
+enum DockVisibilityPolicy {
+    /// Scene ids that count as "a real AgentDeck window".
+    ///
+    /// This is an ALLOW-LIST on purpose. `NSApp.windows` is not a list of the
+    /// app's document windows — it also contains the panel backing
+    /// `MenuBarExtra`'s `.window` style, status-item windows, and assorted
+    /// AppKit-internal windows. Counting `NSApp.windows` (or filtering by
+    /// anything other than an explicit id set) means the count never reaches
+    /// zero, the demote never fires, and the whole feature silently does
+    /// nothing: the toggle flips and the Dock icon stays put.
+    ///
+    /// Must list every `Window(id:)` scene declared in `AgentDeckApp.body`.
+    /// SwiftUI sets `NSWindow.identifier` to the scene id (already relied on by
+    /// `ControlTowerPanel.closeDashboard()`).
+    static let trackedWindowIDs: Set<String> = [
+        "dashboard",
+        "apme-dashboard",
+        "device-preview",
+        "pairing-qr",
+        "settings",
+    ]
+
+    /// The subset of an `NSWindow` we actually decide on. Lets tests drive the
+    /// policy without constructing real windows.
+    struct WindowSnapshot: Equatable {
+        let identifier: String?
+        let isVisible: Bool
+        let isMiniaturized: Bool
+
+        init(identifier: String?, isVisible: Bool, isMiniaturized: Bool = false) {
+            self.identifier = identifier
+            self.isVisible = isVisible
+            self.isMiniaturized = isMiniaturized
+        }
+    }
+
+    /// Tracked windows that are currently "open" from the user's point of view.
+    ///
+    /// A minimized window counts as open: `isVisible` is false while
+    /// miniaturized, and demoting to `.accessory` in that state strands the
+    /// window's Dock tile — the user minimizes the Dashboard and can never
+    /// restore it. A closed SwiftUI `Window` scene, by contrast, stays in
+    /// `NSApp.windows` with `isVisible == false`, so the id alone is not
+    /// enough to tell "closed" from "open".
+    static func openTrackedWindowIDs(in windows: [WindowSnapshot]) -> Set<String> {
+        var open: Set<String> = []
+        for window in windows {
+            guard let id = window.identifier, trackedWindowIDs.contains(id) else { continue }
+            guard window.isVisible || window.isMiniaturized else { continue }
+            open.insert(id)
+        }
+        return open
+    }
+
+    static func desiredPolicy(
+        menuBarOnly: Bool,
+        openTrackedWindowIDs: Set<String>
+    ) -> NSApplication.ActivationPolicy {
+        guard menuBarOnly else { return .regular }
+        return openTrackedWindowIDs.isEmpty ? .accessory : .regular
+    }
+}
+
+/// Coalescing window for demote checks. Closing Settings and opening the
+/// Dashboard is one user gesture but two window events; without a beat between
+/// them the policy flaps `.regular` → `.accessory` → `.regular` and the Dock
+/// icon visibly blinks. File scope rather than a `@MainActor` static so it can
+/// be a default argument value (Swift 6 rejects the isolated form there).
+private let dockRecomputeDebounce: TimeInterval = 0.25
+
+/// First recompute is deferred so a launch that is about to open the Dashboard
+/// doesn't hide the icon and immediately show it again.
+private let dockLaunchSettleDelay: TimeInterval = 1.0
+
+/// Owns the live activation policy. Singleton because the window-opening call
+/// sites (`ControlTowerPanel`, the Settings command in `AgentDeckApp`) are
+/// SwiftUI views with no path to the `AppDelegate`.
+@MainActor
+final class DockVisibilityController {
+    static let shared = DockVisibilityController()
+
+    /// Posted by a second instance that `SingletonGuard` is about to kill.
+    /// `NSRunningApplication.activate()` is a no-op for an app with no Dock
+    /// icon and no windows, so relaunching AgentDeck from Finder/Spotlight
+    /// while in the hidden state would otherwise appear to do nothing at all.
+    static let showDashboardNotification = Notification.Name(
+        "bound.serendipity.agent.deck.showDashboard"
+    )
+
+    /// Installed by the MenuBarExtra label, which is the only view guaranteed
+    /// to exist from launch onward — `configureDaemonConnection()` runs in the
+    /// Dashboard window's `.task` and so never fires for a user who runs
+    /// menu-bar-only and never opens the Dashboard.
+    var openDashboard: (() -> Void)?
+
+    private var preferences: AppPreferences?
+    private var cancellables = Set<AnyCancellable>()
+    private var pendingRecompute: DispatchWorkItem?
+    private var started = false
+
+    private init() {}
+
+    func start(preferences: AppPreferences) {
+        guard !started else { return }
+        // Never touch the activation policy under xctest — the test host is a
+        // regular app and demoting it mid-run confuses the runner's XPC
+        // handshake (same reasoning as SingletonGuard's xctest bypass).
+        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
+        started = true
+        self.preferences = preferences
+        let center = NotificationCenter.default
+        for name: Notification.Name in [
+            NSWindow.willCloseNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification,
+        ] {
+            center.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                // willClose fires while the window is still visible, so every
+                // one of these has to settle before we look at the window list.
+                MainActor.assumeIsolated { self?.scheduleRecompute() }
+            }
+        }
+
+        preferences.$menuBarOnlyMode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.recomputeNow() }
+            .store(in: &cancellables)
+
+        if preferences.menuBarOnlyMode && !preferences.openDashboardOnLaunch {
+            // Pure background launch — the configuration the feature exists
+            // for. Try to hide immediately rather than showing the icon for a
+            // second.
+            recomputeNow()
+        }
+        // Always re-check once SwiftUI has settled, and never treat the
+        // first pass as authoritative: at applicationDidFinishLaunching the
+        // Dashboard's NSWindow already exists and still reports
+        // `isVisible == true` even when its scene is `.suppressed`, so an
+        // early-only read decides `.regular` and nothing ever revisits it.
+        scheduleRecompute(after: dockLaunchSettleDelay)
+    }
+
+    /// Call BEFORE `openWindow(id:)`. Promoting after the window already
+    /// exists makes AppKit drop key focus and the new window lands behind the
+    /// app the user came from.
+    func prepareToShowWindow() {
+        pendingRecompute?.cancel()
+        pendingRecompute = nil
+        apply(.regular)
+    }
+
+    func scheduleRecompute(after delay: TimeInterval = dockRecomputeDebounce) {
+        pendingRecompute?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.recomputeNow() }
+        }
+        pendingRecompute = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    func recomputeNow() {
+        pendingRecompute?.cancel()
+        pendingRecompute = nil
+        guard started else { return }
+        let snapshots = NSApp.windows.map {
+            DockVisibilityPolicy.WindowSnapshot(
+                identifier: $0.identifier?.rawValue,
+                isVisible: $0.isVisible,
+                isMiniaturized: $0.isMiniaturized
+            )
+        }
+        apply(DockVisibilityPolicy.desiredPolicy(
+            menuBarOnly: preferences?.menuBarOnlyMode ?? false,
+            openTrackedWindowIDs: DockVisibilityPolicy.openTrackedWindowIDs(in: snapshots)
+        ))
+    }
+
+    private func apply(_ policy: NSApplication.ActivationPolicy) {
+        guard NSApp.activationPolicy() != policy else { return }
+        NSApp.setActivationPolicy(policy)
+        if policy == .regular {
+            // Coming back from .accessory the app is not frontmost, so without
+            // this the restored Dock icon sits inactive behind whatever the
+            // user was in.
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        NSLog("[AgentDeck] Activation policy → \(policy == .accessory ? "accessory (no Dock icon)" : "regular")")
+    }
+}
+#endif

--- a/apple/AgentDeck/App/SingletonGuard.swift
+++ b/apple/AgentDeck/App/SingletonGuard.swift
@@ -63,8 +63,21 @@ enum SingletonGuard {
             Thread.sleep(forTimeInterval: 0.3)
         }
 
-        // Activate existing instance so user sees a window come to front
+        // Activate existing instance so user sees a window come to front.
         other.activate(options: [.activateAllWindows])
+        // ...except that activation is a no-op when the existing instance is
+        // running menu-bar-only with no window open: there is no Dock icon and
+        // nothing to bring forward, so relaunching from Finder/Spotlight would
+        // look like the app simply failed to start. Ask it to show the
+        // Dashboard as well. Name-only post — App Sandbox strips `userInfo`
+        // from distributed notifications, and a regular-policy instance
+        // treats this as the harmless "raise the Dashboard" it already is.
+        DistributedNotificationCenter.default().postNotificationName(
+            DockVisibilityController.showDashboardNotification,
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
         Thread.sleep(forTimeInterval: 0.2)
         NSLog("[AgentDeck] Activated existing instance — this instance exiting")
         exit(0)

--- a/apple/AgentDeck/UI/MenuBar/ControlTowerPanel.swift
+++ b/apple/AgentDeck/UI/MenuBar/ControlTowerPanel.swift
@@ -407,7 +407,10 @@ struct ControlTowerPanel: View {
             .buttonStyle(.plain)
             .foregroundStyle(Color.accentColor)
 
-            Button { openWindow(id: "pairing-qr") } label: {
+            Button {
+                DockVisibilityController.shared.prepareToShowWindow()
+                openWindow(id: "pairing-qr")
+            } label: {
                 Label("Pair iPad", systemImage: "qrcode")
                     .font(.system(size: 10.5, weight: .medium))
             }
@@ -614,6 +617,7 @@ struct ControlTowerPanel: View {
                 .fixedSize(horizontal: false, vertical: true)
             if !connected {
                 Button {
+                    DockVisibilityController.shared.prepareToShowWindow()
                     NSApp.activate(ignoringOtherApps: true)
                     openWindow(id: "settings")
                 } label: {
@@ -907,6 +911,7 @@ struct ControlTowerPanel: View {
 
     private var settingsPillButton: some View {
         Button {
+            DockVisibilityController.shared.prepareToShowWindow()
             NSApp.activate(ignoringOtherApps: true)
             openWindow(id: "settings")
         } label: {
@@ -1033,6 +1038,10 @@ struct ControlTowerPanel: View {
     }
 
     private func openDashboard() {
+        // Promote out of "menu bar only" BEFORE the window exists — promoting
+        // afterwards makes AppKit drop key focus and the window lands behind
+        // whatever the user was in.
+        DockVisibilityController.shared.prepareToShowWindow()
         // SwiftUI's openWindow brings an existing window of this scene to front
         // if one exists, otherwise creates it. Avoids fragile title string matching.
         openWindow(id: "dashboard")
@@ -1059,6 +1068,7 @@ struct ControlTowerPanel: View {
     /// roundtrip, no token in address bar history.
     private func openApmeDashboard() {
         guard daemonService.port > 0 else { return }
+        DockVisibilityController.shared.prepareToShowWindow()
         openWindow(id: "apme-dashboard")
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
@@ -1066,6 +1076,7 @@ struct ControlTowerPanel: View {
     /// Open the Device Preview window. Safe to call whether or not any
     /// hardware is connected — this is the whole point of the window.
     private func openDevicePreview() {
+        DockVisibilityController.shared.prepareToShowWindow()
         openWindow(id: "device-preview")
         NSApplication.shared.activate(ignoringOtherApps: true)
     }

--- a/apple/AgentDeck/UI/Settings/SettingsScreen.swift
+++ b/apple/AgentDeck/UI/Settings/SettingsScreen.swift
@@ -884,6 +884,15 @@ struct SettingsScreen: View {
                 }
             }
 
+            Toggle("Menu bar only", isOn: $preferences.menuBarOnlyMode)
+            // The user is reading this inside a window, so the Dock icon will
+            // still be there after they flip it. Say so — otherwise the toggle
+            // reads as broken at the exact moment it is switched on.
+            Text("Hides the Dock icon while no AgentDeck window is open. The icon comes back whenever you open one, so \u{2318}Tab keeps working. While it's hidden, Quit and Settings live in the menu bar icon.")
+                .font(.system(size: 10))
+                .foregroundStyle(TerrariumHUD.subtext)
+                .fixedSize(horizontal: false, vertical: true)
+
             Divider()
             #endif
 

--- a/apple/AgentDeckTests/DockVisibilityPolicyTests.swift
+++ b/apple/AgentDeckTests/DockVisibilityPolicyTests.swift
@@ -1,0 +1,119 @@
+#if os(macOS)
+import AppKit
+import XCTest
+
+@testable import AgentDeck
+
+/// Gates the decision layer of "Menu bar only" (issue #221). Deliberately
+/// tests the pure policy rather than the live NSApplication — an activation
+/// policy assertion inside the test host would fight the test runner.
+final class DockVisibilityPolicyTests: XCTestCase {
+
+    private func snap(
+        _ id: String?,
+        visible: Bool = true,
+        miniaturized: Bool = false
+    ) -> DockVisibilityPolicy.WindowSnapshot {
+        DockVisibilityPolicy.WindowSnapshot(
+            identifier: id,
+            isVisible: visible,
+            isMiniaturized: miniaturized
+        )
+    }
+
+    // MARK: - The polarity of the feature
+
+    func testDefaultOffAlwaysStaysRegular() {
+        // Off is the shipped default; nothing about window state may change it.
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(menuBarOnly: false, openTrackedWindowIDs: []),
+            .regular
+        )
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(menuBarOnly: false, openTrackedWindowIDs: ["dashboard"]),
+            .regular
+        )
+    }
+
+    func testHidesOnlyWhenNoTrackedWindowIsOpen() {
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(menuBarOnly: true, openTrackedWindowIDs: []),
+            .accessory
+        )
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(menuBarOnly: true, openTrackedWindowIDs: ["dashboard"]),
+            .regular,
+            "An open window must keep the Dock icon — that is what preserves ⌘Tab."
+        )
+    }
+
+    // MARK: - The trap this feature dies on
+
+    func testUntrackedWindowsDoNotHoldTheDockIcon() {
+        // NSApp.windows also contains the MenuBarExtra `.window` panel, status
+        // item windows, and AppKit internals. If any of those counted, the
+        // demote would never fire and the toggle would silently do nothing.
+        let windows = [
+            snap(nil),
+            snap("menu-bar-extra-panel"),
+            snap("NSStatusBarWindow"),
+        ]
+        XCTAssertTrue(DockVisibilityPolicy.openTrackedWindowIDs(in: windows).isEmpty)
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(
+                menuBarOnly: true,
+                openTrackedWindowIDs: DockVisibilityPolicy.openTrackedWindowIDs(in: windows)
+            ),
+            .accessory
+        )
+    }
+
+    func testClosedSceneWindowDoesNotCount() {
+        // A closed SwiftUI `Window` scene stays in NSApp.windows with
+        // isVisible == false, so the identifier alone can't tell open from
+        // closed.
+        let windows = [snap("dashboard", visible: false)]
+        XCTAssertTrue(DockVisibilityPolicy.openTrackedWindowIDs(in: windows).isEmpty)
+    }
+
+    func testMiniaturizedWindowStillCounts() {
+        // isVisible is false while miniaturized. Demoting here strands the
+        // window's Dock tile and the user can never restore it.
+        let windows = [snap("dashboard", visible: false, miniaturized: true)]
+        XCTAssertEqual(DockVisibilityPolicy.openTrackedWindowIDs(in: windows), ["dashboard"])
+        XCTAssertEqual(
+            DockVisibilityPolicy.desiredPolicy(
+                menuBarOnly: true,
+                openTrackedWindowIDs: DockVisibilityPolicy.openTrackedWindowIDs(in: windows)
+            ),
+            .regular
+        )
+    }
+
+    func testAnyTrackedWindowHoldsTheIconNotJustTheDashboard() {
+        for id in DockVisibilityPolicy.trackedWindowIDs {
+            let open = DockVisibilityPolicy.openTrackedWindowIDs(in: [snap(id)])
+            XCTAssertEqual(open, [id], "\(id) should count as an open window")
+            XCTAssertEqual(
+                DockVisibilityPolicy.desiredPolicy(menuBarOnly: true, openTrackedWindowIDs: open),
+                .regular,
+                "\(id) is a real window — it must keep the app in ⌘Tab"
+            )
+        }
+    }
+
+    func testMixedWindowListCountsOnlyTheTrackedVisibleOnes() {
+        let windows = [
+            snap(nil),
+            snap("dashboard", visible: false),          // closed
+            snap("settings"),                            // open
+            snap("device-preview", visible: false, miniaturized: true),  // minimized
+            snap("some-appkit-panel"),
+        ]
+        XCTAssertEqual(
+            DockVisibilityPolicy.openTrackedWindowIDs(in: windows),
+            ["settings", "device-preview"]
+        )
+    }
+}
+#endif


### PR DESCRIPTION
Closes #221.

## What

A `Menu bar only` toggle in Settings → Dashboard, under the existing "Menu bar icon" picker. Default **off**; existing behavior unchanged.

**Semantics: the Dock icon is hidden while no AgentDeck window is open, and comes back while one is.** Not a permanent `.accessory` policy, and not an Info.plist `LSUIElement`.

The Dashboard is a full 1280×840 app window, and for App Store users running without the Node CLI it *is* the app. Under a permanent accessory policy that window drops out of ⌘Tab and Mission Control, so the moment it goes behind another app the only way back is the menu bar icon — a failure that reads as "AgentDeck is broken in ⌘Tab", not as "the setting I enabled". `LSUIElement`, separately, cannot be toggled without a relaunch and would default the behavior on, contradicting the issue's default-off requirement.

The issue author's use case is fully covered: they say they almost never open the Dashboard, so they will almost never see a Dock icon.

## Two traps this is shaped around

**`NSApp.windows` is not a list of the app's document windows.** It also contains the panel backing `MenuBarExtra`'s `.window` style and assorted AppKit internals, which carry no identifier. Counting it — or filtering by anything other than an explicit id set — means the count never reaches zero, the demote never fires, and the toggle silently does nothing. So the policy keys off an allow-list of scene ids. A miniaturized window still counts as open: `isVisible` is false while miniaturized, and demoting there strands the window's Dock tile.

**SwiftUI always shows the first `Window` scene at launch, and `.defaultLaunchBehavior(.suppressed)` does not apply to it.** Measured with no saved application state present, the Dashboard's NSWindow is created and `isVisible` regardless. `openDashboardOnLaunch` therefore could not be honoured by declining to open the window — it has to close the one macOS opened. **This also fixes that preference, which until now did nothing:** the window opened twice over, once implicitly and once via `openWindow`.

## Consequences handled

- `configureDaemonConnection()` moved off the Dashboard's `.task`, which never ran for a user who never opens the Dashboard, onto the MenuBarExtra label. It does **not** start the daemon (`DaemonService.init` does) — it wires AppDelegate's shutdown handles, `onReady`, and `onPromotedToOwner`. One-shot guarded, since `.onAppear` may fire again.
- The onboarding poll is now bounded. It waits on a sheet that rides the Dashboard window, so with no Dashboard it ticked every 500 ms for the life of the process.
- Every window entry point promotes **before** `openWindow`; promoting after the window exists makes AppKit drop key focus.
- `SingletonGuard` posts a distributed notification as well as activating. `NSRunningApplication.activate()` is a no-op against an instance with no Dock icon and no window, so relaunching from Finder looked like a failure to start.

While hidden, macOS also removes the global menu bar, so Quit / Settings / Start at Login are reachable only from the menu bar panel. All three already live in `ControlTowerPanel` — which is why the menu bar icon itself stays non-hideable. It is the escape hatch.

## Verification

Measured on a running build, reading the live window list and `background only of process`:

| menuBarOnly | openDashOnLaunch | windows seen | decided | Dock icon |
|---|---|---|---|---|
| ON | OFF | `open=[]` | accessory | **hidden** |
| ON | ON | `open=["dashboard"]` | regular | shown |
| OFF | ON | `open=["dashboard"]` | regular | shown |
| OFF | OFF | `open=[]` | **regular** | shown |

The last row is the default-off guarantee: no windows, but the toggle is off, so the icon stays.

Relaunch-while-hidden was verified separately: `background only` true → `open -a` → false, with the instance count still 1. In every run the allow-list correctly ignored the `nil`-identifier windows.

7 new unit tests pin the policy, including the untracked-window and miniaturized cases. **614 macOS tests pass; iOS builds.**

## Not included

No App Store surface concerns: this is a runtime `NSApp.setActivationPolicy` call, no subprocess, no entitlement, no Info.plist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)