### PR TITLE
Make the three daemon topologies a state, and test the transitions between them

### DIFF
--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		076E08E5217ECF4528B4AC9A /* TerrariumConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403CDDF7DDFCF5D8702491EA /* TerrariumConfig.swift */; };
 		07B804BD8A367595E8FF639F /* ActivityPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6186E147F760B85461F02022 /* ActivityPanel.swift */; };
 		08B47BC18D206538B33DD3B9 /* CloudCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A135216D37932FE68501F4 /* CloudCreature.swift */; };
+		09121C3375386AAC089BD428 /* DaemonOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B649BF2ACE34B4E61EB10D /* DaemonOwnership.swift */; };
 		091A43AE8CEB292071866D39 /* ApmeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E176199605E14D2EAF35A1 /* ApmeStore.swift */; };
 		0A2C81CEDF264AFA229180E4 /* AttentionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3124B9668030FDF0A9CE513F /* AttentionNotifier.swift */; };
 		0A7DA2C45E7C6BDB33D0F736 /* DevicePreviewCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4FB1F847E5695EF75A4FB /* DevicePreviewCatalog.swift */; };
@@ -35,6 +36,7 @@
 		0E136B3EF9DD10F02BFC158D /* LocalPeerOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685766B4F565619F7EC7DB28 /* LocalPeerOwnership.swift */; };
 		0E60D3FBC7626624FF7B5A2E /* TopologyRailHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D05CE505E1EC5729C69752E /* TopologyRailHelpersTests.swift */; };
 		0ED91B65645B05541D82E446 /* NotificationPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC62763B9E0E57235CFDACED /* NotificationPermission.swift */; };
+		0F4918AD129011B8E6A54CA6 /* TimelineCrossDaemonFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A785B4452043AE85943C4563 /* TimelineCrossDaemonFormatTests.swift */; };
 		1055170019B2376B38A0B8FE /* SessionAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3177DE60C73B3A102F9FB /* SessionAggregator.swift */; };
 		10B201D2AF96C0838CCEC4CF /* SerialModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F618D3253FD55D4DD7D5AF /* SerialModule.swift */; };
 		10DE349A3E6CF8732C19FB99 /* AgentDeckApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D587189DB0E504028BE4BEF /* AgentDeckApp.swift */; };
@@ -114,6 +116,7 @@
 		3C1F74B5C8002F65FFDA282F /* ProcessEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CE020EB705544FFD580DD9 /* ProcessEnumerator.swift */; };
 		3C2668742A6920AB392BA3EA /* CrayfishCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD30721AD4CBA74DD049A1F /* CrayfishCreature.swift */; };
 		3C58A78598B065AC2EDD44B8 /* BridgeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F34DE9E44936BAC6D96F19 /* BridgeDiscovery.swift */; };
+		3C8433978728206E408B0155 /* DaemonTopologyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E14C9F6E83FDFE6C204970 /* DaemonTopologyTests.swift */; };
 		3DF6BC8D6B4841A3EF370023 /* ObservedAskUserQuestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767EE1D15C8564C2A5AC5713 /* ObservedAskUserQuestionTests.swift */; };
 		3EF77B464A70587DAF191FFD /* KiroCreature.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF126528728AEF6E07C3C7ED /* KiroCreature.swift */; };
 		3F707E15A1A8E2707F36796D /* TerrariumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BCA057209786EF62993762 /* TerrariumView.swift */; };
@@ -152,6 +155,7 @@
 		50C1853357255E13C2F9EB93 /* DaemonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BD296835DE366BFDBB15B9 /* DaemonService.swift */; };
 		5110D91D663BA602A485005E /* DaemonActorIndependenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84D819AA86894944600240C /* DaemonActorIndependenceTests.swift */; };
 		52277012C5AE29828E911577 /* ESP32WifiOta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176599CD3E03A96EA977362 /* ESP32WifiOta.swift */; };
+		52482527CC6CB84FEB4BD188 /* DaemonTopologyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E14C9F6E83FDFE6C204970 /* DaemonTopologyTests.swift */; };
 		530A55B6786D79B8D42211BF /* RockFormation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF517661B1BEF3ACD330054D /* RockFormation.swift */; };
 		53D37B6B6CCF9EFD0013F153 /* DeviceApprovalGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95997D1E19933CBB5A3F400D /* DeviceApprovalGateTests.swift */; };
 		547881B213D488EBEC3ED00C /* ReviewRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A8384A78E6B40497C01168 /* ReviewRunner.swift */; };
@@ -191,6 +195,7 @@
 		67FA80518E8F347B39576FCC /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6BEE1A730418C1EBDC048 /* StatusBadge.swift */; };
 		6958E073DCDF46DFF22FFCE4 /* DevicePreviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965AE4E31EBD72B1A484DE25 /* DevicePreviewScreen.swift */; };
 		69EEBFCB47436C161B442D2B /* AttentionTheaterHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B38A97F5852FE0E8249C2 /* AttentionTheaterHUD.swift */; };
+		6BB8A27A4FDE10F9E9B6F2F6 /* TimelineCrossDaemonFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A785B4452043AE85943C4563 /* TimelineCrossDaemonFormatTests.swift */; };
 		6BFB8392D79D133C46111364 /* DaemonServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B857A690693DD802AA05429D /* DaemonServer.swift */; };
 		6D2EA7E15F98B8510CF048E9 /* SessionLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF82AE8E20EDCAE99DCEDD /* SessionLauncherTests.swift */; };
 		6D9C5D2BBACEF2F070863C45 /* TimeboxBLE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FFF88A2747DFBB1E626CA9 /* TimeboxBLE.swift */; };
