### PR TITLE
A failed usage fetch must not launder itself as a fresh one

### DIFF
--- a/bridge/src/__tests__/bridge-core.test.ts
+++ b/bridge/src/__tests__/bridge-core.test.ts
@@ -181,6 +181,59 @@ describe('BridgeCore Orchestration', () => {
       const snapshot = core.stateMachine.getSnapshot();
       expect(snapshot.billingType).toBe('subscription');
     });
+
+    // ─── Failed fetch must not launder as a fresh one ────────────────
+    //
+    // Every failure branch of fetchUsageFromApi (429 / 401 / !ok / API-error /
+    // network-throw) still returns the last good numbers off the shared cache
+    // file. Before UsageFetchResult those were indistinguishable from a live
+    // reading, so updateApiUsage() pushed lastApiFetchTime forward and cleared
+    // apiUsageStale — leaving the `usageStale` wire flag unreachable and the
+    // USAGE_STALE_TTL backstop permanently disarmed. On 2026-08-19 that shipped
+    // a 7-minute-old 0% to every surface, marked `usageStale: false`.
+    describe('stale fetch results', () => {
+      it('a not-fresh result keeps the numbers but marks them stale', () => {
+        core.applyUsageResult({ data: sampleApiUsage({ fiveHourPercent: 41 }), fresh: false });
+
+        expect(core.cachedApiUsage?.fiveHourPercent).toBe(41);
+        expect(core.apiUsageStale).toBe(true);
+      });
+
+      it('a not-fresh result does NOT advance lastApiFetchTime', () => {
+        // The freshness clock is what USAGE_STALE_TTL and fetchUsageIfStale both
+        // read; advancing it on a failure is what disarmed them.
+        core.applyUsageResult({ data: sampleApiUsage(), fresh: true });
+        const afterFresh = core.lastApiFetchTime;
+        expect(afterFresh).toBeGreaterThan(0);
+
+        core.applyUsageResult({ data: sampleApiUsage({ fiveHourPercent: 99 }), fresh: false });
+
+        expect(core.lastApiFetchTime).toBe(afterFresh);
+        expect(core.apiUsageStale).toBe(true);
+      });
+
+      it('a fresh result clears staleness again', () => {
+        core.applyUsageResult({ data: sampleApiUsage(), fresh: false });
+        expect(core.apiUsageStale).toBe(true);
+
+        core.applyUsageResult({ data: sampleApiUsage({ fiveHourPercent: 8 }), fresh: true });
+
+        expect(core.apiUsageStale).toBe(false);
+        expect(core.cachedApiUsage?.fiveHourPercent).toBe(8);
+      });
+
+      it('a null result (no numbers at all) marks an existing cache stale', () => {
+        core.applyUsageResult({ data: sampleApiUsage(), fresh: true });
+
+        expect(core.applyUsageResult(null)).toBe(false);
+        expect(core.apiUsageStale).toBe(true);
+      });
+
+      it('reports freshness back to the caller', () => {
+        expect(core.applyUsageResult({ data: sampleApiUsage(), fresh: true })).toBe(true);
+        expect(core.applyUsageResult({ data: sampleApiUsage(), fresh: false })).toBe(false);
+      });
+    });
   });
 
   // ─── Client connect: initial state ────────────────────────────────

