### PR TITLE
An unstamped relayed usage reading is unknown-age, not fresh

### DIFF
--- a/apple/AgentDeck.xcodeproj/project.pbxproj
+++ b/apple/AgentDeck.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		015E006D6E9D932E1DDEED68 /* ApmeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5857149AEB13F8BEC5CDE41B /* ApmeClassifier.swift */; };
 		0190133B8ADCA735206316EF /* PixooSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FFD673C1AD8EAF690B9E82 /* PixooSheet.swift */; };
 		0264C182D89757B656DFE108 /* AquariumSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE102D050319B6A78A505B3 /* AquariumSurface.swift */; };
+		0330736E0FF888DCC943EC4C /* UsageRelayFreshnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004AFFB1B0E061D54CDCDED0 /* UsageRelayFreshnessTests.swift */; };
 		0347DAE5A86DD416D1666E23 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF390BEA92326B1152B55A9 /* HTTPServer.swift */; };
 		06C6D342554422542396AC74 /* ApmeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DB3C4DCB23D09CFA856786 /* ApmeOutcome.swift */; };
 		0702C9FEAA7C1E2A2E6CAA36 /* ApmeDashboardWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA36B13CDF6548B698F4C55 /* ApmeDashboardWindow.swift */; };
@@ -334,6 +335,7 @@
 		B9A16BFB5249C6389638BCD0 /* PairingCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E868DDC13347FD992B9AF3D /* PairingCredential.swift */; };
 		BA2CB0DAA113D75AF63951DD /* MicroGlyphs.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1603E1F58E35F85044D7913A /* MicroGlyphs.generated.swift */; };
 		BA45B7FBDCFDD8971904714D /* ObservedAskUserQuestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767EE1D15C8564C2A5AC5713 /* ObservedAskUserQuestionTests.swift */; };
+		BAF60F55BB39F43FE479652D /* UsageRelayFreshness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832BF47EA8F4F9DE55F6EA4F /* UsageRelayFreshness.swift */; };
 		BB291B71C944FF384AFD634C /* D200HLayoutModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075254486BFFC613DB33B99D /* D200HLayoutModel.swift */; };
 		BBEB24AC6D843E71B5C8D517 /* ApmeRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D4EF93231AAC8CD23FB819 /* ApmeRunner.swift */; };
 		BC3E7181AA49F859B3BA8BF4 /* AgentDeckLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A43BCFF7E55A34B4C5FC1 /* AgentDeckLogo.swift */; };
@@ -363,6 +365,7 @@
 		C37CD3CFD263A0903096C515 /* TimeboxSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362BC758256086C0D78EF7A8 /* TimeboxSheet.swift */; };
 		C46F9CBAF1E5CFC66037BDA2 /* IDotMatrixIdentity.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6218B1AC0EA6F206DB424EC5 /* IDotMatrixIdentity.generated.swift */; };
 		C4F117E796C0C81A8E52A02B /* PortDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15083D65B8571C662DD6E2CE /* PortDiagnostics.swift */; };
+		C53E6FF3C458CFE3A65A926F /* UsageRelayFreshness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832BF47EA8F4F9DE55F6EA4F /* UsageRelayFreshness.swift */; };
 		C60311E11652C03785B9F449 /* LocalKiroObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9DCDE7C19F4BE7649995B33 /* LocalKiroObserver.swift */; };
 		C68C5F90DA83B7DFE263289D /* ESP32ProvisionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6229A084E6CE2AB75D86F83 /* ESP32ProvisionSheet.swift */; };
 		C71587998379ED779ADFF54F /* ESP32Serial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C62F7ABA6BDEE39F39DBDFA /* ESP32Serial.swift */; };
@@ -378,6 +381,7 @@
 		CDABC5CCE965EF7FA30DE280 /* LocalKiroObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B49DE4157BFB50F9F51EF40 /* LocalKiroObserverTests.swift */; };
 		CF27ABB66E4B268C31C44E6E /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B7BAB1080F7958F74A1B74 /* IntegrationsView.swift */; };
 		CFCABF9422E74B8CF2A23C7E /* CodexOtelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE1D983995443760EDE3A4A /* CodexOtelParserTests.swift */; };