@@ -378,6 +383,7 @@
 		D0A70501108B295ED44C169E /* PortFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165A6BFF174139F6AF07CED /* PortFormatting.swift */; };
 		D0FB0E0FFBBCE44786BA9B51 /* DaemonPortFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */; };
 		D130F3747ED283214E599734 /* DaemonPostureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6675586368BA1D73919FA7E0 /* DaemonPostureTests.swift */; };
+		D13B4726A425CEA84B3476F1 /* DaemonOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B649BF2ACE34B4E61EB10D /* DaemonOwnership.swift */; };
 		D14972CEAF0D69E6918C86BA /* AgentDeckPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056D70153C3F720A6D935C9F /* AgentDeckPaths.swift */; };
 		D169DFD5EA54C323E1128E7B /* AgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F55435772A15B8F0E92C1 /* AgentState.swift */; };
 		D2335AB9E3A5DEE25405617F /* TimeboxProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A351E073AB448BEE1DA392 /* TimeboxProtocolTests.swift */; };
@@ -637,6 +643,7 @@
 		965AE4E31EBD72B1A484DE25 /* DevicePreviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePreviewScreen.swift; sourceTree = "<group>"; };
 		979988BB4CB2A4B5948FD360 /* Adapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Adapter.swift; sourceTree = "<group>"; };
 		9965CED8937C8C1F27DFCC68 /* OnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingScreen.swift; sourceTree = "<group>"; };
+		99B649BF2ACE34B4E61EB10D /* DaemonOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonOwnership.swift; sourceTree = "<group>"; };
 		9C75E7B3676BD283B9A4BE27 /* PairingCodeRules.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeRules.generated.swift; sourceTree = "<group>"; };
 		9DC487120E810897B3BF0FC4 /* CodexFreshnessRules.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexFreshnessRules.generated.swift; sourceTree = "<group>"; };
 		9E6E252A5DCAC5E298C21473 /* SessionBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionBrand.swift; sourceTree = "<group>"; };
@@ -646,6 +653,7 @@
 		A4EB2E51F6EFD29341EB6127 /* StateColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateColors.swift; sourceTree = "<group>"; };
 		A5D17A24E0C5B16A097D62E9 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		A70843624A0EEB9E63435EC5 /* PlanktonSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanktonSystem.swift; sourceTree = "<group>"; };
+		A785B4452043AE85943C4563 /* TimelineCrossDaemonFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineCrossDaemonFormatTests.swift; sourceTree = "<group>"; };
 		A7F99A265E8C83A287F7DB71 /* DaemonOfflineAffordance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonOfflineAffordance.swift; sourceTree = "<group>"; };
 		ACF3E9B667BE141F81917F89 /* DaemonVoiceAssistant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonVoiceAssistant.swift; sourceTree = "<group>"; };
 		AE17EFB01F43FCB1A53F644D /* DaemonTimelineStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonTimelineStore.swift; sourceTree = "<group>"; };
@@ -654,6 +662,7 @@
 		B1F43DCAC6100C73B98139EA /* DisplayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMonitor.swift; sourceTree = "<group>"; };
 		B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockVisibilityPolicyTests.swift; sourceTree = "<group>"; };
 		B6E0B3C7EBBFFD8C2EB08F11 /* HookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstaller.swift; sourceTree = "<group>"; };
+		B6E14C9F6E83FDFE6C204970 /* DaemonTopologyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonTopologyTests.swift; sourceTree = "<group>"; };
 		B857A690693DD802AA05429D /* DaemonServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonServer.swift; sourceTree = "<group>"; };
 		B9841FBF8AFC5D5C65809F8B /* UsageAPIClientThreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClientThreadingTests.swift; sourceTree = "<group>"; };
 		BAC179B8F91EF42F5EBDE911 /* SetupNeededCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupNeededCard.swift; sourceTree = "<group>"; };
@@ -747,6 +756,7 @@
 				FB4C24732A9A2DB27CC5F7C0 /* AnthropicAdminApiClient.swift */,
 				3A70C6FAC4BDE4DAAFA08E74 /* CodexConfigInstaller.swift */,
 				69470A0782BDF6A29012E9F0 /* DaemonActor.swift */,
+				99B649BF2ACE34B4E61EB10D /* DaemonOwnership.swift */,
 				21FC16ECE363684E997BE01E /* DaemonPosture.swift */,
 				B6E0B3C7EBBFFD8C2EB08F11 /* HookInstaller.swift */,
 				685766B4F565619F7EC7DB28 /* LocalPeerOwnership.swift */,
@@ -794,6 +804,7 @@
 				E84D819AA86894944600240C /* DaemonActorIndependenceTests.swift */,
 				DA9A38D1BD38841DF83F3017 /* DaemonPortFallbackTests.swift */,
 				6675586368BA1D73919FA7E0 /* DaemonPostureTests.swift */,
+				B6E14C9F6E83FDFE6C204970 /* DaemonTopologyTests.swift */,
 				95997D1E19933CBB5A3F400D /* DeviceApprovalGateTests.swift */,
 				4E033ABF49F0DDF31D309181 /* DevicePreviewSnapshotTests.swift */,
 				B41DA855405F8F1F5BA174D0 /* DockVisibilityPolicyTests.swift */,
