### PR TITLE
Land the unpushed Stream Deck usage-key and Pixoo creature-clamp work

### DIFF
--- a/.agents/skills/agentdeck-deploy/SKILL.md
+++ b/.agents/skills/agentdeck-deploy/SKILL.md
@@ -134,12 +134,12 @@ adb -s $SERIAL reverse tcp:9120 tcp:9120
 
 **Pantone 6** (after ANY install, especially after uninstall→reinstall):
 ```bash
-# Rotation fix — reinstall resets system rotation settings
+# Rotation fix — reinstall resets system rotation settings (NOTE: Pantone 6 only! Do NOT run on Crema S or ordinary tablets)
 adb -s AA007422R24C1300039 shell settings put system accelerometer_rotation 0
 adb -s AA007422R24C1300039 shell settings put system user_rotation 1  # 1=landscape
 ```
 
-**Crema S**: No special steps needed.
+**Crema S**: No special steps needed. (Standard `requestedOrientation` is used; do not modify system-wide `user_rotation`.)
 
 **Lenovo Tab**: No special steps needed.
 

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-08-18 — Pixoo64 하단 사용량 HUD 활성 시 크리처 Safe Area Floor 동적 클램핑
+
+### 배경 및 원인
+- Pixoo64(64×64 LED 매트릭스)에서 하단 Usage HUD(단일 공급자 시 Y 57~63, 듀얼 공급자 시 Y 50~63)가 70% 블랙 불투명 배경으로 최상단 오버레이 렌더링됨.
+- 반면 유휴 상태(`idle`) 크리처들의 배치 수심(`worldY ≈ 0.80`, 화면 Y ≈ 51.2px, 스프라이트 높이 12~14px)이 바닥 모래사장 근처에 고정되어 있어, 하단 사용량 표시 영역 뒤로 크리처 하반신과 활동이 가려져 잘 보이지 않는 문제가 발생함.
+- Crayfish(OpenClaw) 착석 위치 및 테트라 물고기 떼의 유영 하한선 역시 HUD 뒤로 묻힘.
+
+### 개선 사항
+- **Safe Area Floor 동적 적용**: 활성화된 Usage HUD 행 수에 따라 크리처 및 수조 환경 요소의 유휴 수심 하한을 HUD 상단 안전 구역으로 클램핑:
+  - 듀얼 HUD (Y 50~63 점유): 크리처 중심 `Y ≤ 0.65` (약 41px)로 클램핑하여 HUD 상단(Y=50) 위쪽 수조에서 온전히 표시.
+  - 단일 HUD (Y 57~63 점유): 크리처 중심 `Y ≤ 0.72` (약 46px)로 클램핑.
+  - HUD 미표시: 기존 바닥 수심 (`Y = 0.80`) 유지.
+  - 작업 중(`processing`, 상/중층 수심)인 크리처는 Safe Area보다 위에 있으므로 기존 자연스러운 유영 궤적 유지.
+- **Crayfish 및 Tetra 물고기 떼 동기화**:
+  - Crayfish 착석 Y(`cfY`)도 HUD 활성 시 Safe Area 상단(0.65 / 0.72)으로 조정.
+  - 테트라 물고기 떼의 최대 유영 수심(`tetraMaxY`)을 HUD 상단선 위(46 / 52px)로 제한하여 HUD 뒤로 묻히지 않도록 개선.
+- **Node.js 데몬 & macOS Swift 데몬 동기화 (SSOT)**:
+  - `bridge/src/pixoo/pixoo-renderer.ts` 및 `apple/AgentDeck/Daemon/Modules/PixooRenderer.swift` 대칭 수정.
+- **검증**: `bridge/src/__tests__/pixoo-creature-sync.test.ts`에 HUD 상태별 Safe Area Floor 단위 테스트 추가, 3,215개 전체 테스트 패스 확인.
+
+---
+
 ## 2026-08-17 — Kiro 는 아무것도 보고하지 않는다 (그래서 양쪽 데몬이 직접 읽는다)
 
 ### 측정: 훅은 로드되지만 발화하지 않는다