+		CFDDFF75A732BEA08DDA7A95 /* UsageRelayFreshnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004AFFB1B0E061D54CDCDED0 /* UsageRelayFreshnessTests.swift */; };
 		D036600F5679C1A191132F87 /* SingletonGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5C866AF54937CD8E433F49 /* SingletonGuard.swift */; };
 		D0668EACC4D50BE30B10ACE5 /* SessionPushRegisterMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB88D8C2921CB4B93EC8B9 /* SessionPushRegisterMergeTests.swift */; };
 		D0A70501108B295ED44C169E /* PortFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165A6BFF174139F6AF07CED /* PortFormatting.swift */; };
@@ -492,6 +496,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		004AFFB1B0E061D54CDCDED0 /* UsageRelayFreshnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageRelayFreshnessTests.swift; sourceTree = "<group>"; };
 		01B7BAB1080F7958F74A1B74 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
 		0392D39F45022F762AFE6BE0 /* CodexConfigInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexConfigInstallerTests.swift; sourceTree = "<group>"; };
 		03941C6DD60609AB9D1E12C1 /* SessionWeightRules.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionWeightRules.generated.swift; sourceTree = "<group>"; };
@@ -620,6 +625,7 @@
 		7FF390BEA92326B1152B55A9 /* HTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
 		80BD296835DE366BFDBB15B9 /* DaemonService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonService.swift; sourceTree = "<group>"; };
 		81ECEA1581963132423FB0C8 /* CodexTelemetryModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTelemetryModule.swift; sourceTree = "<group>"; };
+		832BF47EA8F4F9DE55F6EA4F /* UsageRelayFreshness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageRelayFreshness.swift; sourceTree = "<group>"; };
 		83589BA4C41B89C8EF1A46FD /* AdbModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdbModule.swift; sourceTree = "<group>"; };
 		83D5CE0F7637C0913938BA6B /* DeskPreviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeskPreviews.swift; sourceTree = "<group>"; };
 		83E77BCD933FB80831B3E6FD /* AgentDeck.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AgentDeck.entitlements; sourceTree = "<group>"; };
@@ -769,6 +775,7 @@
 				D9FBCA5AE4B47A5D67D12207 /* StateTransitions.generated.swift */,
 				4CEC7D8557C3DA805DBA75E1 /* TailDecoder.swift */,
 				DBBD731AC01994F5C7C1A78A /* UsageAPIClient.swift */,
+				832BF47EA8F4F9DE55F6EA4F /* UsageRelayFreshness.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -837,6 +844,7 @@
 				CAA529E02014523C9AD2CD0E /* UnauthorizedCloseCodeTests.swift */,
 				A472C32952DF18A4C77A969A /* UnknownAgentForwardCompatTests.swift */,
 				B9841FBF8AFC5D5C65809F8B /* UsageAPIClientThreadingTests.swift */,
+				004AFFB1B0E061D54CDCDED0 /* UsageRelayFreshnessTests.swift */,
 			);
 			path = AgentDeckTests;
 			sourceTree = "<group>";
@@ -1476,6 +1484,7 @@
 				1326D167890900B50643E129 /* UnauthorizedCloseCodeTests.swift in Sources */,
 				18B5EB50FB19AB4013D78F74 /* UnknownAgentForwardCompatTests.swift in Sources */,
 				CB4DB4586BC5196412C3429C /* UsageAPIClientThreadingTests.swift in Sources */,
+				CFDDFF75A732BEA08DDA7A95 /* UsageRelayFreshnessTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1528,6 +1537,7 @@
 				C15E3EF9660F1EAD28AE33BF /* UnauthorizedCloseCodeTests.swift in Sources */,
 				D8B0E597FE6FF31AE5F7B0EB /* UnknownAgentForwardCompatTests.swift in Sources */,
 				DD57AEBB6F916C984C85F48F /* UsageAPIClientThreadingTests.swift in Sources */,
+				0330736E0FF888DCC943EC4C /* UsageRelayFreshnessTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1713,6 +1723,7 @@
 				88E5BC49F042917DFE14A2C9 /* ToastOverlay.swift in Sources */,
 				7A3F1644ABE4AE5BDDD0BB85 /* TopologyRail.swift in Sources */,
 				4492EC65271E1C630601393F /* UsageAPIClient.swift in Sources */,
+				C53E6FF3C458CFE3A65A926F /* UsageRelayFreshness.swift in Sources */,
 				840FBBACA9DC9EF12D49D37D /* UtilityProxy.swift in Sources */,
 				7FE91079BB8AE03AB4F092CD /* WaterEffect.swift in Sources */,
 				D863C121DC06035A0007914B /* WaterSurface.swift in Sources */,