@@ -820,6 +831,7 @@
 				BB282455F078889B6DB35F93 /* TerrariumCloudFoldTests.swift */,
 				2E75D955A31F999F568B7BED /* TerrariumCrayfishPresenceTests.swift */,
 				27A351E073AB448BEE1DA392 /* TimeboxProtocolTests.swift */,
+				A785B4452043AE85943C4563 /* TimelineCrossDaemonFormatTests.swift */,
 				7847FA7381FB8075331B0F12 /* TimelineTests.swift */,
 				7D05CE505E1EC5729C69752E /* TopologyRailHelpersTests.swift */,
 				CAA529E02014523C9AD2CD0E /* UnauthorizedCloseCodeTests.swift */,
@@ -1431,6 +1443,7 @@
 				5110D91D663BA602A485005E /* DaemonActorIndependenceTests.swift in Sources */,
 				F30F046B8C2F044E12263AE8 /* DaemonPortFallbackTests.swift in Sources */,
 				37AB2DCA4C89195958B01709 /* DaemonPostureTests.swift in Sources */,
+				52482527CC6CB84FEB4BD188 /* DaemonTopologyTests.swift in Sources */,
 				1DA82A36B17B48756691D2CD /* DeviceApprovalGateTests.swift in Sources */,
 				1D406D25862B20792A8293F3 /* DevicePreviewSnapshotTests.swift in Sources */,
 				8FE3D8A54EF01D4165144E0E /* DockVisibilityPolicyTests.swift in Sources */,
@@ -1457,6 +1470,7 @@
 				56228049434E99DBC2BFD016 /* TerrariumCloudFoldTests.swift in Sources */,
 				805AC8BBF1600EA9BFB044F5 /* TerrariumCrayfishPresenceTests.swift in Sources */,
 				008D05FDF30426FE1B0DC37F /* TimeboxProtocolTests.swift in Sources */,
+				6BB8A27A4FDE10F9E9B6F2F6 /* TimelineCrossDaemonFormatTests.swift in Sources */,
 				DBE7242898F7F03CB3463B6D /* TimelineTests.swift in Sources */,
 				AFF81F64527A02F26615AB61 /* TopologyRailHelpersTests.swift in Sources */,
 				1326D167890900B50643E129 /* UnauthorizedCloseCodeTests.swift in Sources */,
@@ -1481,6 +1495,7 @@
 				A7560FE516D5460EB526FA3A /* DaemonActorIndependenceTests.swift in Sources */,
 				D0FB0E0FFBBCE44786BA9B51 /* DaemonPortFallbackTests.swift in Sources */,
 				D130F3747ED283214E599734 /* DaemonPostureTests.swift in Sources */,
+				3C8433978728206E408B0155 /* DaemonTopologyTests.swift in Sources */,
 				53D37B6B6CCF9EFD0013F153 /* DeviceApprovalGateTests.swift in Sources */,
 				19CDAF0B79C1F843366192C0 /* DevicePreviewSnapshotTests.swift in Sources */,
 				4E3E8F33089962383FF83309 /* DockVisibilityPolicyTests.swift in Sources */,
@@ -1507,6 +1522,7 @@
 				7409E65BFDFE78944B389B63 /* TerrariumCloudFoldTests.swift in Sources */,
 				E1027789C4EBBF134CA8D464 /* TerrariumCrayfishPresenceTests.swift in Sources */,
 				D2335AB9E3A5DEE25405617F /* TimeboxProtocolTests.swift in Sources */,
+				0F4918AD129011B8E6A54CA6 /* TimelineCrossDaemonFormatTests.swift in Sources */,
 				4F6DEDF8FD3A71AFD059278D /* TimelineTests.swift in Sources */,
 				0E60D3FBC7626624FF7B5A2E /* TopologyRailHelpersTests.swift in Sources */,
 				C15E3EF9660F1EAD28AE33BF /* UnauthorizedCloseCodeTests.swift in Sources */,
@@ -1574,6 +1590,7 @@
 				5B7A5FC7C0209AF3CF13C563 /* D200HLayoutModel.swift in Sources */,
 				45F924FE8D817EB16CA71345 /* DaemonActor.swift in Sources */,
 				13C1C940711C51743C8B5C97 /* DaemonOfflineAffordance.swift in Sources */,
+				09121C3375386AAC089BD428 /* DaemonOwnership.swift in Sources */,
 				0B0D2D3CF0D97D237B671C5B /* DaemonPosture.swift in Sources */,
 				9A804F6E4630630D21967869 /* DaemonPttVoice.swift in Sources */,
 				263F5BDD1FD0077BCCCA5DE8 /* DaemonServer.swift in Sources */,
@@ -1764,6 +1781,7 @@
 				BB291B71C944FF384AFD634C /* D200HLayoutModel.swift in Sources */,
 				8A28584D14249A2DB2E94361 /* DaemonActor.swift in Sources */,
 				1833E28AEE39E209E4AA45B6 /* DaemonOfflineAffordance.swift in Sources */,
+				D13B4726A425CEA84B3476F1 /* DaemonOwnership.swift in Sources */,
 				149FCBCC393ED40C0C0EBAD9 /* DaemonPosture.swift in Sources */,
 				F8C78DB678C94B49C23122AE /* DaemonPttVoice.swift in Sources */,
 				6BFB8392D79D133C46111364 /* DaemonServer.swift in Sources */,