--- a/bridge/src/__tests__/hook-server-usage-relay.test.ts
+++ b/bridge/src/__tests__/hook-server-usage-relay.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `/usage` is the relay SOURCE that sibling daemons pull from — the one place a
+ * session bridge's usage numbers cross a process (and daemon-implementation)
+ * boundary. These pin the contract that numbers and their age travel together.
+ *
+ * `fetchedAt` is `BridgeCore.lastApiFetchTime`, which advances only on a live
+ * reading. Once a failed fetch stopped laundering itself as a fresh one, the
+ * pair {numbers, fetchedAt: 0} became reachable for the first time: a bridge
+ * whose only cached usage came from a failed fetch's stale-cache fallback.
+ *
+ * Neither relay consumer handles that pair. Node's `fetchUsageViaHttp` computes
+ * a huge age and skips the sibling (harmless). Swift's `fetchUsageViaHTTP`
+ * guards its whole block on `fetchedAt > 0`, so a 0 skips the 5-minute age gate
+ * AND leaves the key off the dict it returns — `parseRelayedUsage` then reads no
+ * `fetchedAt` and falls to `lastApiFetchTime = Date()`, stamping unknown-age
+ * numbers as just-fetched. Closing it at the producer covers both consumers.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import type { AddressInfo } from 'net';
+import { HookServer } from '../hook-server.js';
+
+const servers: HookServer[] = [];
+
+async function startServer(): Promise<{ server: HookServer; port: number }> {
+  const server = new HookServer();
+  servers.push(server);
+  await server.listen(0);
+  // `listen(0)` binds an ephemeral port; read it back off the raw server.
+  const raw = (server as unknown as { server: { address(): AddressInfo | string | null } }).server;
+  const addr = raw.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  return { server, port };
+}
+
+const sampleUsage = () => ({ fiveHourPercent: 41, sevenDayPercent: 73 });
+
+afterEach(async () => {
+  while (servers.length) await servers.pop()!.close();
+});
+
+describe('GET /usage — relay source contract', () => {
+  it('serves numbers together with a positive fetchedAt', async () => {
+    const { server, port } = await startServer();
+    const fetchedAt = Date.now();
+    server.onApiUsage(() => ({ usage: sampleUsage(), fetchedAt }));
+
+    const body = await (await fetch(`http://127.0.0.1:${port}/usage`)).json();
+
+    expect(body.status).toBe('ok');
+    expect(body.usage).toEqual(sampleUsage());
+    expect(body.fetchedAt).toBe(fetchedAt);
+  });
+
+  it('withholds numbers that carry no timestamp (fetchedAt 0)', async () => {
+    // The regression: a bridge holding cached numbers it never freshly fetched
+    // must not present itself as a relay source. Serving `usage` here is what
+    // reaches Swift's defensive `lastApiFetchTime = Date()` branch.
+    const { server, port } = await startServer();
+    server.onApiUsage(() => ({ usage: sampleUsage(), fetchedAt: 0 }));
+
+    const body = await (await fetch(`http://127.0.0.1:${port}/usage`)).json();
+
+    expect(body.status).toBe('ok');
+    expect(body.usage).toBeNull();
+    expect(body.fetchedAt).toBe(0);
+  });
+
+  it('reports the same empty shape when no usage source is registered', async () => {
+    // The two "nothing to relay" cases must be byte-identical on the wire, so a
+    // consumer needs exactly one branch for them.
+    const { port } = await startServer();
+
+    const body = await (await fetch(`http://127.0.0.1:${port}/usage`)).json();
+
+    expect(body).toEqual({ status: 'ok', usage: null, fetchedAt: 0 });
+  });
+});

--- a/bridge/src/__tests__/usage-api.test.ts
+++ b/bridge/src/__tests__/usage-api.test.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCredSources, resolveOAuthCredentials, parseScopedLimits, type CredSources } from '../usage-api.js';
+import { buildCredSources, resolveOAuthCredentials, parseScopedLimits, fileCacheExpired, type CredSources } from '../usage-api.js';
 
 /** Build a CredSources with sane defaults; override per case. Spies let us assert which
  *  I/O path was taken (critically, that `runSecurityCli` never fires off-darwin). */
@@ -190,5 +190,39 @@ describe('parseScopedLimits', () => {
     expect(parseScopedLimits(undefined)).toEqual([]);
     expect(parseScopedLimits(null)).toEqual([]);
     expect(parseScopedLimits({})).toEqual([]);
+  });
+});
+
+describe('fileCacheExpired — TTL slack', () => {
+  // The shared file cache nominally lives 120s. `fetchedAt` is stamped AFTER the
+  // HTTP round trip, so a poller whose interval divides the TTL always arrives a
+  // little EARLY at the tick that should have expired it, reads a hit, and waits
+  // a whole extra interval. With the daemon's 60s poll that turned the intended
+  // 120s refresh into a hard 180s floor (measured 2026-08-19: network fetches at
+  // 08:25:43 / 08:28:43 / 08:31:43, exact to the second).
+  const NOW = 1_800_000_000_000;
+
+  it('expires a cache that is a fetch-latency hair under the nominal TTL', () => {
+    // The exact shape of the bug: the 120s tick lands at age 119.6s.
+    expect(fileCacheExpired(NOW - 119_600, NOW)).toBe(true);
+  });
+
+  it('expires at the nominal TTL and beyond', () => {
+    expect(fileCacheExpired(NOW - 120_000, NOW)).toBe(true);
+    expect(fileCacheExpired(NOW - 300_000, NOW)).toBe(true);
+  });
+
+  it('still holds a genuinely recent cache — the cross-session 429 dedupe survives', () => {
+    // One poll interval in (60s) must NOT re-fetch, or two bridges double the
+    // request rate the TTL exists to cap.
+    expect(fileCacheExpired(NOW - 60_000, NOW)).toBe(false);
+    expect(fileCacheExpired(NOW - 1_000, NOW)).toBe(false);
+    expect(fileCacheExpired(NOW, NOW)).toBe(false);
+  });
+
+  it('slack stays well inside the poll interval', () => {
+    // The effective TTL must remain above the 60s this started at, so the slack
+    // can never be widened into "fetch on every tick".
+    expect(fileCacheExpired(NOW - 100_000, NOW)).toBe(false);
   });
 });