@@ -1905,6 +1916,7 @@
 				FC8022AFF367CE956C1C2FE4 /* ToastOverlay.swift in Sources */,
 				7F2EF2FA2C61302C14EC7D77 /* TopologyRail.swift in Sources */,
 				B13C4855773086AA7115A5D4 /* UsageAPIClient.swift in Sources */,
+				BAF60F55BB39F43FE479652D /* UsageRelayFreshness.swift in Sources */,
 				28BBAAFD6BE94905F082370E /* UtilityProxy.swift in Sources */,
 				AC7E59A42A23408F8FEC3AC5 /* WaterEffect.swift in Sources */,
 				AFF6EF70E6B6A6BC16048A65 /* WaterSurface.swift in Sources */,

--- a/apple/AgentDeck/Daemon/Core/UsageRelayFreshness.swift
+++ b/apple/AgentDeck/Daemon/Core/UsageRelayFreshness.swift
@@ -1,0 +1,64 @@
+#if os(macOS)
+// How old is a relayed usage reading, and may we use it at all?
+//
+// Tier 1 usage comes from a sibling bridge over `GET /usage`, which answers
+// `{ usage, fetchedAt }`. The age gate that decides whether to accept it lived
+// inline as:
+//
+//     if let fetchedAt = json["fetchedAt"] as? Int, fetchedAt > 0 { …gate… }
+//
+// which conflates three different situations into one `if`. When the condition
+// failed — no stamp, a zero stamp, or a non-Int — the whole block was skipped,
+// so the reading lost the five-minute gate AND arrived with no `fetchedAt`,
+// and the caller then stamped `Date()` on it. Numbers of unknown age were
+// recorded as just-fetched, which is the one reading that can never go stale:
+// `usageStaleTTL` measures against that stamp.
+//
+// That branch was unreachable while every Node result advanced the producer's
+// clock. It stopped being unreachable the moment the Node daemon correctly
+// refused to advance `lastApiFetchTime` on a non-live apply (2026-08-19), which
+// made `fetchedAt: 0` a real pair for a bridge whose only cached numbers came
+// from a failed fetch's fallback. The producer now refuses to serve those, but
+// a consumer that treats a missing stamp as "now" is wrong on its own terms and
+// on any producer, so the rule is enforced here too.
+//
+// The repository rule this restates: **absence of a timestamp is "unknown",
+// never "fresh" and never "old"** — the same rule `capturedAt` follows on the
+// Codex gauges. Unknown age is not usable as a relay source; it is not an
+// error either, just a sibling we skip.
+
+import Foundation
+
+/// What a relayed usage payload's `fetchedAt` tells us.
+enum UsageRelayFreshness: Equatable {
+    /// Stamped, and inside the acceptance window. Carries epoch **seconds**,
+    /// which is the unit `ApiUsageData.fetchedAt` uses.
+    case usable(fetchedAtSeconds: Double)
+    /// Stamped, but older than the window — a sibling worth skipping.
+    case tooOld
+    /// No usable stamp. Cannot be aged, so it cannot be relayed; treating it
+    /// as fresh is what put unstaleable numbers on the dashboard.
+    case unknownAge
+}
+
+enum UsageRelay {
+    /// Readings older than this are not relayed.
+    static let maxAgeMs = 5 * 60 * 1000
+
+    /// Classify a `/usage` payload's stamp.
+    ///
+    /// `fetchedAtMs` is whatever came off the wire: `nil` when the key is
+    /// absent or not a number, `0` when the producer has numbers but has never
+    /// completed a live fetch. Both mean the same thing to us — we cannot say
+    /// how old this is.
+    static func classify(fetchedAtMs: Int?, nowMs: Int) -> UsageRelayFreshness {
+        guard let fetchedAtMs, fetchedAtMs > 0 else { return .unknownAge }
+        let ageMs = nowMs - fetchedAtMs
+        // A stamp from the future is a clock disagreement between two local
+        // processes, not a fresh reading. Accept it rather than skip — the
+        // sibling is on this machine — but never let it read as negative age.
+        if ageMs > maxAgeMs { return .tooOld }
+        return .usable(fetchedAtSeconds: Double(fetchedAtMs) / 1000.0)
+    }
+}
+#endif

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -7273,10 +7273,15 @@ final class DaemonServer {
                 cachedApiUsage = parseRelayedUsage(usage)
                 if let fetchedAt = cachedApiUsage?.fetchedAt {
                     lastApiFetchTime = Date(timeIntervalSince1970: fetchedAt)
+                    apiUsageStale = cachedApiUsage?.stale ?? false
                 } else {
-                    lastApiFetchTime = Date()
+                    // Unreachable now that `fetchUsageViaHTTP` rejects an
+                    // unstamped payload outright; kept as the floor. Stamping
+                    // `Date()` here would make numbers of unknown age the one
+                    // reading `usageStaleTTL` can never retire, so leave the
+                    // clock alone and say the value is stale instead.
+                    apiUsageStale = true
                 }
-                apiUsageStale = cachedApiUsage?.stale ?? false
                 apiUsagePreAdjusted = false  // raw data from HTTP, needs adjustment
                 oauthConnected = usage["oauthConnected"] as? Bool ?? true
                 // Infer billing type
@@ -7322,10 +7327,11 @@ final class DaemonServer {
             cachedApiUsage = usage
             if let fetchedAt = usage.fetchedAt {
                 lastApiFetchTime = Date(timeIntervalSince1970: fetchedAt)
+                apiUsageStale = usage.stale
             } else {
-                lastApiFetchTime = Date()
+                // Same floor as Tier 1: unknown age is not fresh.
+                apiUsageStale = true
             }
-            apiUsageStale = usage.stale
             apiUsagePreAdjusted = false  // raw data from API, needs adjustment
             oauthConnected = usageAPI.tokenStatus == .valid
             if let inferred = usage.inferredBillingType {
@@ -7364,11 +7370,15 @@ final class DaemonServer {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200,
                   let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   var usage = json["usage"] as? [String: Any] else { return nil }
-            // Validate fetchedAt — skip stale data (>5 min)
-            if let fetchedAt = json["fetchedAt"] as? Int, fetchedAt > 0 {
-                let ageMs = Int(Date().timeIntervalSince1970 * 1000) - fetchedAt
-                if ageMs > 5 * 60 * 1000 { return nil }
-                usage["fetchedAt"] = Double(fetchedAt) / 1000.0
+            // Age-gate the sibling's reading. An unstamped payload is not
+            // "fresh with no stamp" — it is a reading we cannot age, so it is
+            // skipped like any other unusable source. See `UsageRelayFreshness`.
+            switch UsageRelay.classify(fetchedAtMs: json["fetchedAt"] as? Int,
+                                       nowMs: Int(Date().timeIntervalSince1970 * 1000)) {
+            case .usable(let seconds):
+                usage["fetchedAt"] = seconds
+            case .tooOld, .unknownAge:
+                return nil
             }
             usage["type"] = "usage_update"
             return usage

--- a/apple/AgentDeckTests/UsageRelayFreshnessTests.swift
+++ b/apple/AgentDeckTests/UsageRelayFreshnessTests.swift
@@ -1,0 +1,83 @@
+#if os(macOS)
+// The Tier 1 usage relay's age gate.
+//
+// A sibling bridge answers `GET /usage` with `{ usage, fetchedAt }`, and this
+// app decides from that stamp whether the reading may be relayed. The gate used
+// to be one `if let … , fetchedAt > 0` whose failure skipped the whole block —
+// losing the five-minute window AND leaving the payload unstamped, after which
+// the caller wrote `Date()` on it. Numbers of unknown age became the one
+// reading `usageStaleTTL` can never retire.
+//
+// The case that made it reachable is in here by name: a Node bridge that has
+// numbers but has never completed a live fetch serves `fetchedAt: 0`.
+
+import XCTest
+@testable import AgentDeck
+
+final class UsageRelayFreshnessTests: XCTestCase {
+    private let now = 1_787_100_000_000   // epoch ms
+
+    func testAFreshStampIsUsableAndComesBackInSeconds() {
+        // `ApiUsageData.fetchedAt` is epoch seconds while the wire is ms;
+        // getting that conversion wrong would age every reading by 1000×.
+        let stamped = now - 30_000
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: stamped, nowMs: now),
+                       .usable(fetchedAtSeconds: Double(stamped) / 1000.0))
+    }
+
+    func testAReadingOlderThanTheWindowIsSkipped() {
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: now - (5 * 60 * 1000) - 1, nowMs: now),
+                       .tooOld)
+    }
+
+    func testTheWindowBoundaryItselfIsStillUsable() {
+        // Exactly five minutes old is inside the window; only strictly older is
+        // skipped. Pinning the edge stops a later `>=` from silently halving
+        // the relay's usefulness.
+        let edge = now - (5 * 60 * 1000)
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: edge, nowMs: now),
+                       .usable(fetchedAtSeconds: Double(edge) / 1000.0))
+    }
+
+    // MARK: - The two shapes of "we cannot age this"
+
+    func testAZeroStampIsUnknownAgeNotAncient() {
+        // This is the pair the Node fix created: a bridge whose only cached
+        // numbers came from a failed fetch's fallback reports `fetchedAt: 0`.
+        // Read as a timestamp it is 1970 — ancient, and it would classify as
+        // `.tooOld` by accident. It has to be `.unknownAge` on purpose, because
+        // the producer is telling us it never fetched, not that it fetched long
+        // ago.
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: 0, nowMs: now), .unknownAge)
+    }
+
+    func testAMissingStampIsUnknownAgeNotFresh() {
+        // The regression this file exists for. Absence of a timestamp is "no
+        // information" — never "fresh", which is what stamping `Date()` on it
+        // amounted to, and never "old" either.
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: nil, nowMs: now), .unknownAge)
+    }
+
+    func testUnknownAgeIsNeverUsable() {
+        // Stated as the property rather than as two cases, so a third way of
+        // losing the stamp cannot quietly become usable.
+        for missing in [nil, 0, -1] as [Int?] {
+            let verdict = UsageRelay.classify(fetchedAtMs: missing, nowMs: now)
+            XCTAssertEqual(verdict, .unknownAge, "fetchedAt \(String(describing: missing))")
+            if case .usable = verdict { XCTFail("unstamped reading accepted as a relay source") }
+        }
+    }
+
+    // MARK: - Clocks
+
+    func testAStampFromTheFutureIsAcceptedRatherThanSkipped() {
+        // Both processes are on this machine, so a stamp slightly ahead of us
+        // is clock jitter between two local daemons, not a bad reading. It must
+        // not compute a negative age that reads as "way inside the window" by
+        // luck — it is inside the window on purpose.
+        let ahead = now + 2_000
+        XCTAssertEqual(UsageRelay.classify(fetchedAtMs: ahead, nowMs: now),
+                       .usable(fetchedAtSeconds: Double(ahead) / 1000.0))
+    }
+}
+#endif