--- a/apple/AgentDeck/Daemon/Core/DaemonOwnership.swift
+++ b/apple/AgentDeck/Daemon/Core/DaemonOwnership.swift
@@ -1,0 +1,74 @@
+#if os(macOS)
+// DaemonOwnership.swift — which daemon owns this machine's port, as three
+// states rather than two booleans.
+//
+// A Mac can be in exactly one of three topologies, and every AgentDeck feature
+// has to behave in all three:
+//
+//   .none      no daemon — nothing is serving 9120 yet, or we just tore down
+//   .selfOwned the in-process Swift daemon is bound (Tier 1, sandboxed)
+//   .external  a terminal-managed Node daemon is bound and this app is its
+//              WebSocket client (Tier 2 features become available)
+//
+// `DaemonService` used to carry this as two independent `@Published` booleans
+// with a `didSet` on one of them, which made the *promotion* edge — external
+// client becoming the owner — something inferred from a flag write rather than
+// stated. There are ten write sites, and one of them is `stop()`: tearing the
+// service down while in client mode wrote `false` and therefore reported a
+// promotion that never happened, firing `clearRelayedUsageState()` and blanking
+// the Claude quota, Codex rate limits, subscription rows and Antigravity status
+// that the external daemon had relayed. `restart()` — which Settings uses for a
+// port or posture change — goes through `stop()`, so a settings edit while
+// connected to a Node daemon wiped every usage gauge.
+//
+// Naming the states makes the edge a property of the transition instead of a
+// property of one boolean, and gives the three topologies something a test can
+// drive as a sequence.
+
+/// Which daemon currently owns this machine's port.
+enum DaemonOwnership: Equatable {
+    case none
+    case selfOwned
+    case external
+}
+
+/// Why ownership changed. The reason is not decoration: a teardown and a
+/// promotion both leave `isUsingExternalDaemon == false`, and only the second
+/// one is a promotion.
+enum DaemonOwnershipChange: Equatable {
+    /// The in-process daemon bound the port, or took over after the external
+    /// one disappeared.
+    case tookOwnership
+    /// An external Node daemon was found and this app became its client.
+    case becameClient
+    /// The service is going away — quit, restart, or a listener failure that
+    /// tears everything down before retrying. Never a promotion, whatever the
+    /// previous state was.
+    case toreDown
+}
+
+extension DaemonOwnership {
+    /// The state this change lands in.
+    func applying(_ change: DaemonOwnershipChange) -> DaemonOwnership {
+        switch change {
+        case .tookOwnership: return .selfOwned
+        case .becameClient:  return .external
+        case .toreDown:      return .none
+        }
+    }
+
+    /// `true` only for the edge that hands this app data the external daemon
+    /// used to relay — external client → owner. Tearing down is not a
+    /// promotion even though it also ends the client relationship, and taking
+    /// ownership from `.none` is a cold start, not a promotion: there was no
+    /// relayed state to invalidate.
+    func promotes(_ change: DaemonOwnershipChange) -> Bool {
+        self == .external && applying(change) == .selfOwned
+    }
+
+    /// The app is serving its own daemon (Tier 1 surfaces active).
+    var isSelfDaemon: Bool { self == .selfOwned }
+    /// A separately-installed Node daemon is serving (Tier 2 surfaces active).
+    var isUsingExternalDaemon: Bool { self == .external }
+}
+#endif