--- a/bridge/src/__tests__/usage-relay-fallback.test.ts
+++ b/bridge/src/__tests__/usage-relay-fallback.test.ts
@@ -99,11 +99,11 @@ describe('fetchUsageRelayed — direct-API fallback (regression: fa1d98c9)', () 
   // used the direct API before fa1d98c9. Pins that it still does.
   it('no siblings → uses the direct API', async () => {
     const direct = sampleUsage({ fiveHourPercent: 7 });
-    fetchUsageFromApiMock.mockResolvedValue(direct);
+    fetchUsageFromApiMock.mockResolvedValue({ data: direct, fresh: true });
 
     const result = await fetchUsageRelayed(SELF_PORT);
 
-    expect(result).toBe(direct);
+    expect(result?.data).toBe(direct);
     expect(fetchUsageFromApiMock).toHaveBeenCalledTimes(1);
   });
 
@@ -114,11 +114,11 @@ describe('fetchUsageRelayed — direct-API fallback (regression: fa1d98c9)', () 
     registryState.siblings = [{ port: deadPort, agentType: 'claude' }];
 
     const direct = sampleUsage({ fiveHourPercent: 63 });
-    fetchUsageFromApiMock.mockResolvedValue(direct);
+    fetchUsageFromApiMock.mockResolvedValue({ data: direct, fresh: true });
 
     const result = await fetchUsageRelayed(SELF_PORT);
 
-    expect(result).toBe(direct);
+    expect(result?.data).toBe(direct);
     expect(fetchUsageFromApiMock).toHaveBeenCalledTimes(1);
   });
 