### PR DESCRIPTION
Consumer-side counterpart to concurrent Node work on the usage relay. Found by tracing a branch I had called unreachable one message before it stopped being unreachable.

## The gate did three jobs in one condition

Tier 1 usage comes from a sibling bridge over `GET /usage`:

```swift
if let fetchedAt = json["fetchedAt"] as? Int, fetchedAt > 0 { …five-minute gate… }
```

When that condition failed — key absent, or a literal `0` — **the whole block was skipped**. The reading lost the age window *and* arrived with no `fetchedAt`, after which the caller wrote `Date()` on it. Numbers of unknown age were recorded as just-fetched, which makes them the one reading `usageStaleTTL` can never retire, because the TTL measures against that stamp.

## Why it was dead code and then wasn't

It was unreachable while every Node result advanced the producer's clock. It stopped being unreachable when the Node daemon correctly stopped advancing `lastApiFetchTime` on a non-live apply — that created a pair which had previously been impossible: **numbers with `fetchedAt: 0`**, for a bridge whose only cached reading came from a failed fetch's stale-cache fallback.

The Node side now refuses to serve those at the producer, so nothing in the current tree reaches this. It is still fixed here: a consumer that reads a missing stamp as "now" is wrong on its own terms, and on any producer.

## The fix

`UsageRelay.classify` names the three answers a stamp can give:

| `fetchedAt` | verdict |
|---|---|
| stamped, inside the window | `.usable(fetchedAtSeconds:)` |
| stamped, older than 5 min | `.tooOld` — skip the sibling |
| absent, `0`, or negative | `.unknownAge` — skip the sibling |

`.unknownAge` is deliberately **not** folded into `.tooOld`: a `0` read as a timestamp lands in 1970 and would classify as ancient by accident, when what the producer is actually saying is that it never fetched. Same distinction the repo already makes for `capturedAt` — absence is "unknown", never "old" and never "fresh".

The two `else { lastApiFetchTime = Date() }` branches now leave the clock alone and set `apiUsageStale` instead, as the floor beneath the gate.

## Verification

- Seven tests, driving the stamp values that occur on the wire rather than the enum's cases — including `0` by name, since that is the value the Node change created.
- Reverting `classify` to the old "no stamp means now" behaviour fails three of them.
- macOS **636 tests pass** (was 629); iOS compiles.

Scope: `apple/` only. Concurrent Node-side work in the shared tree is deliberately excluded and is not required for this to be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)