--- a/android/app/src/main/kotlin/dev/agentdeck/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/MainActivity.kt
@@ -197,14 +197,39 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private var originalAccelerometerRotation: Int? = null
+    private var originalUserRotation: Int? = null
+    private var hasModifiedSystemRotation: Boolean = false
+
+    override fun onDestroy() {
+        super.onDestroy()
+        restoreSystemRotationIfNeeded()
+    }
+
+    private fun restoreSystemRotationIfNeeded() {
+        if (hasModifiedSystemRotation && Settings.System.canWrite(this)) {
+            try {
+                originalAccelerometerRotation?.let {
+                    Settings.System.putInt(contentResolver, Settings.System.ACCELEROMETER_ROTATION, it)
+                }
+                originalUserRotation?.let {
+                    Settings.System.putInt(contentResolver, Settings.System.USER_ROTATION, it)
+                }
+                hasModifiedSystemRotation = false
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to restore system rotation: ${e.message}")
+            }
+        }
+    }
+
     /**
-     * Apply system-level rotation for RK3566 devices that ignore requestedOrientation.
+     * Apply system-level rotation only for devices that ignore requestedOrientation (e.g. Pantone 6).
      * Auto-requests WRITE_SETTINGS permission if not granted (lost on APK reinstall).
      */
     private fun applyOrientationPreference(orientation: Int) {
         requestedOrientation = DashboardOrientation.requestedActivityOrientation(orientation)
 
-        if (!deviceProfile.isEink) return
+        if (!deviceProfile.requiresSystemFixedRotation) return
 
         when {
             orientation == DashboardOrientation.Landscape -> applySystemFixedRotation(Surface.ROTATION_90)
@@ -217,8 +242,17 @@ class MainActivity : ComponentActivity() {
     private fun applySystemFixedRotation(rotation: Int) {
         if (Settings.System.canWrite(this)) {
             try {
+                if (!hasModifiedSystemRotation) {
+                    originalAccelerometerRotation = try {
+                        Settings.System.getInt(contentResolver, Settings.System.ACCELEROMETER_ROTATION)
+                    } catch (_: Exception) { null }
+                    originalUserRotation = try {
+                        Settings.System.getInt(contentResolver, Settings.System.USER_ROTATION)
+                    } catch (_: Exception) { null }
+                }
                 Settings.System.putInt(contentResolver, Settings.System.ACCELEROMETER_ROTATION, 0)
                 Settings.System.putInt(contentResolver, Settings.System.USER_ROTATION, rotation)
+                hasModifiedSystemRotation = true
             } catch (e: Exception) {
                 Log.w(TAG, "System rotation fallback failed: ${e.message}")
             }

--- a/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfile.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/util/DeviceProfile.kt
@@ -175,6 +175,11 @@ data class DeviceProfile(
      * Vendor names live here rather than in the rail so the two cannot drift.
      */
     val shortLabel: String,
+    /**
+     * True for rare reader firmwares (Pantone 6 / MOAAN) that ignore
+     * requestedOrientation and require direct Settings.System writes.
+     */
+    val requiresSystemFixedRotation: Boolean = false,
 ) {
     val isEink: Boolean get() = panel.isEink
     val isColorEink: Boolean get() = panel == PanelKind.EinkColor
@@ -300,6 +305,7 @@ fun classifyDevice(
         overridden = override != PanelOverride.Auto,
         displayName = displayNameFor(fp),
         shortLabel = shortLabelFor(fp, formFactor),
+        requiresSystemFixedRotation = requiresSystemFixedRotationFor(fp),
     )
 }
 
@@ -540,6 +546,13 @@ private val COLOR_EINK_MODELS: Map<String, Set<String>> = mapOf(
     "remarkable" to setOf("paper pro"),
     "viwoods" to setOf("color"),
 )
+
+private fun requiresSystemFixedRotationFor(fp: DeviceFingerprint): Boolean {
+    val identity = vendorIdentityOf(fp)
+    val model = normalizeVendor(fp.model)
+    // Pantone 6 (MOAAN Pantone) ignores requestedOrientation in its RK3566 framework build.
+    return identity.any { it.contains("moaan") || it.contains("moan") } || model.contains("pantone")
+}
 
 /**
  * Short device label for the daemon topology row. Named readers keep their own

--- a/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/util/DeviceProfileTest.kt
@@ -119,30 +119,34 @@ class DeviceProfileTest {
     // MARK: - Devices the previous detector recognised must keep working
 
     @Test
-    fun `crema stays eink`() {
+    fun `crema stays eink and does not require system fixed rotation`() {
         val profile = classifyDevice(fingerprint(manufacturer = "crema", model = "Crema S"))
         assertEquals(PanelKind.EinkMono, profile.panel)
         assertEquals(EinkEvidence.KnownVendor, profile.einkEvidence)
         assertEquals(FormFactor.Reader, profile.formFactor)
+        assertFalse(profile.requiresSystemFixedRotation)
     }
 
     @Test
     fun `onyx boox stays eink`() {
         val profile = classifyDevice(fingerprint(manufacturer = "ONYX", model = "Nova3"))
         assertEquals(PanelKind.EinkMono, profile.panel)
+        assertFalse(profile.requiresSystemFixedRotation)
     }
 
     @Test
     fun `kobo stays eink`() {
         val profile = classifyDevice(fingerprint(manufacturer = "Kobo", model = "Clara HD"))
         assertEquals(PanelKind.EinkMono, profile.panel)
+        assertFalse(profile.requiresSystemFixedRotation)
     }
 
     @Test
-    fun `moaan pantone is color eink`() {
+    fun `moaan pantone is color eink and requires system fixed rotation`() {
         val profile = classifyDevice(fingerprint(manufacturer = "MOAAN", model = "Pantone 6"))
         assertEquals(PanelKind.EinkColor, profile.panel)
         assertTrue(profile.isColorEink)
+        assertTrue(profile.requiresSystemFixedRotation)
     }
 
     @Test

--- a/apple/AgentDeck/Daemon/Modules/PixooRenderer.swift
+++ b/apple/AgentDeck/Daemon/Modules/PixooRenderer.swift
@@ -423,11 +423,13 @@ final class PixooRenderer {
             }
         }
 
+        let hudCount = hudProviderCount(from: dashboardState)
+        let crayfishY = hudCount >= 2 ? 0.65 : (hudCount == 1 ? 0.72 : Self.cfDefaultY)
         let crayfishRouting = hasGateway && dashboardState.siblingSessions.contains {
             $0.agentType == "openclaw" && $0.state == "processing"
         }
         if crayfishRouting {
-            activeCreatures.append(.init(x: Self.cfDefaultX, y: Self.cfDefaultY, priority: 2))
+            activeCreatures.append(.init(x: Self.cfDefaultX, y: crayfishY, priority: 2))
         }
 
         let nowMs = Date().timeIntervalSince1970 * 1000
@@ -438,7 +440,7 @@ final class PixooRenderer {
             dt: dt,
             activeCreatures: activeCreatures,
             crayfishRouting: crayfishRouting,
-            crayfishPos: hasGateway ? (Self.cfDefaultX, Self.cfDefaultY) : nil,
+            crayfishPos: hasGateway ? (Self.cfDefaultX, crayfishY) : nil,
             schoolPos: schoolPos
         ))
 
@@ -480,7 +482,7 @@ final class PixooRenderer {
                 glowPixel(&world, Int(round(particle.x)), Int(round(particle.y)), color, 0.5 * fadeAlpha)
             }
 
-            let tetraMaxY = Self.sandTop - 3
+            let tetraMaxY = hudCount >= 2 ? 46 : (hudCount == 1 ? 52 : (Self.sandTop - 3))
             updateTetras(animFrame: animFrame, surfaceY: Self.surfaceY, maxY: tetraMaxY)
             drawSurface(&world, animFrame: animFrame, surfaceY: Self.surfaceY, palette: palette, state: effectiveState)
 
@@ -507,7 +509,7 @@ final class PixooRenderer {
             }
 
             if hasGateway {
-                drawOfficialDotGlyph(&output, glyph: .openClaw, worldX: Self.cfDefaultX, worldY: Self.cfDefaultY, state: crayfishRouting ? .processing : .idle, animFrame: animFrame, camera: camera, sessionToneIndex: 0, sick: dashboardState.gatewayHasError)
+                drawOfficialDotGlyph(&output, glyph: .openClaw, worldX: Self.cfDefaultX, worldY: crayfishY, state: crayfishRouting ? .processing : .idle, animFrame: animFrame, camera: camera, sessionToneIndex: 0, sick: dashboardState.gatewayHasError)
             }
 
             if usagePct >= 90 {
@@ -878,13 +880,14 @@ final class PixooRenderer {
         let kiroSlots = pixooSlots(for: .kiro, count: typeCounts[.kiro] ?? 0)
         var typeIndices: [CreatureKind: Int] = [.octopus: 0, .cloud: 0, .opencode: 0, .antigravity: 0, .kiro: 0]
 
+        let hudCount = hudProviderCount(from: dashboardState)
         for (index, session) in aliveCoding.enumerated() {
             let kind = creatureType(for: session.agentType)
             let slotIndex = typeIndices[kind, default: 0]
             typeIndices[kind, default: 0] = slotIndex + 1
             let slot = pixooSlot(for: kind, index: slotIndex, octopusSlots: octopusSlots, cloudSlots: cloudSlots, opencodeSlots: opencodeSlots, antigravitySlots: antigravitySlots, kiroSlots: kiroSlots)
             let worldX = Double(slot.x)
-            let worldY = stateY(session.state, kind: kind, baseY: Double(slot.y))
+            let worldY = stateY(session.state, kind: kind, baseY: Double(slot.y), hudProviderCount: hudCount)
 
             if var existing = creatureInstances[session.id] {
                 existing.state = session.state
@@ -930,7 +933,7 @@ final class PixooRenderer {
                 antigravitySlots: antigravitySlots,
                 kiroSlots: kiroSlots
             )
-            primary.worldY = stateY(preciseState, kind: primary.creatureType, baseY: Double(baseSlot.y))
+            primary.worldY = stateY(preciseState, kind: primary.creatureType, baseY: Double(baseSlot.y), hudProviderCount: hudCount)
             creatureInstances[aliveCoding[primaryIndex].id] = primary
         }
     }
@@ -1955,39 +1958,61 @@ final class PixooRenderer {
         }
     }
 
-    private func stateY(_ state: CreatureState, kind: CreatureKind, baseY: Double) -> Double {
-        switch kind {
+    private func hudProviderCount(from dashboardState: DashboardState) -> Int {
+        var count = 0
+        if dashboardState.usageStale != true, dashboardState.fiveHourPercent != nil {
+            count += 1
+        }
+        func freshCodexWindow(_ window: CodexRateLimitWindow?) -> Bool {
+            window?.stale != true && window?.usedPercent != nil
+        }
+        let codexPrimary = freshCodexWindow(dashboardState.codexRateLimits?.primary)
+        let codexSecondary = freshCodexWindow(dashboardState.codexRateLimits?.secondary)
+        if codexPrimary || codexSecondary {
+            count += 1
+        }
+        return count
+    }
+
+    private func stateY(_ state: CreatureState, kind: CreatureKind, baseY: Double, hudProviderCount: Int = 0) -> Double {
+        let y: Double = switch kind {
         case .octopus:
             switch state {
-            case .processing: return clamp(baseY, min: 0.40, max: 0.54)
-            case .awaiting: return clamp(baseY - 0.04, min: 0.35, max: 0.48)
-            case .idle: return 0.80
+            case .processing: clamp(baseY, min: 0.40, max: 0.54)
+            case .awaiting: clamp(baseY - 0.04, min: 0.35, max: 0.48)
+            case .idle: 0.80
             }
         case .cloud:
             switch state {
-            case .processing: return clamp(baseY, min: 0.16, max: 0.28)
-            case .awaiting: return clamp(baseY + 0.26, min: 0.52, max: 0.64)
-            case .idle: return clamp(baseY + 0.40, min: 0.80, max: 0.82)
+            case .processing: clamp(baseY, min: 0.16, max: 0.28)
+            case .awaiting: clamp(baseY + 0.26, min: 0.52, max: 0.64)
+            case .idle: clamp(baseY + 0.40, min: 0.80, max: 0.82)
             }
         case .opencode:
             switch state {
-            case .processing: return clamp(baseY - 0.02, min: 0.20, max: 0.34)
-            case .awaiting: return clamp(baseY + 0.22, min: 0.50, max: 0.62)
-            case .idle: return clamp(baseY + 0.36, min: 0.79, max: 0.81)
+            case .processing: clamp(baseY - 0.02, min: 0.20, max: 0.34)
+            case .awaiting: clamp(baseY + 0.22, min: 0.50, max: 0.62)
+            case .idle: clamp(baseY + 0.36, min: 0.79, max: 0.81)
             }
         case .antigravity:
             switch state {
-            case .processing: return clamp(baseY - 0.04, min: 0.16, max: 0.30)
-            case .awaiting: return clamp(baseY + 0.22, min: 0.46, max: 0.54)
-            case .idle: return clamp(baseY + 0.34, min: 0.56, max: 0.64)
+            case .processing: clamp(baseY - 0.04, min: 0.16, max: 0.30)
+            case .awaiting: clamp(baseY + 0.22, min: 0.46, max: 0.54)
+            case .idle: clamp(baseY + 0.34, min: 0.56, max: 0.64)
             }
         case .kiro:
             switch state {
-            case .processing: return clamp(baseY - 0.04, min: 0.16, max: 0.30)
-            case .awaiting: return clamp(baseY + 0.16, min: 0.42, max: 0.54)
-            case .idle: return clamp(baseY + 0.26, min: 0.60, max: 0.70)
+            case .processing: clamp(baseY - 0.04, min: 0.16, max: 0.30)
+            case .awaiting: clamp(baseY + 0.16, min: 0.42, max: 0.54)
+            case .idle: clamp(baseY + 0.26, min: 0.60, max: 0.70)
             }
         }
+        if hudProviderCount >= 2 {
+            return min(y, 0.65)
+        } else if hudProviderCount == 1 {
+            return min(y, 0.72)
+        }
+        return y
     }
 
     private func clamp(_ value: Double, min minValue: Double, max maxValue: Double) -> Double {

--- a/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
@@ -675,8 +675,7 @@ public enum D200HLayoutModel {
             codexTiles.append((.usageGauge(agent: "codex", window: usageWindowKind(usage.codexSecondaryWindowMinutes), percent: s, known: true, stale: usage.codexSecondaryStale, inactive: false, footnote: codexFootnote(stale: usage.codexSecondaryStale, capturedAt: usage.codexCapturedAt)), usageWindowLabel(usage.codexSecondaryWindowMinutes), "codex"))
         }
         let worstScoped = usage.known ? usage.scopedLimits.first : nil
-        let scopedClaims = worstScoped.map { $0.active || codexTiles.isEmpty } ?? false
-        if scopedClaims && !codexTiles.isEmpty { codexTiles.removeLast() }
+        let scopedClaims = worstScoped != nil
         let scopedTile: (D200HSlotKind, String, String)? = {
             guard scopedClaims, let s = worstScoped else { return nil }
             let label = s.label

--- a/bridge/src/__tests__/pixoo-creature-sync.test.ts
+++ b/bridge/src/__tests__/pixoo-creature-sync.test.ts
@@ -205,3 +205,62 @@ describe('pixoo creature sync — unknown agent types', () => {
     }
   });
 });
+
+describe('pixoo creature sync — Usage HUD safe area floor', () => {
+  const usage = (over: Record<string, unknown> = {}) => ({
+    type: 'usage_update',
+    sessionDurationSec: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    toolCalls: 0,
+    ...over,
+  } as never);
+
+  it('keeps normal ground depth (0.80) when no usage HUD is active', () => {
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'claude:1', agentType: 'claude-code', state: 'idle' }),
+    ], null, null);
+
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].worldY).toBeCloseTo(0.80, 2);
+  });
+
+  it('clamps idle creatures to 0.72 when a single-provider HUD is active', () => {
+    const singleHudUsage = usage({ fiveHourPercent: 42 });
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'claude:1', agentType: 'claude-code', state: 'idle' }),
+    ], null, singleHudUsage);
+
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].worldY).toBeCloseTo(0.72, 2);
+  });
+
+  it('clamps idle creatures to 0.65 when a dual-provider HUD is active', () => {
+    const dualHudUsage = usage({
+      fiveHourPercent: 42,
+      codexRateLimits: { secondary: { usedPercent: 80, windowMinutes: 10080 } },
+    });
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'claude:1', agentType: 'claude-code', state: 'idle' }),
+      session({ id: 'codex:1', agentType: 'codex-cli', state: 'idle' }),
+    ], null, dualHudUsage);
+
+    expect(snapshot).toHaveLength(2);
+    expect(snapshot.every(c => c.worldY <= 0.65)).toBe(true);
+  });
+
+  it('does not alter upper/mid-water processing creatures when HUD is active', () => {
+    const dualHudUsage = usage({
+      fiveHourPercent: 42,
+      codexRateLimits: { secondary: { usedPercent: 80, windowMinutes: 10080 } },
+    });
+    const snapshot = getCreatureLayoutSnapshot([
+      session({ id: 'claude:1', agentType: 'claude-code', state: 'processing' }),
+    ], null, dualHudUsage);
+
+    expect(snapshot).toHaveLength(1);
+    // Processing octopus holds mid-water (<= 0.54), well above 0.65
+    expect(snapshot[0].worldY).toBeLessThanOrEqual(0.54);
+  });
+});
+

--- a/docs/streamdeck-layout.md
+++ b/docs/streamdeck-layout.md
@@ -43,19 +43,8 @@ All keypad buttons are `session-slot`; the plugin reads the physical device grid
 
 Encoder/dial families: the **Stream Deck+** (4 dials) and **Stream Deck + XL** (6 dials) carry usage on their dials, so the keypad reserves no usage keys. E1–E4 map to Volume / Claude Usage / Codex Usage / Launcher; on the + XL, E5–E6 are intentionally unassigned. The **Stream Deck XL** has no dials and pins usage to its last keypad keys, like the classic deck. Device→family is resolved from the Elgato `DeviceType` (2 = XL, 7 = Plus, 13 = + XL); bundled profiles `agentdeck-sdxl` (DeviceType 2) and `agentdeck-sdplusxl` (DeviceType 13) AutoInstall and auto-switch on connect.
 
-**The keypad usage strip is hide-if-absent, and the scoped cap competes for what Codex leaves.**
-Claude 5H/7D take the first two reserved keys; the rest go to Codex windows. A
-provider reporting nothing claims no key at all, so the freed slots flow back to
-sessions — most commonly on a **free ChatGPT tier**, which has no rolling
-subscription windows (the daemon still ships the account tier as a windowless
-`codexRateLimits`, so the plan stays nameable and a retired plan's gauge can be
-retracted). The worst per-model scoped cap — the weekly "Fable" limit and its
-kin, otherwise reachable only via the E2 encoder and the opt-in `limit-key` —
-takes a key under `scopedLimitClaimsUsageKey` (`shared/src/format-utils.ts`),
-shared with the D200H strip so the two decks can't disagree about which limit the
-user is looking at: an **active** cap is the binding one and is placed ahead of
-Codex; an **inactive** one only lands on a key Codex left spare, and never
-displaces a live window.
+**The keypad usage strip is hide-if-absent, taking up to 4 keys on 15+ key devices.**
+Claude 5H/7D take the first two reserved keys; a per-model scoped cap (e.g. weekly "Fable") and Codex windows (e.g. Codex 7D) occupy the remaining reserved keys without displacing each other. On devices with 15+ keys, up to 4 reserved buttons are used so Claude 5H, Claude 7D, Fable, and Codex 7D can all be displayed simultaneously. A provider reporting nothing claims no key at all, so freed slots flow back to sessions — most commonly on a **free ChatGPT tier**, which has no rolling subscription windows. An **active** scoped cap (the binding limit) is placed ahead of Codex windows; an **inactive** cap renders muted after Codex windows. Stream Deck+ dial encoders (E2/E3) and 0-keypad usage reserve remain unchanged.
 
 No daemon: single recovery hero. The geometric center key (`floor(rows/2) * columns + floor(columns/2)` — SD+ 4×2 → slot 6, SD MK2 5×3 → slot 7, SD XL 8×4 → slot 20, SD Mini 3×2 → slot 4) shows **OFFLINE / Open AgentDeck** and launches the AgentDeck Dashboard app on press; every other key is intentionally dark and inert. Auto-reconnect handles re-discovery so no manual RETRY affordance is exposed.
 

--- a/plugin/src/__tests__/session-slot-manager.test.ts
+++ b/plugin/src/__tests__/session-slot-manager.test.ts
@@ -903,19 +903,19 @@ describe('SessionSlotManager scoped cap vs the Codex usage keys', () => {
     expect(tiles[2]).toMatchObject({ usageLabel: 'FABLE', usagePercent: 61, usageInactive: true });
   });
 
-  it('lets an ACTIVE cap TAKE the Codex key — it is the limit that binds', () => {
+  it('shows Claude 5H, 7D, active Fable, and Codex weekly together on 4 reserved keys', () => {
     const tiles = gauges({
       fiveHourPercent: 42, sevenDayPercent: 17,
       codexRateLimits: CODEX_WEEKLY, scopedLimits: [FABLE],
     });
-    // Replacement, not addition: the reserve is carved out of session keys, so
-    // three gauges stay three. The lone Codex weekly is what the cap took.
-    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE']);
+    // On 15+ key Stream Deck devices, up to 4 keys are reserved.
+    // Claude 5H, 7D, Fable, and Codex 7D (weekly) all show together across 4 keys.
+    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE', '7D']);
     expect(tiles[2]).toMatchObject({ usageInactive: false, usageAgent: 'claude' });
-    expect(tiles.some((t) => t.usageAgent === 'codex')).toBe(false);
+    expect(tiles[3]).toMatchObject({ usageAgent: 'codex' });
   });
 
-  it('keeps the first Codex window when Codex reports two', () => {
+  it('keeps Codex windows beside active Fable and enables paging when >4 gauges exist', () => {
     const tiles = gauges({
       fiveHourPercent: 42, sevenDayPercent: 17,
       codexRateLimits: {
@@ -924,17 +924,19 @@ describe('SessionSlotManager scoped cap vs the Codex usage keys', () => {
       },
       scopedLimits: [FABLE],
     });
-    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE', '5H']);
-    expect(tiles[3]).toMatchObject({ usageAgent: 'codex' });
+    // 5 gauges total (Claude 5H, 7D, Fable, Codex 5H, Codex 7D) > MAX_USAGE_RESERVE (4).
+    // Page 1 displays 3 usage tiles + 1 page toggle tile.
+    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE']);
   });
 
-  it('never lets an INACTIVE cap displace a live Codex window', () => {
+  it('places an inactive cap after live Codex windows on 4 reserved keys', () => {
     const tiles = gauges({
       fiveHourPercent: 42, sevenDayPercent: 17,
       codexRateLimits: CODEX_WEEKLY, scopedLimits: [FABLE_IDLE],
     });
-    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', '7D']);
+    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', '7D', 'FABLE']);
     expect(tiles[2]).toMatchObject({ usageAgent: 'codex' });
+    expect(tiles[3]).toMatchObject({ usageLabel: 'FABLE', usageInactive: true });
   });
 
   it('drops the scoped cap along with the Claude gauges when usage goes stale', () => {
@@ -947,10 +949,7 @@ describe('SessionSlotManager scoped cap vs the Codex usage keys', () => {
     expect(tiles).toHaveLength(0);
   });
 
-  it('handles the live free-tier shape: a lone 30-day window yields to the binding cap', () => {
-    // Verbatim from the daemon on a free ChatGPT tier (2026-08-08): one 43200-min
-    // window at 0% and no credits. It is a real window, so it is NOT voided — but
-    // an active weekly cap at 76% is the limit the user is actually up against.
+  it('shows Claude 5H, 7D, Fable, and a lone 30-day Codex window together across 4 reserved keys', () => {
     const tiles = gauges({
       fiveHourPercent: 45, sevenDayPercent: 65,
       codexRateLimits: {
@@ -960,7 +959,7 @@ describe('SessionSlotManager scoped cap vs the Codex usage keys', () => {
       },
       scopedLimits: [{ label: 'Fable', percent: 76, active: true }],
     });
-    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE']);
+    expect(tiles.map((t) => t.usageLabel)).toEqual(['5H', '7D', 'FABLE', '30D']);
   });
 
   it('shows the scoped cap for a Codex-less, Claude-only user too', () => {

--- a/shared/src/__tests__/format-utils.test.ts
+++ b/shared/src/__tests__/format-utils.test.ts
@@ -326,18 +326,9 @@ describe('scopedLimitClaimsUsageKey', () => {
   const active = { active: true };
   const idle = { active: false };
 
-  it('lets an ACTIVE cap take a key even when Codex is reporting', () => {
-    // The point of surfacing scoped caps (issue #99): a weekly per-model cap can
-    // sit at 98% while 5H/7D read low, so it outranks a non-binding window.
+  it('claims a key when a scoped cap is present', () => {
     expect(scopedLimitClaimsUsageKey(active, 2)).toBe(true);
-  });
-
-  it('never lets an INACTIVE cap displace a live Codex window', () => {
-    expect(scopedLimitClaimsUsageKey(idle, 1)).toBe(false);
-  });
-
-  it('gives an inactive cap the key Codex left spare', () => {
-    // The ordinary free-ChatGPT-tier state: no rolling windows at all.
+    expect(scopedLimitClaimsUsageKey(idle, 1)).toBe(true);
     expect(scopedLimitClaimsUsageKey(idle, 0)).toBe(true);
   });
 
@@ -345,26 +336,19 @@ describe('scopedLimitClaimsUsageKey', () => {
     expect(scopedLimitClaimsUsageKey(undefined, 0)).toBe(false);
     expect(scopedLimitClaimsUsageKey(null, 2)).toBe(false);
   });
-
-  it('treats a missing `active` as not binding (wire-flag rule)', () => {
-    expect(scopedLimitClaimsUsageKey({}, 1)).toBe(false);
-    expect(scopedLimitClaimsUsageKey({}, 0)).toBe(true);
-  });
 });
 
 describe('codexWindowsBeside', () => {
-  it('drops the trailing window when the scoped cap claims a key', () => {
-    // The cap REPLACES a Codex gauge. Growing the strip to fit both would
-    // quietly cost a session tile, which is the budget the strip is carved from.
-    expect(codexWindowsBeside(['5h', '7d'], true)).toEqual(['5h']);
-    expect(codexWindowsBeside(['7d'], true)).toEqual([]);
+  it('retains all Codex windows beside the scoped cap', () => {
+    expect(codexWindowsBeside(['5h', '7d'], true)).toEqual(['5h', '7d']);
+    expect(codexWindowsBeside(['7d'], true)).toEqual(['7d']);
   });
 
   it('leaves Codex untouched when no cap claims a key', () => {
     expect(codexWindowsBeside(['5h', '7d'], false)).toEqual(['5h', '7d']);
   });
 
-  it('has nothing to drop when Codex reports nothing', () => {
+  it('returns empty when Codex reports nothing', () => {
     expect(codexWindowsBeside([], true)).toEqual([]);
   });
 });

--- a/shared/src/format-utils.ts
+++ b/shared/src/format-utils.ts
@@ -294,27 +294,23 @@ export function codexUsageFootnote(
  */
 export function scopedLimitClaimsUsageKey(
   scoped: { active?: boolean } | undefined | null,
-  codexWindowCount: number,
+  _codexWindowCount?: number,
 ): boolean {
   if (!scoped) return false;
-  return scoped.active === true || codexWindowCount === 0;
+  return true;
 }
 
 /**
- * The Codex windows that still fit once the scoped cap has taken its key.
+ * The Codex windows that sit beside the scoped limit tile.
  *
- * A claiming cap REPLACES a Codex gauge, it does not stack onto the strip: the
- * usage block is a fixed budget carved out of session keys, so growing it to fit
- * both would quietly cost the user a session tile. The trailing (longer) window
- * yields first — with Codex's usual single weekly/monthly window that means the
- * cap simply takes its place, which is the whole point.
+ * Retains all present Codex windows so devices with 15+ keys can show
+ * Claude 5H, 7D, Scoped (Fable), and Codex windows together across up to 4 usage keys.
  */
 export function codexWindowsBeside<T>(
   codexWindows: T[],
-  scopedClaimsKey: boolean,
+  _scopedClaimsKey?: boolean,
 ): T[] {
-  if (!scopedClaimsKey || codexWindows.length === 0) return codexWindows;
-  return codexWindows.slice(0, -1);
+  return codexWindows;
 }
 
 /**


### PR DESCRIPTION
These two commits existed only on one machine's local `master` and are the blocker for the next release cut across the npm, ESP32, Stream Deck and Apple tracks. Rebased onto `origin/master` and put in their own PR so they are reviewed on their own terms rather than riding into an unrelated feature branch.

## Commits

- **Show up to 4 usage keys on 15+ key Stream Deck devices** (Claude 5H/7D, Fable, Codex 7D) — touches `bridge`, `shared`, `plugin`, `esp32`, `android`, `apple`, `docs/streamdeck-layout.md`
- **Clamp Pixoo creatures above active Usage HUD rows so idle sprites stay visible** — `bridge/src/pixoo/pixoo-renderer.ts` + the `PixooRenderer.swift` mirror, with sync tests

## What changed while rebasing, and why

Local `master` was six commits ahead of `origin/master`. **Four of those six are already upstream** and are not in this PR:

- `80849d16` — git dropped it as patch-identical during rebase.
- `199bd4dd`, `b3023bc1` — landed squashed as #219. Verified rather than assumed: every substantive file `b3023bc1` touches (`subagent-timeline.ts`, `protocol.ts`, the generated Kotlin/Swift/JSON mirrors, both test files) is **byte-identical** to `origin/master`.
- `fc64cc3a` (child count) — cherry-picked to an **empty commit**; both files it touches are byte-identical upstream. So the often-quoted "three unpushed commits" is really two.

Four conflicts, all resolved toward already-reviewed upstream content:

- `bridge/src/kiro-transcript-timeline.ts` and its test — took `origin/master`. #220's version is a strict bug-fix superset: it adds a per-reply `ts` offset because Kiro writes several `AssistantMessage` records per prompt, which previously collided at `turnTs + 1` and were silently dropped by dedup and by the feed watermark.
- `esp32/src/ui/matrix/matrix_pages.cpp` — took `origin/master`'s enum, which adds the `AGENT_KIND_COUNT` sentinel the local version lacked. The resolved file hashes **identical** to `origin/master`, so this commit's matrix changes were already upstream too.
- `apple/.../MatrixTerminalPreviews.swift` — the `SYNC-HASH` pin. Neither side's value is authoritative for a pin; it was **recomputed** from the resolved file. It lands on `b82038ac…`, matching `origin/master`, consistent with the point above.
- `DEVELOPMENT_LOG.md` — two independent entries, both kept, reverse-chronological.

## Verification

`pnpm build` clean; **3215 vitest tests pass** (204 files, 1 skipped) on this branch.

No release tags are cut by this PR — landing the code and cutting a release are separate decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)