@@ -129,11 +129,11 @@ describe('fetchUsageRelayed — direct-API fallback (regression: fa1d98c9)', () 
     registryState.siblings = [{ port: sibling.port, agentType: 'claude' }];
 
     const direct = sampleUsage({ fiveHourPercent: 88 });
-    fetchUsageFromApiMock.mockResolvedValue(direct);
+    fetchUsageFromApiMock.mockResolvedValue({ data: direct, fresh: true });
 
     try {
       const result = await fetchUsageRelayed(SELF_PORT);
-      expect(result).toBe(direct);
+      expect(result?.data).toBe(direct);
       expect(fetchUsageFromApiMock).toHaveBeenCalledTimes(1);
     } finally {
       await sibling.close();
@@ -145,11 +145,12 @@ describe('fetchUsageRelayed — direct-API fallback (regression: fa1d98c9)', () 
     const sibling = await startSibling(() => ({ usage: relayed, fetchedAt: Date.now() }));
     registryState.siblings = [{ port: sibling.port, agentType: 'claude' }];
 
-    fetchUsageFromApiMock.mockResolvedValue(sampleUsage({ fiveHourPercent: 1 }));
+    fetchUsageFromApiMock.mockResolvedValue({ data: sampleUsage({ fiveHourPercent: 1 }), fresh: true });
 
     try {
       const result = await fetchUsageRelayed(SELF_PORT);
-      expect(result?.fiveHourPercent).toBe(55);
+      expect(result?.data.fiveHourPercent).toBe(55);
+      expect(result?.fresh).toBe(true);
       expect(fetchUsageFromApiMock).not.toHaveBeenCalled();
     } finally {
       await sibling.close();
@@ -162,11 +163,11 @@ describe('fetchUsageRelayed — direct-API fallback (regression: fa1d98c9)', () 
     registryState.siblings = [{ port: sibling.port, agentType: 'claude' }];
 
     const direct = sampleUsage({ fiveHourPercent: 33 });
-    fetchUsageFromApiMock.mockResolvedValue(direct);
+    fetchUsageFromApiMock.mockResolvedValue({ data: direct, fresh: true });
 
     try {
       const result = await fetchUsageRelayed(SELF_PORT);
-      expect(result).toBe(direct);
+      expect(result?.data).toBe(direct);
       expect(fetchUsageFromApiMock).toHaveBeenCalledTimes(1);
     } finally {
       await sibling.close();

--- a/bridge/src/bridge-core.ts
+++ b/bridge/src/bridge-core.ts
@@ -17,7 +17,7 @@ import { fetchMlxModels } from './mlx-probe.js';
 import { buildDisplayStateEvent } from './display-dim.js';
 import { loadMlxSettings } from '@agentdeck/shared';
 import { probeGateway, checkGatewayHealth } from './gateway-probe.js';
-import { fetchUsageFromApi, hasOAuthToken, getTokenStatus, type ApiUsageData } from './usage-api.js';
+import { fetchUsageFromApi, hasOAuthToken, getTokenStatus, type ApiUsageData, type UsageFetchResult } from './usage-api.js';
 import { buildEnrichedSessionsList } from './session-aggregator.js';
 import { activityFor } from './session-activity.js';
 import {
@@ -436,34 +436,59 @@ export class BridgeCore {
   /**
    * Update cached API usage and broadcast.
    * Handles billingType inference.
+   *
+   * `fresh` decides whether this counts as a LIVE reading. A false value still
+   * updates the numbers shown (they are the best available) but must NOT push
+   * `lastApiFetchTime` forward or clear `apiUsageStale` — doing so is what made
+   * a failed fetch indistinguishable from a successful one, disarming both the
+   * `usageStale` wire flag and the `USAGE_STALE_TTL` backstop that exists to
+   * catch exactly this. See `UsageFetchResult`.
    */
-  updateApiUsage(usage: ApiUsageData): void {
+  updateApiUsage(usage: ApiUsageData, fresh = true): void {
     this.cachedApiUsage = usage;
-    this.lastApiFetchTime = Date.now();
-    this.oauthConnected = true;
-    this.apiUsageStale = false;
     this.apiUsagePreAdjusted = false; // raw data from API, needs adjustment
+    if (fresh) {
+      this.lastApiFetchTime = Date.now();
+      this.oauthConnected = true;
+      this.apiUsageStale = false;
+    } else {
+      // Numbers survive; the claim that they are current does not.
+      this.oauthConnected = hasOAuthToken();
+      this.apiUsageStale = true;
+    }
     if (usage.inferredBillingType) {
       this.stateMachine.inferBillingType(usage.inferredBillingType);
     }
     this.broadcastUsage();
   }
 
-  /** Fetch usage from API and update cache. Returns true if successful. */
-  async fetchAndUpdateUsage(): Promise<boolean> {
-    const usage = await fetchUsageFromApi();
-    if (usage) {
-      this.updateApiUsage(usage);
-      // Token status check — if expired, mark stale even though we got cached data
+  /**
+   * Apply the outcome of a usage fetch — the single place that turns a
+   * `UsageFetchResult | null` into cache + staleness state.
+   *
+   * Five call sites in the daemon each hand-rolled this three-line branch; they
+   * agreed only by luck, and every one of them was reachable-in-theory dead code
+   * because the fetch never returned null. One function so a new caller cannot
+   * reintroduce the divergence.
+   */
+  applyUsageResult(result: UsageFetchResult | null): boolean {
+    if (result) {
+      this.updateApiUsage(result.data, result.fresh);
+      // Token status check — if expired, mark stale even though we got numbers
       const tokenStatus = getTokenStatus();
       if (tokenStatus === 'expired' || tokenStatus === 'missing') {
         this.apiUsageStale = true;
       }
-      return true;
+      return result.fresh;
     }
     this.oauthConnected = hasOAuthToken();
     if (this.cachedApiUsage) this.apiUsageStale = true;
     return false;
+  }
+
+  /** Fetch usage from API and update cache. Returns true on a LIVE reading. */
+  async fetchAndUpdateUsage(): Promise<boolean> {
+    return this.applyUsageResult(await fetchUsageFromApi());
   }
 
   /** Fetch usage if cache is stale or empty (best-effort, no throw) */
@@ -601,18 +626,11 @@ export class BridgeCore {
    * Start periodic API usage refresh.
    * @param fetchFn Custom fetch function (for daemon relay). Defaults to direct API.
    */
-  startApiUsagePolling(intervalMs: number, fetchFn?: () => Promise<ApiUsageData | null>): void {
+  startApiUsagePolling(intervalMs: number, fetchFn?: () => Promise<UsageFetchResult | null>): void {
     const fetch = fetchFn ?? (() => fetchUsageFromApi());
     this.addInterval(setInterval(() => {
       if (!this.hasClients()) return;
-      fetch().then((usage) => {
-        if (usage) {
-          this.updateApiUsage(usage);
-        } else {
-          this.oauthConnected = hasOAuthToken();
-          if (this.cachedApiUsage) this.apiUsageStale = true;
-        }
-      }).catch(() => {});
+      fetch().then((result) => this.applyUsageResult(result)).catch(() => {});
     }, intervalMs));
   }
 

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -141,7 +141,7 @@ import {
   PREFERRED_PORT_RECLAIM_MS,
   type DaemonPortSource,
 } from './daemon-port.js';
-import { fetchUsageFromApi, hasOAuthToken, resetConsecutiveFailures, type ApiUsageData } from './usage-api.js';
+import { fetchUsageFromApi, hasOAuthToken, resetConsecutiveFailures, type ApiUsageData, type UsageFetchResult } from './usage-api.js';
 import { getOrCreateToken, isLocalConnection, validateToken } from './auth.js';
 import { buildPublicHealth, gateHttpRequest, isAuthorizedHttpRequest } from './http-auth-gate.js';
 import {
@@ -836,15 +836,17 @@ async function fetchUsageViaWs(siblings: { port: number }[]): Promise<ApiUsageDa
 }
 
 /** @internal Exported for the relay-fallback regression test. */
-export async function fetchUsageRelayed(selfPort: number): Promise<ApiUsageData | null> {
+export async function fetchUsageRelayed(selfPort: number): Promise<UsageFetchResult | null> {
   const sessions = listActiveSessions();
   const siblings = sessions.filter(s => s.port !== selfPort && s.agentType !== 'daemon');
 
+  // A sibling's reading is a real successful one, not a failure fallback, so it
+  // is `fresh` — its age contract is the 5-minute gate inside fetchUsageViaHttp.
   if (siblings.length > 0) {
     const httpResult = await fetchUsageViaHttp(siblings);
-    if (httpResult) return httpResult.usage;
+    if (httpResult) return { data: httpResult.usage, fresh: true };
     const wsResult = await fetchUsageViaWs(siblings);
-    if (wsResult) return wsResult;
+    if (wsResult) return { data: wsResult, fresh: true };
     // Relay is only an optimization to avoid multiple API pollers. A PTY session
     // bridge only refreshes usage when it has *direct* inbound WS clients, but
     // dashboards/Stream Deck connect to the daemon (sole entry point) — so a
@@ -3232,13 +3234,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     // Reset backoff from pre-sleep failures and fetch fresh usage after network stabilizes
     resetConsecutiveFailures();
     setTimeout(() => {
-      fetchUsageRelayed(port).then((usage) => {
-        if (usage) core.updateApiUsage(usage);
-        else {
-          core.oauthConnected = hasOAuthToken();
-          if (core.cachedApiUsage) core.apiUsageStale = true;
-        }
-      });
+      fetchUsageRelayed(port).then((result) => core.applyUsageResult(result));
     }, 4000);
   });
 
@@ -4605,10 +4601,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       return;
     }
     if (cmd.type === 'query_usage') {
-      fetchUsageRelayed(port).then((usage) => {
-        if (usage) core.updateApiUsage(usage);
-        else if (core.cachedApiUsage) core.apiUsageStale = true;
-      });
+      fetchUsageRelayed(port).then((result) => core.applyUsageResult(result));
     }
   };
   // ── Device-sourced voice ──────────────────────────────────────────────
@@ -5405,13 +5398,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     // Fetch usage on connect if stale
     const cacheAge = Date.now() - core.lastApiFetchTime;
     if (!core.cachedApiUsage || (core.lastApiFetchTime > 0 && cacheAge > 5 * 60 * 1000)) {
-      fetchUsageRelayed(port).then((usage) => {
-        if (usage) core.updateApiUsage(usage);
-        else {
-          core.oauthConnected = hasOAuthToken();
-          if (core.cachedApiUsage) core.apiUsageStale = true;
-        }
-      });
+      fetchUsageRelayed(port).then((result) => core.applyUsageResult(result));
     }
   });
 
@@ -5628,13 +5615,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
   // Initial usage fetch (delayed 10s)
   core.addTimeout(setTimeout(() => {
-    fetchUsageRelayed(port).then((usage) => {
-      if (usage) core.updateApiUsage(usage);
-      else {
-        core.oauthConnected = hasOAuthToken();
-        if (core.cachedApiUsage) core.apiUsageStale = true;
-      }
-    });
+    fetchUsageRelayed(port).then((result) => core.applyUsageResult(result));
   }, 10_000));
 
   // Backstop sweep for held PreToolUse approval responses whose per-entry timer

--- a/bridge/src/hook-server.ts
+++ b/bridge/src/hook-server.ts
@@ -142,6 +142,23 @@ export class HookServer extends EventEmitter {
         return;
       }
       const data = this.apiUsageGetter();
+      // Numbers and their age travel together, or not at all. `fetchedAt` is
+      // `BridgeCore.lastApiFetchTime`, which advances only on a LIVE reading —
+      // so a bridge whose cache came from a failed fetch's fallback has numbers
+      // with a 0 timestamp. This endpoint exists to be a relay SOURCE, and a
+      // bridge that never completed a live fetch is not one: say so with an
+      // explicit null rather than shipping unstamped values.
+      //
+      // Both relay consumers gate on a positive `fetchedAt` and neither handles
+      // the pair {numbers, 0}: Node's fetchUsageViaHttp computes a huge age and
+      // skips (harmless), but Swift's fetchUsageViaHTTP skips its whole
+      // `fetchedAt > 0` block — dropping the age gate AND the key — so
+      // parseRelayedUsage falls to `lastApiFetchTime = Date()` and stamps
+      // unknown-age data as just-fetched. Closing it at the producer fixes both.
+      if (!data.fetchedAt) {
+        res.json({ status: 'ok', usage: null, fetchedAt: 0 });
+        return;
+      }
       res.json({ status: 'ok', usage: data.usage, fetchedAt: data.fetchedAt });
     });
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -53,7 +53,6 @@ import {
 } from './session-registry.js';
 import { resolveProjectName } from './utils/project-name.js';
 import { DaemonWsClient } from './daemon-ws-client.js';
-import { fetchUsageFromApi, hasOAuthToken } from './usage-api.js';
 import { buildUsageEvent } from './usage-event.js';
 import { getLanIp } from '@agentdeck/shared';
 import { buildEnrichedSessionsList } from './session-aggregator.js';
@@ -1061,7 +1060,10 @@ export async function startSession(opts: SessionOptions): Promise<void> {
 
   // ===== Polling =====
   core.startUsageTick();
-  core.startApiUsagePolling(90_000);
+  // 60s, matching the daemon. A 90s poll against the 120s file-cache TTL can
+  // only ever fetch on its second tick, so this bridge's readings — which the
+  // daemon relays from via /usage — were pinned to a 180s floor.
+  core.startApiUsagePolling(60_000);
   core.startOllamaProbe();
   core.startMlxProbe();
   core.startAntigravityProbe();

--- a/bridge/src/usage-api.ts
+++ b/bridge/src/usage-api.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { debug } from './logger.js';
+import { debug, logTagged } from './logger.js';
 import type { ScopedUsageLimit } from './types.js';
 
 const USAGE_API_URL = 'https://api.anthropic.com/api/oauth/usage';
@@ -12,6 +12,30 @@ const USAGE_CACHE_FILE = join(AGENTDECK_DIR, 'usage-cache.json');
 
 /** Shared file cache TTL — multiple bridge sessions share one cache file */
 const FILE_CACHE_TTL_MS = 120_000; // 120s — reduced from 60s to avoid 429 from multiple pollers
+
+/**
+ * Slack subtracted from the TTL when testing expiry.
+ *
+ * `fetchedAt` is stamped AFTER the HTTP round trip completes, so a poller whose
+ * interval divides the TTL always arrives a few hundred ms EARLY at the tick
+ * that should have expired the cache: it reads a hit and then waits a whole
+ * extra interval. With the daemon's 60s poll and a 120s TTL that turned the
+ * intended 120s refresh into a hard 180s floor — measured 2026-08-19, three
+ * consecutive network fetches at 08:25:43 / 08:28:43 / 08:31:43, exact to the
+ * second, never once landing on 120s.
+ *
+ * The slack must exceed fetch latency plus timer drift, and stay well under the
+ * poll interval so the cross-session dedupe the TTL exists for is preserved
+ * (effective TTL 105s — still comfortably above the 60s this started at).
+ */
+const FILE_CACHE_SLACK_MS = 15_000;
+
+/** True when the on-disk cache is old enough that a poller should go to the network.
+ *  Exported for the slack regression test — the bug it prevents is invisible in
+ *  any single call and only shows up as a cadence, so pin the predicate. */
+export function fileCacheExpired(fetchedAt: number, nowMs = Date.now()): boolean {
+  return (nowMs - fetchedAt) >= (FILE_CACHE_TTL_MS - FILE_CACHE_SLACK_MS);
+}
 
 /** Token expiry safety margin — skip fetch if token expires within this window */
 const TOKEN_EXPIRY_MARGIN_MS = 10 * 60 * 1000; // 10 minutes
@@ -31,6 +55,30 @@ export interface ApiUsageData {
   scopedLimits: ScopedUsageLimit[];
   /** Inferred from API response: subscription if rate-limit fields present, api if 401/no fields */
   inferredBillingType: 'subscription' | 'api' | null;
+}
+
+/**
+ * A usage reading plus whether it is a LIVE one.
+ *
+ * Freshness must not be folded into the data or into a null return. Every
+ * failure branch below can still produce numbers — the last good ones off the
+ * shared cache file — and a caller that cannot tell those apart from a live
+ * reading will stamp them as fresh: that is exactly what happened before this
+ * type existed. `fetchUsageFromApi` returned `fileCache?.data ?? null` on 429 /
+ * 401 / !ok / API-error / network-throw, so `BridgeCore.updateApiUsage()` ran on
+ * the truthy value, pushed `lastApiFetchTime` forward and cleared
+ * `apiUsageStale`. The `usageStale` wire flag was therefore unreachable for the
+ * commonest failure mode, `USAGE_STALE_TTL` never tripped, and a 7-minute freeze
+ * on 2026-08-19 shipped a stale 0% to every surface marked `usageStale: false`.
+ *
+ * `null` now means only "no numbers at all" (no cache file and no live fetch).
+ */
+export interface UsageFetchResult {
+  data: ApiUsageData;
+  /** True only when `data` came from the network, or from a cache entry a
+   *  network fetch wrote within the TTL. False when it is a fallback served
+   *  because the fetch could not be made or failed. */
+  fresh: boolean;
 }
 
 export type TokenStatus = 'valid' | 'expired' | 'missing' | 'unknown';
@@ -58,6 +106,38 @@ export function getTokenStatus(): TokenStatus {
 export function resetConsecutiveFailures(): void {
   consecutiveFailures = 0;
   lastFetchFailed = false;
+}
+
+/**
+ * Record a failed fetch and make it visible in the daemon's own log.
+ *
+ * `debug()` was the only breadcrumb here, and the daemon runs without DEBUG —
+ * so a run of failed fetches left NO record anywhere. The 2026-08-19 freeze had
+ * to be reconstructed from cache-file mtimes, and the reason for it is still
+ * unknown because nothing wrote it down. Log the first failure and every fifth
+ * after it: a persistent outage stays visible without flooding a file that a
+ * 60s poller writes to.
+ */
+function noteFailure(reason: string): void {
+  lastFetchFailed = true;
+  consecutiveFailures++;
+  if (consecutiveFailures === 1 || consecutiveFailures % 5 === 0) {
+    logTagged(
+      'usage',
+      `Claude usage fetch failed (${consecutiveFailures}x): ${reason} — serving cached values as stale, next attempt after ${Math.round(getBackoffMs() / 1000)}s backoff`,
+    );
+  }
+  debug('UsageAPI', `Fetch failed (${consecutiveFailures}x): ${reason}`);
+}
+
+/** Clear failure state after a live fetch, announcing recovery if one was needed. */
+function noteSuccess(): void {
+  if (consecutiveFailures > 0) {
+    logTagged('usage', `Claude usage fetch recovered after ${consecutiveFailures} failure(s)`);
+  }
+  lastFetchFailed = false;
+  consecutiveFailures = 0;
+  lastTokenStatus = 'valid';
 }
 
 /** Backoff interval based on consecutive failures: 0→0, 1→45s, 2→90s, 3→180s, 4+→300s */
@@ -281,15 +361,20 @@ export function parseScopedLimits(limits: unknown): ScopedUsageLimit[] {
 
 // ===== Main fetch =====
 
-export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
+export async function fetchUsageFromApi(): Promise<UsageFetchResult | null> {
+  // A cached reading served because the live path could not run or failed. Never
+  // `fresh` — see UsageFetchResult.
+  const stale = (fc: UsageCacheFile | null): UsageFetchResult | null =>
+    (fc ? { data: fc.data, fresh: false } : null);
+
   // 1. Check file cache first — shared across all bridge sessions
   const fileCache = readFileCache();
-  if (fileCache && (Date.now() - fileCache.fetchedAt) < FILE_CACHE_TTL_MS) {
+  if (fileCache && !fileCacheExpired(fileCache.fetchedAt)) {
     debug('UsageAPI', `File cache hit (age ${Math.round((Date.now() - fileCache.fetchedAt) / 1000)}s)`);
-    lastFetchFailed = false;
-    consecutiveFailures = 0;
-    lastTokenStatus = 'valid';
-    return fileCache.data;
+    // A within-TTL entry was written by a real network fetch (only the success
+    // path writes it), so this IS a fresh reading — just a shared one.
+    noteSuccess();
+    return { data: fileCache.data, fresh: true };
   }
 
   // 2. Read OAuth credentials
@@ -297,7 +382,7 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
   if (!creds) {
     debug('UsageAPI', 'No OAuth token available');
     lastTokenStatus = 'missing';
-    return fileCache?.data ?? null; // return stale cache if available
+    return stale(fileCache); // last known values, explicitly not fresh
   }
 
   // 3. Token expiry check
@@ -307,12 +392,12 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
       debug('UsageAPI', 'OAuth token expired — waiting for Claude Code to refresh');
       lastTokenStatus = 'expired';
       lastFetchFailed = true;
-      return fileCache?.data ?? null;
+      return stale(fileCache);
     }
     if (timeUntilExpiry < TOKEN_EXPIRY_MARGIN_MS) {
       debug('UsageAPI', `OAuth token expires in ${Math.round(timeUntilExpiry / 60000)}m — skipping fetch`);
       lastTokenStatus = 'expired';
-      return fileCache?.data ?? null;
+      return stale(fileCache);
     }
   }
 
@@ -320,7 +405,7 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
   const backoff = getBackoffMs();
   if (backoff > 0 && fileCache && (Date.now() - fileCache.fetchedAt) < backoff) {
     debug('UsageAPI', `Backoff active (${consecutiveFailures} failures, next in ${Math.round((backoff - (Date.now() - fileCache.fetchedAt)) / 1000)}s)`);
-    return fileCache.data; // return stale cache
+    return stale(fileCache); // holding off on purpose — the numbers are still old
   }
 
   // 5. Actual API fetch
@@ -338,8 +423,7 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
 
     // 429 — respect Retry-After header, backoff on next poll
     if (res.status === 429) {
-      consecutiveFailures++;
-      lastFetchFailed = true;
+      noteFailure('rate limited (429)');
       const retryAfter = res.headers.get('retry-after');
       if (retryAfter) {
         const retrySec = parseInt(retryAfter, 10);
@@ -363,23 +447,19 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
       } else {
         debug('UsageAPI', `Rate limited (429), consecutive failures: ${consecutiveFailures}, backoff: ${getBackoffMs() / 1000}s`);
       }
-      return fileCache?.data ?? null;
+      return stale(fileCache);
     }
 
     // 401/403 — token issue
     if (res.status === 401 || res.status === 403) {
-      debug('UsageAPI', `Auth error ${res.status} — token may be invalid or expired`);
       lastTokenStatus = 'expired';
-      lastFetchFailed = true;
-      consecutiveFailures++;
-      return fileCache?.data ?? null;
+      noteFailure(`auth error ${res.status} — token may be invalid or expired`);
+      return stale(fileCache);
     }
 
     if (!res.ok) {
-      debug('UsageAPI', `API returned ${res.status}: ${res.statusText}`);
-      lastFetchFailed = true;
-      consecutiveFailures++;
-      return fileCache?.data ?? null;
+      noteFailure(`API returned ${res.status} ${res.statusText}`);
+      return stale(fileCache);
     }
 
     const data = await res.json() as Record<string, any>;
@@ -397,10 +477,8 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
     } catch { /* ignore */ }
 
     if (data.error) {
-      debug('UsageAPI', `API error: ${data.error.type}`);
-      lastFetchFailed = true;
-      consecutiveFailures++;
-      return fileCache?.data ?? null;
+      noteFailure(`API error: ${data.error.type}`);
+      return stale(fileCache);
     }
 
     const extraUsage = data.extra_usage;
@@ -421,17 +499,13 @@ export async function fetchUsageFromApi(): Promise<ApiUsageData | null> {
     debug('UsageAPI', `5h: ${result.fiveHourPercent}%, 7d: ${result.sevenDayPercent}%, extra: ${result.extraUsageEnabled ? 'enabled' : 'disabled'}`);
 
     // Success — reset counters, write cache
-    lastFetchFailed = false;
-    consecutiveFailures = 0;
-    lastTokenStatus = 'valid';
+    noteSuccess();
     writeFileCache(result);
 
-    return result;
+    return { data: result, fresh: true };
   } catch (err) {
-    debug('UsageAPI', `Fetch failed: ${err}`);
-    lastFetchFailed = true;
-    consecutiveFailures++;
-    return fileCache?.data ?? null;
+    noteFailure(String(err).slice(0, 160));
+    return stale(fileCache);
   }
 }
 


### PR DESCRIPTION
Claude usage looked frozen. The API and the daemon were both healthy — network fetches were landing at **08:25:43 / 08:28:43 / 08:31:43**, exact to the second. Measuring that cadence turned up three defects.

### 1. A failed fetch was indistinguishable from a live one

Every failure branch of `fetchUsageFromApi` (429 / 401·403 / `!res.ok` / API-error / network-throw) returned `fileCache?.data ?? null` — the last good numbers off the shared cache file, **not** null. The caller's `if (usage)` took the success branch, so `updateApiUsage()` stamped `lastApiFetchTime = Date.now()` and cleared `apiUsageStale`.

Consequences, all silent:

- the `usageStale` wire flag was **unreachable** for the commonest failure mode (it only fires when there is no cache file at all)
- `USAGE_STALE_TTL` never tripped — `lastApiFetchTime` had just been refreshed
- `fetchUsageIfStale`'s 5-minute guard was reset on every failure

A 7-minute freeze shipped a stale `0%` to every surface, marked `usageStale: false`.

Freshness now rides the value — `UsageFetchResult { data, fresh }`, with `null` meaning only "no numbers at all". `updateApiUsage(usage, fresh)` keeps the numbers on a stale result but leaves the clock alone. The five hand-rolled apply blocks in `daemon-server.ts` — every one of them unreachable dead code under the old contract, agreeing only by luck — collapse into one `core.applyUsageResult()`.

### 2. A poll interval that divides the TTL never expires the cache on that tick

`fetchedAt` is stamped *after* the HTTP round trip, so the 120s tick always arrived at age `120s − latency`, read a hit, and waited a whole extra interval. The intended 120s refresh was a hard **180s floor**.

Fixed in the comparison rather than the constant: `age >= TTL − slack`, slack 15s (effective TTL 105s — still well above the 60s this dedupe started at). `index.ts`'s PTY-bridge poll was 90s against the same 120s TTL, structurally the same trap, and is now 60s; the daemon relays its readings via `/usage`.

### 3. A relay source must serve numbers and their age together, or neither

Not advancing the clock on a failure made `{numbers, fetchedAt: 0}` reachable for the first time — a bridge whose only cached reading came from a fallback. Node's `fetchUsageViaHttp` computes a huge age and skips it harmlessly, but the Swift consumer gates its whole block on `fetchedAt > 0`: a `0` drops **both** the 5-minute age gate and the key, so `parseRelayedUsage` reads no stamp and falls to `lastApiFetchTime = Date()`, stamping unknown-age data as just-fetched.

`/usage` now answers `usage: null` when the stamp is missing — the same shape it already returns with no source registered, so a consumer needs one branch for both. Closed at the consumer end too in #231.

### Observability

Failures only reached `debug()`, and the daemon runs without `DEBUG` — so the freeze left **no record anywhere** and its cause is still unknown. `noteFailure`/`noteSuccess` now log the first failure, every fifth after it, and the recovery, each with the reason and the current backoff.

### Verification

`pnpm build` clean; suite green on this base. Every new gate was verified **red** against the unfixed code:

| gate | pins |
|---|---|
| `usage-api.test.ts` → `fileCacheExpired` | the 180s floor (a tick landing at 119.6s must expire) and that a 60s-old cache still holds |
| `bridge-core.test.ts` → stale fetch results | a not-fresh result marks stale and does **not** advance `lastApiFetchTime` |
| `hook-server-usage-relay.test.ts` | `/usage` withholds unstamped numbers; both "nothing to relay" shapes are byte-identical |

### Note

The generalization shared with #230/#231: all three are one value meaning two situations with no way for the caller to tell them apart. The fix is the same move each time — put *what happened* on the value instead of inferring it from the value's shape. The wrong version always looks total; every branch returns something. What is missing is a distinction, not a case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)