--- a/apple/AgentDeck/Daemon/DaemonService.swift
+++ b/apple/AgentDeck/Daemon/DaemonService.swift
@@ -37,15 +37,23 @@ import IOKit
 @MainActor
 final class DaemonService: ObservableObject {
     @Published private(set) var isRunning = false
-    @Published private(set) var isUsingExternalDaemon = false {
-        didSet {
-            // Promotion edge: was an external-daemon client, now not (becoming
-            // owner). Purge Node-relayed usage/subscription cache so features
-            // the self-daemon can't produce stop showing as a stale trace. A
-            // false→true flip (connecting to a returning external daemon)
-            // re-populates naturally, so only true→false clears.
-            if oldValue && !isUsingExternalDaemon { onPromotedToOwner?() }
-        }
+    @Published private(set) var isUsingExternalDaemon = false
+
+    /// Which daemon owns the port, as one of three states. The two published
+    /// booleans above are derived from it and kept only because the views bind
+    /// to them; this is the value that decides the promotion edge. See
+    /// `DaemonOwnership` for why the edge cannot live in a `didSet`.
+    private(set) var ownership: DaemonOwnership = .none
+
+    /// Record an ownership change and fire `onPromotedToOwner` if — and only
+    /// if — it is the external-client → owner edge. Every site that used to
+    /// assign `isUsingExternalDaemon` directly goes through here, so a
+    /// teardown can no longer masquerade as a promotion.
+    private func changeOwnership(_ change: DaemonOwnershipChange) {
+        let promoted = ownership.promotes(change)
+        ownership = ownership.applying(change)
+        isUsingExternalDaemon = ownership.isUsingExternalDaemon
+        if promoted { onPromotedToOwner?() }
     }
 
     /// Fired on the external→owner promotion edge (see `isUsingExternalDaemon`
@@ -253,7 +261,7 @@ final class DaemonService: ObservableObject {
                 self.server = daemon
                 self.port = daemon.port
                 self.isRunning = true
-                self.isUsingExternalDaemon = false
+                self.changeOwnership(.tookOwnership)
                 self.localFailureCount = 0
                 self.externalFailureCount = 0
                 self.errorMessage = nil
@@ -296,7 +304,7 @@ final class DaemonService: ObservableObject {
             } catch {
                 self.server = nil
                 self.isRunning = false
-                self.isUsingExternalDaemon = false
+                self.changeOwnership(.toreDown)
                 self.port = 0
                 self.readyUrl = nil
                 self.errorMessage = "Daemon failed: \(error.localizedDescription)"
@@ -339,7 +347,7 @@ final class DaemonService: ObservableObject {
         await server?.shutdown()
         server = nil
         isRunning = false
-        isUsingExternalDaemon = false
+        changeOwnership(.toreDown)
         port = 0
         readyUrl = nil
     }
@@ -354,7 +362,7 @@ final class DaemonService: ObservableObject {
         guard let resolvedPort else {
             self.server = nil
             self.isRunning = false
-            self.isUsingExternalDaemon = false
+            self.changeOwnership(.toreDown)
             self.port = 0
             self.readyUrl = nil
             self.errorMessage = "External daemon detected, but port lookup failed"
@@ -397,7 +405,7 @@ final class DaemonService: ObservableObject {
             DaemonLogger.shared.info("External daemon on port \(resolvedPort) is stale — starting local daemon instead")
             self.server = nil
             self.isRunning = false
-            self.isUsingExternalDaemon = false
+            self.changeOwnership(.toreDown)
             self.port = 0
             self.readyUrl = nil
             self.errorMessage = nil
@@ -432,7 +440,7 @@ final class DaemonService: ObservableObject {
             DaemonLogger.shared.info("Daemon on port \(resolvedPort) belongs to another user — not attaching to it; starting our own daemon instead")
             self.server = nil
             self.isRunning = false
-            self.isUsingExternalDaemon = false
+            self.changeOwnership(.toreDown)
             self.port = 0
             self.readyUrl = nil
             self.errorMessage = nil
@@ -459,7 +467,7 @@ final class DaemonService: ObservableObject {
         self.server = nil
         self.port = UInt16(resolvedPort)
         self.isRunning = false
-        self.isUsingExternalDaemon = true
+        self.changeOwnership(.becameClient)
         self.localFailureCount = 0
         self.externalFailureCount = 0
         self.errorMessage = nil
@@ -511,7 +519,7 @@ final class DaemonService: ObservableObject {
         await server?.shutdown()
         server = nil
         isRunning = false
-        isUsingExternalDaemon = false
+        changeOwnership(.toreDown)
         port = 0
         readyUrl = nil
         await retryOrFallback(error: error, attemptedPort: attemptedPort)
@@ -722,7 +730,9 @@ final class DaemonService: ObservableObject {
             DaemonLogger.shared.error("External daemon on port \(currentPort) disappeared — promoting this app to own the daemon")
             server = nil
             isRunning = false
-            isUsingExternalDaemon = false
+            // The external daemon is gone and we are about to bind: this is
+            // the one edge that IS a promotion.
+            changeOwnership(.tookOwnership)
             port = 0
             readyUrl = nil
             errorMessage = nil

--- a/apple/AgentDeckTests/DaemonTopologyTests.swift
+++ b/apple/AgentDeckTests/DaemonTopologyTests.swift
@@ -1,0 +1,155 @@
+#if os(macOS)
+// The three daemon topologies, driven as sequences.
+//
+// A Mac running AgentDeck is in exactly one of three states — no daemon, the
+// in-process Swift daemon, or a terminal-managed Node daemon with this app as
+// its client — and every feature has to behave in all three. Before this file
+// the transitions between them had no test at all: `DaemonService` carried the
+// topology as two independent booleans and inferred the promotion edge from a
+// `didSet` on one of them, across ten write sites.
+//
+// These tests drive TRANSITION SEQUENCES rather than asking the predicate what
+// it returns for a given pair, because the defect this file was written for is
+// only visible as a sequence: `client → settings restart → client` reported a
+// promotion in the middle, and a promotion purges the usage state the external
+// daemon relayed.
+
+import XCTest
+@testable import AgentDeck
+
+final class DaemonTopologyTests: XCTestCase {
+
+    /// Replays a run and returns how many promotions it reported.
+    private func promotions(_ changes: [DaemonOwnershipChange],
+                            from start: DaemonOwnership = .none) -> Int {
+        var state = start
+        var count = 0
+        for change in changes {
+            if state.promotes(change) { count += 1 }
+            state = state.applying(change)
+        }
+        return count
+    }
+
+    private func finalState(_ changes: [DaemonOwnershipChange],
+                            from start: DaemonOwnership = .none) -> DaemonOwnership {
+        changes.reduce(start) { $0.applying($1) }
+    }
+
+    // MARK: - The three topologies are three states
+
+    func testTheThreeTopologiesAreMutuallyExclusive() {
+        // Tier 1 (app alone), Tier 2 (Node daemon + app as client), and neither.
+        // No state may claim both tiers, and none may claim neither-nor.
+        for state in [DaemonOwnership.none, .selfOwned, .external] {
+            XCTAssertFalse(state.isSelfDaemon && state.isUsingExternalDaemon,
+                           "\(state) claims to be both tiers at once")
+        }
+        XCTAssertTrue(DaemonOwnership.selfOwned.isSelfDaemon)
+        XCTAssertTrue(DaemonOwnership.external.isUsingExternalDaemon)
+        XCTAssertFalse(DaemonOwnership.none.isSelfDaemon)
+        XCTAssertFalse(DaemonOwnership.none.isUsingExternalDaemon)
+    }
+
+    // MARK: - Cold start into each topology
+
+    func testColdStartIntoTheSwiftDaemonIsNotAPromotion() {
+        // App launches with nothing on the port and binds. There was no
+        // external daemon and therefore no relayed state to invalidate, so
+        // firing the promotion callback here would purge nothing and mean
+        // nothing.
+        XCTAssertEqual(promotions([.tookOwnership]), 0)
+        XCTAssertEqual(finalState([.tookOwnership]), .selfOwned)
+    }
+
+    func testColdStartIntoClientModeIsNotAPromotion() {
+        // App launches, finds a Node daemon already on the port, becomes its
+        // WebSocket client. Tier 2 surfaces light up; nothing is promoted.
+        XCTAssertEqual(promotions([.becameClient]), 0)
+        XCTAssertEqual(finalState([.becameClient]), .external)
+    }
+
+    // MARK: - The one real promotion
+
+    func testExternalDaemonDisappearingPromotesExactlyOnce() {
+        // The Node daemon goes away mid-session and the app takes the port.
+        // This is the only edge that must fire `onPromotedToOwner`: the app
+        // cannot produce Claude quota or subscription rows itself, so the
+        // relayed copies have to be cleared rather than left as a stale trace.
+        XCTAssertEqual(promotions([.becameClient, .tookOwnership]), 1)
+        XCTAssertEqual(finalState([.becameClient, .tookOwnership]), .selfOwned)
+    }
+
+    func testHealthCheckPromotionFollowedByABindDoesNotFireTwice() {
+        // `checkDaemonHealth` records the promotion and then calls `start()`,
+        // which records `.tookOwnership` again when the bind succeeds. The
+        // second one is already-owner → already-owner and must be silent, or
+        // the usage state would be purged twice for one event.
+        XCTAssertEqual(promotions([.becameClient, .tookOwnership, .tookOwnership]), 1)
+    }
+
+    // MARK: - Teardown is not a promotion  (the regression this file exists for)
+
+    func testTearingDownWhileInClientModeReportsNoPromotion() {
+        // `stop()` used to write the same `false` a promotion writes, so
+        // quitting or restarting while connected to a Node daemon fired
+        // `onPromotedToOwner` and blanked every usage gauge.
+        XCTAssertEqual(promotions([.becameClient, .toreDown]), 0)
+        XCTAssertEqual(finalState([.becameClient, .toreDown]), .none)
+    }
+
+    func testSettingsRestartWhileOnAnExternalDaemonNeverPromotes() {
+        // The exact user-visible path: the app is a client, the user changes
+        // the daemon port or the network posture in Settings, `restart()` runs
+        // `stop()` then `start()`, and the app reconnects to the same external
+        // daemon. Nothing was ever promoted, so the Claude quota, Codex rate
+        // limits, subscriptions and Antigravity status must survive it.
+        let restart: [DaemonOwnershipChange] = [.becameClient, .toreDown, .becameClient]
+        XCTAssertEqual(promotions(restart), 0)
+        XCTAssertEqual(finalState(restart), .external)
+    }
+
+    func testListenerFailureAndRetryAsOwnerNeverPromotes() {
+        // Owning the port, the listener dies, we tear down and rebind. We were
+        // never a client, so there is no relayed state and no promotion.
+        let flap: [DaemonOwnershipChange] = [.tookOwnership, .toreDown, .tookOwnership]
+        XCTAssertEqual(promotions(flap), 0)
+        XCTAssertEqual(finalState(flap), .selfOwned)
+    }
+
+    // MARK: - Longer runs
+
+    func testAFullDayOfHandoversPromotesOncePerTakeover() {
+        // Node daemon starts and stops repeatedly under the app: each time the
+        // app takes the port back it is a fresh promotion, and each teardown
+        // in between is not.
+        let day: [DaemonOwnershipChange] = [
+            .tookOwnership,                 // app boots alone
+            .toreDown, .becameClient,       // user starts `agentdeck daemon start`
+            .tookOwnership,                 // CLI daemon quits, app takes over   ← 1
+            .toreDown, .becameClient,       // CLI daemon comes back
+            .toreDown,                      // user quits the app while it is a client
+        ]
+        XCTAssertEqual(promotions(day), 1)
+        XCTAssertEqual(finalState(day), .none)
+    }
+
+    func testEveryChangeLandsInADefinedState() {
+        // Exhaustive over states × changes: no transition may leave the
+        // topology undefined, which is what would let a fourth state exist.
+        for state in [DaemonOwnership.none, .selfOwned, .external] {
+            for change in [DaemonOwnershipChange.tookOwnership, .becameClient, .toreDown] {
+                let next = state.applying(change)
+                XCTAssertTrue([.none, .selfOwned, .external].contains(next),
+                              "\(state) + \(change) landed outside the three topologies")
+                // A promotion is only ever reported when the result actually
+                // owns the daemon.
+                if state.promotes(change) {
+                    XCTAssertEqual(next, .selfOwned)
+                    XCTAssertEqual(state, .external)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/apple/AgentDeckTests/TimelineCrossDaemonFormatTests.swift
+++ b/apple/AgentDeckTests/TimelineCrossDaemonFormatTests.swift
@@ -1,0 +1,182 @@
+#if os(macOS)
+// `timeline.json` is the one file both daemons own in turn.
+//
+// Either daemon can be the one bound to 9120, and whichever is serving is the
+// only process allowed to write this file. So a handover — the CLI daemon
+// stops and the app takes the port, or the reverse — means one implementation
+// rehydrating history the OTHER one wrote. If the formats drift, the symptom
+// is not an error: the decode returns nil and the entire timeline silently
+// starts empty.
+//
+// The Node suite already pins this from its side (`timeline-persistence.test.ts`
+// asserts it writes a plain JSON array, that every row carries the ts/type/raw
+// triple, and that it can read a file in the shape the Swift daemon writes).
+// The Swift side only round-tripped its OWN file, so the contract was pinned in
+// one direction and the reverse handover was untested.
+//
+// **The fixtures below are copied verbatim from a real `~/.agentdeck/timeline.json`
+// written by the Node daemon (read 2026-08-19), not composed from the decoder's
+// field list.** A fixture built from what the reader expects cannot fail, which
+// is exactly how a format gap survives a green suite.
+
+import XCTest
+@testable import AgentDeck
+
+final class TimelineCrossDaemonFormatTests: XCTestCase {
+    private var dir: URL!
+
+    override func setUpWithError() throws {
+        dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("timeline-xdaemon-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    /// The richest row the Node daemon actually emits — a closed task carrying
+    /// its APME verdict. Fifteen keys, several of which the Swift decoder has
+    /// no property for; unknown keys must be ignored, never fatal.
+    private let nodeTaskEnd = """
+    {
+      "endedAt": 1786970557842,
+      "taskId": "d60fdec7-622f-4212-bb71-6caffafb402e",
+      "boundarySignal": "session_end",
+      "taskCategory": "ops",
+      "sessionId": "215ec8a9-e98a-498e-8281-6bc5d5a99754",
+      "ts": 1786970557842,
+      "runId": "16ba3c3e-5dd4-4dd0-8d8c-573cb91f0771",
+      "startedAt": 1786969352964,
+      "taskOutcome": "success",
+      "agentType": "claude-code",
+      "taskSummary": "Created, merged, and deployed PR #219, then corrected a local git state assessment after peer review.",
+      "projectName": "AgentDeck",
+      "taskScore": 0.95,
+      "type": "task_end",
+      "raw": "Session end · 20m 5s"
+    }
+    """
+
+    /// A plain prompt row — the common case, and the one that proves a row
+    /// needs nothing beyond the shared triple plus attribution.
+    private let nodeChatStart = """
+    {
+      "ts": 1787096905572,
+      "type": "chat_start",
+      "raw": "CLAUDE.md 가 없는데 그래도 괜찮은가? 현재 프로젝트 상태 점검하라.",
+      "sessionId": "a3dab322-fe25-42fc-9080-d1c84326e8c8",
+      "agentType": "claude-code",
+      "startedAt": 1787096905572,
+      "taskId": "da44437f-3bcd-4662-84ed-4d5138633fa9",
+      "projectName": "foundby-site"
+    }
+    """
+
+    private func writeNodeFile(_ rows: [String]) throws -> URL {
+        let url = dir.appendingPathComponent("timeline.json")
+        try "[\(rows.joined(separator: ","))]".write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Reading the other daemon's file
+
+    func testRehydratesAFileTheNodeDaemonWrote() async throws {
+        let file = try writeNodeFile([nodeChatStart, nodeTaskEnd])
+        let store = DaemonTimelineStore(persistFile: file)
+        await store.start()
+        let entries = await store.getAll()
+
+        XCTAssertEqual(entries.count, 2,
+                       "history the CLI daemon wrote was dropped on handover")
+        // Rehydration sorts by `ts`, and the task_end fixture is the OLDER of
+        // the two real rows, so match on content rather than on file order.
+        let prompt = entries.first { $0.type == "chat_start" }
+        let closed = entries.first { $0.type == "task_end" }
+        XCTAssertEqual(prompt?.sessionId, "a3dab322-fe25-42fc-9080-d1c84326e8c8")
+        XCTAssertEqual(closed?.raw, "Session end · 20m 5s")
+        XCTAssertEqual(entries.map(\.ts), entries.map(\.ts).sorted(),
+                       "carried-over history must stay chronological")
+    }
+
+    func testKeepsTheAttributionTheOtherDaemonRecorded() async throws {
+        // Losing agentType/projectName would not empty the timeline — it would
+        // render every carried-over row as an unattributed one, which reads as
+        // corruption rather than as a handover.
+        let file = try writeNodeFile([nodeTaskEnd])
+        let store = DaemonTimelineStore(persistFile: file)
+        await store.start()
+        let first = await store.getAll().first
+        let entry = try XCTUnwrap(first)
+
+        XCTAssertEqual(entry.agentType, "claude-code")
+        XCTAssertEqual(entry.projectName, "AgentDeck")
+        XCTAssertEqual(entry.taskId, "d60fdec7-622f-4212-bb71-6caffafb402e")
+    }
+
+    func testAnUnknownKeyFromANewerNodeDaemonDoesNotDropTheRow() async throws {
+        // The two daemons ship on their own schedules, so the app WILL meet a
+        // file written by a Node daemon that records a field this build has
+        // never heard of. One unknown key must not cost the whole history.
+        let futureRow = """
+        {"ts":1787096905572,"type":"chat_start","raw":"hello",
+         "sessionId":"a3dab322-fe25-42fc-9080-d1c84326e8c8",
+         "agentType":"claude-code","somethingAddedLater":{"nested":true}}
+        """
+        let file = try writeNodeFile([futureRow, nodeTaskEnd])
+        let store = DaemonTimelineStore(persistFile: file)
+        await store.start()
+        let count = await store.getAll().count
+        XCTAssertEqual(count, 2)
+    }
+
+    // MARK: - Writing a file the other daemon can read
+
+    func testWritesAPlainArrayWithTheSharedTriple() async throws {
+        // Mirror of the Node assertion. An object wrapper, or a row missing
+        // ts/type/raw, would decode to nothing on the Node side and lose the
+        // history in the other direction.
+        let file = dir.appendingPathComponent("out.json")
+        let store = DaemonTimelineStore(persistFile: file)
+        await store.start()
+        await store.add(DaemonTimelineEntry(
+            ts: 1787096905572, type: "chat_start", raw: "written by Swift",
+            agentType: "claude-code", projectName: "AgentDeck",
+            sessionId: "a3dab322-fe25-42fc-9080-d1c84326e8c8"))
+        await store.flush()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let data = try Data(contentsOf: file)
+        let parsed = try JSONSerialization.jsonObject(with: data)
+        let rows = try XCTUnwrap(parsed as? [[String: Any]],
+                                 "not a plain JSON array — the Node reader decodes an array")
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertNotNil(row["ts"])
+        XCTAssertNotNil(row["type"])
+        XCTAssertNotNil(row["raw"])
+    }
+
+    func testRoundTripsThroughTheNodeShapeWithoutLoss() async throws {
+        // Write with Swift, re-read with Swift through the same plain-array
+        // path Node uses. This is the handover in both directions.
+        let file = dir.appendingPathComponent("round.json")
+        let writer = DaemonTimelineStore(persistFile: file)
+        await writer.start()
+        await writer.add(DaemonTimelineEntry(
+            ts: 1787096905572, type: "task_end", raw: "Session end · 20m 5s",
+            agentType: "claude-code", projectName: "AgentDeck",
+            sessionId: "215ec8a9-e98a-498e-8281-6bc5d5a99754"))
+        await writer.flush()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let reader = DaemonTimelineStore(persistFile: file)
+        await reader.start()
+        let readBack = await reader.getAll().first
+        let entry = try XCTUnwrap(readBack)
+        XCTAssertEqual(entry.ts, 1787096905572)
+        XCTAssertEqual(entry.type, "task_end")
+        XCTAssertEqual(entry.raw, "Session end · 20m 5s")
+        XCTAssertEqual(entry.sessionId, "215ec8a9-e98a-498e-8281-6bc5d5a99754")
+    }
+}
+#endif


### PR DESCRIPTION
A Mac running AgentDeck is in exactly one of three topologies — no daemon, the in-process Swift daemon, or a terminal-managed Node daemon with this app as its client — and every feature has to behave in all three. Auditing the suite for that property turned up two gaps and one defect.

## The defect: teardown reported itself as a promotion

`isUsingExternalDaemon` had **no test at all**, while gating six UI surfaces and carrying a `didSet` side effect. It was written from ten sites, and one of them is `stop()`:

```swift
isRunning = false
isUsingExternalDaemon = false   // ← didSet: oldValue && !new ⇒ "promoted to owner"
```

Tearing down while in client mode writes the same `false` a promotion writes, so it fired `onPromotedToOwner` → `clearRelayedUsageState()`, blanking Claude 5H/7D quota, Codex rate limits, subscription rows and Antigravity status. `restart()` runs `stop()`, and Settings uses `restart()` for a **port or posture change** — so editing either while connected to a Node daemon wiped every usage gauge.

The fix stops inferring the edge from a flag write. `DaemonOwnership` names the three states and the three reasons ownership changes; `promotes()` is true only for external-client → owner. Tearing down is not a promotion even though it also ends the client relationship, and binding from `.none` is a cold start — there was no relayed state to invalidate. All ten sites now route through `changeOwnership(_:)`; the published booleans are derived and stay for the views.

## Gap 1 — the topology transitions

`DaemonTopologyTests` (10 cases) drives transition **sequences** rather than asking the predicate about a pair, because the defect is only visible as one:

| Sequence | Promotions |
|---|:--:|
| cold start → own the port | 0 |
| cold start → become client | 0 |
| client → external daemon disappears → own | **1** |
| health-check promotion → `start()` rebinds | 1 (not 2) |
| client → **settings restart** → client | 0 |
| owner → listener failure → rebind | 0 |

Reverting `promotes()` to the old `didSet` rule fails 4 of the 10, including that settings-restart path.

## Gap 2 — the `timeline.json` contract was pinned in one direction

Both daemons own that file in turn, so a handover means one implementation rehydrating what the other wrote — and a format gap does not raise, it decodes to `nil` and the timeline silently starts empty. The Node suite already asserts it writes a plain array, that rows carry `ts`/`type`/`raw`, and that it can read the shape Swift writes. **Swift only round-tripped its own file.**

`TimelineCrossDaemonFormatTests` (5 cases) adds the reverse direction, including an unknown-key row from a hypothetical newer Node daemon. Fixtures are copied **verbatim from a real `~/.agentdeck/timeline.json`**, not composed from the decoder's field list — a fixture built from what the reader expects cannot fail, which is how a format gap survives a green suite. Encoding a wrapper object instead of an array fails 2 of the 5.

## Verification

- macOS **629 tests pass** (was 614); iOS compiles.
- Both new suites were checked against a deliberately reverted implementation and fail as intended.
- Node `vitest` and the mirror/doc gates untouched and green.

Scope note: only the five files above are in this PR. Concurrent Node-side work in the shared tree (usage relay) is deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)