### PR TITLE
A staged firmware nothing will ever pull is not a fallback

### DIFF
--- a/bridge/src/__tests__/esp32-ota-stage-key.test.ts
+++ b/bridge/src/__tests__/esp32-ota-stage-key.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WebSocket } from 'ws';
+import { __resetWifiEsp32OtaState, __wifiOtaTestApi } from '../daemon-server.js';
+
+// ─── Pull-OTA staging: the key, and the promise ──────────────────────────────
+// `--stage` reported success twice for a stage that could never install, and
+// the board sat a whole release behind while its OTA read as handled.
+//
+// Two independent failures, both measured on t_display_pro 192.168.68.74 on
+// 2026-08-19, and each of them alone is enough to make the stage inert:
+//
+//   1. The map was keyed on the RAW target. Naming a unit by IP is the
+//      documented way to disambiguate two units sharing a `board` string, so
+//      the key became `192.168.68.74` while the advert is looked up by
+//      `device_info.board` — a pair that can never meet.
+//   2. Nothing in this repo's esp32/ tree pulls the feed at all (`grep -rl
+//      "/feed" esp32/src` is empty; those boards hold a live WS). Only the
+//      external pull-sync fork does, so a stage aimed at a WS board is a
+//      reservation no one collects.
+//
+// These pin the POLARITY, not today's fleet: a stage resolves to a board, and
+// a stage the daemon has no evidence anyone will collect says so.
+
+const fakeWs = (): WebSocket => ({ readyState: 1 } as unknown as WebSocket);
+
+function register(board: string, ip: string): void {
+  __wifiOtaTestApi.registerWifiEsp32(
+    { board, ip, version: '1.0.5', otaSupported: true, otaSlotSize: 6291456 },
+    fakeWs(),
+  );
+}
+
+describe('pull-OTA staging', () => {
+  let dir: string;
+  let firmware: string;
+  let realHome: string | undefined;
+
+  beforeEach(() => {
+    __resetWifiEsp32OtaState();
+    __wifiOtaTestApi.clearStagedFwForTest();
+    dir = mkdtempSync(join(tmpdir(), 'stage-fw-'));
+    firmware = join(dir, 'firmware.bin');
+    writeFileSync(firmware, Buffer.alloc(2048, 0x5a));
+    // stageEsp32Fw persists to ~/.agentdeck/staged-fw.json; keep the real one
+    // out of reach. os.homedir() reads $HOME per call on POSIX.
+    realHome = process.env.HOME;
+    process.env.HOME = dir;
+    mkdirSync(join(dir, '.agentdeck'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
+    __wifiOtaTestApi.clearStagedFwForTest();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves an IP target to the board the advert is keyed on', () => {
+    register('t_display_pro', '192.168.68.74');
+    expect(__wifiOtaTestApi.resolveStagedFwBoard('192.168.68.74')).toBe('t_display_pro');
+  });
+
+  it('keeps an unknown target verbatim rather than inventing a board', () => {
+    // Staging for a board this daemon has not met is legitimate — an empty
+    // registry must not silently retarget the stage at something else.
+    expect(__wifiOtaTestApi.resolveStagedFwBoard('xteink_x4')).toBe('xteink_x4');
+  });
+
+  it('adverts an IP-targeted stage to the board that pulls the feed', () => {
+    register('t_display_pro', '192.168.68.74');
+    const staged = __wifiOtaTestApi.stageEsp32Fw('192.168.68.74', firmware);
+
+    expect(staged.board).toBe('t_display_pro');
+    // The regression: the advert is looked up by device_info.board, so a stage
+    // stored under the IP answers `undefined` here and installs nowhere.
+    expect(__wifiOtaTestApi.stagedFwAdvert('t_display_pro')).toEqual({
+      size: 2048,
+      md5: staged.md5,
+    });
+    expect(__wifiOtaTestApi.stagedFwAdvert('192.168.68.74')).toBeUndefined();
+  });
+
+  it('reports pullSeen=false when no feed pull has ever been observed', () => {
+    register('t_display_pro', '192.168.68.74');
+    expect(__wifiOtaTestApi.stageEsp32Fw('192.168.68.74', firmware).pullSeen).toBe(false);
+  });
+
+  it('reports pullSeen=true once that board has actually pulled the feed', () => {
+    __wifiOtaTestApi.feedPulls.noteBoard('192.168.68.90', 'xteink_x4');
+    __wifiOtaTestApi.feedPulls.record('192.168.68.90', { cards: 3, nextPullSec: 900 });
+
+    expect(__wifiOtaTestApi.stageEsp32Fw('xteink_x4', firmware).pullSeen).toBe(true);
+  });
+
+  it('resolves a target through the feed tracker when the board has slept out of the WS roster', () => {
+    // A wake-sync-sleep client is absent from the WiFi registry between wakes —
+    // which is exactly the board staging exists for, so the roster cannot be
+    // the only place a target is resolved.
+    __wifiOtaTestApi.feedPulls.noteBoard('192.168.68.91', 'xteink_x3');
+    __wifiOtaTestApi.feedPulls.record('192.168.68.91', { cards: 2, nextPullSec: 1800 });
+
+    expect(__wifiOtaTestApi.resolveStagedFwBoard('192.168.68.91')).toBe('xteink_x3');
+  });
+});

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -1558,6 +1558,19 @@ program
         throw new Error(String(body.error ?? `HTTP ${statusCode}`));
       }
       log(`Staged for ${body.board}: ${formatBytes(body.bytes)} md5=${body.md5}`);
+      if (body.pullSeen === false) {
+        // "Staged" is a promise the board has to keep, and only a board that
+        // pulls the feed can keep it. Boards in this repo's esp32/ tree hold a
+        // live WebSocket and never pull, so a stage for one is a reservation
+        // nothing will ever collect — reported as success, which is how a board
+        // sat a full release behind while its OTA looked handled.
+        log(`WARNING: this daemon has seen no feed pull from ${body.board} since it started.`);
+        log('  Only pull-sync boards (XTeink X3/X4/M6) fetch staged firmware. A board that');
+        log('  holds a live WS never asks for it, so this stage may never install.');
+        log('  Check `agentdeck devices` (card-feed clients); otherwise flash over USB serial.');
+        log('  Verify with the board\'s reported buildHash, never with this message.');
+        return;
+      }
       log('The board installs it on its next feed pull (battery cadence: typically within 15-60 min).');
       return;
     }

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -361,16 +361,51 @@ function saveStagedFw(): void {
   }
 }
 
+/** Resolve a stage target (canonical board, registry key, or IP) to the board
+ *  string the advert is keyed on.
+ *
+ *  This map is read back by `stagedFwAdvert(device_info.board)`, so anything
+ *  else stored as the key is an advert that can never fire. Staging with an IP
+ *  is not a misuse to reject — it is the documented way to name one unit when
+ *  two share a `board` string (see esp32-ota's ambiguity error) — so normalize
+ *  it here instead. Consequence worth stating: the feed pull carries only a
+ *  board, so a stage aimed at one unit adverts to every unit of that board.
+ *  They run the same image, so that is correct rather than merely tolerable.
+ *
+ *  Unlike `findWifiOtaTarget` this must NOT require an open socket: a
+ *  wake-sync-sleep board holds none by design, which is the entire reason
+ *  staging exists. An unrecognized target is kept verbatim — staging for a
+ *  board this daemon has not met yet is legitimate. */
+function resolveStagedFwBoard(target: string): string {
+  for (const [key, device] of wifiEsp32Devices) {
+    if (key === target || device.board === target || device.ip === target) return device.board;
+  }
+  // A pull-sync client ages out of the WS roster between wakes; the feed
+  // tracker keeps its IP→board memory precisely for that gap.
+  const puller = feedPulls.clients().find((c) => c.client === target || c.board === target);
+  return puller?.board ?? target;
+}
+
 /** Stage a build for a board. Reads the file once to fingerprint it; the file
  *  itself is re-read at device download time (a rebuild at the same path is
- *  re-fingerprinted by re-staging). */
-function stageEsp32Fw(board: string, firmwarePath: string): { board: string; bytes: number; md5: string } {
+ *  re-fingerprinted by re-staging).
+ *
+ *  `pullSeen` reports whether this daemon has actually observed a feed pull
+ *  from the board, because "staged" proves neither transfer nor install and a
+ *  bare success reads as if it did. Only pull-sync firmware fetches a staged
+ *  image; a board that holds a live WS never asks, so its stage sits forever
+ *  while the CLI says it is handled. It is daemon-lifetime state, so `false`
+ *  means "not seen since this daemon started" — not "cannot pull". */
+function stageEsp32Fw(target: string, firmwarePath: string): { board: string; bytes: number; md5: string; pullSeen: boolean } {
+  const board = resolveStagedFwBoard(target);
   const firmware = readFileSync(firmwarePath);
   const md5 = createHash('md5').update(firmware).digest('hex');
   stagedFwByBoard.set(board, { firmwarePath, md5, size: firmware.length, stagedAt: Date.now() });
   saveStagedFw();
-  log(`[agentdeck] staged firmware for ${board}: ${firmware.length} bytes md5=${md5} — installs on its next feed pull`);
-  return { board, bytes: firmware.length, md5 };
+  const pullSeen = feedPulls.clients().some((c) => c.board === board);
+  log(`[agentdeck] staged firmware for ${board}: ${firmware.length} bytes md5=${md5} — ${
+    pullSeen ? 'installs on its next feed pull' : 'NO feed pull seen from this board since daemon start'}`);
+  return { board, bytes: firmware.length, md5, pullSeen };
 }
 
 /** The staged advert for a feed response, re-validated against the file on
@@ -646,6 +681,11 @@ export const __wifiOtaTestApi = {
   unregisterWifiEsp32Socket,
   handleEsp32OtaReply,
   performWifiEsp32Ota,
+  resolveStagedFwBoard,
+  stageEsp32Fw,
+  stagedFwAdvert,
+  feedPulls,
+  clearStagedFwForTest: (): void => { stagedFwByBoard.clear(); },
 };
 
 async function performWifiEsp32Ota(core: BridgeCore, target: string, firmwarePath: string): Promise<Record<string, unknown>> {


### PR DESCRIPTION
`agentdeck esp32-ota <target> --stage` reported success for a stage that could never install. A `t_display_pro` sat a full release behind at 1.0.3 for a day while its OTA read as handled. Two independent defects, either one sufficient on its own.

## 1. The stage was keyed on the raw target

Naming a unit by IP is the *documented* way to disambiguate two units sharing a `board` string — `findWifiOtaTarget` throws an ambiguity error precisely to send you there. So the key became `192.168.68.74`, while `stagedFwAdvert` looks the advert up by `device_info.board`. A pair that can never meet, reported as `Staged for 192.168.68.74`.

`resolveStagedFwBoard()` normalizes target → board, and deliberately does **not** require an open socket the way `findWifiOtaTarget` does: a wake-sync-sleep board holds none, which is the entire reason staging exists. It falls through to the feed tracker's IP→board memory for a client that has slept out of the WS roster, and keeps an unrecognized target verbatim — staging for a board this daemon has not met yet is legitimate, and inventing a board would be worse than not resolving one.

Consequence worth stating out loud (comment in source): the feed pull carries only a board, so a stage aimed at one unit adverts to every unit of that board. They run the same image, so that is correct rather than merely tolerable.

## 2. Staging is offered to boards that cannot consume it

Nothing in this repo's `esp32/` tree pulls the feed. `grep -rl "/feed" esp32/src` is empty — those boards hold a live WS, and only the external pull-sync fork (XTeink X3/X4/M6) fetches a staged image. Measured on the running daemon while a stage sat waiting:

```
card-feed: { clients: [], recent: [] }
```

`pullSeen` now rides the result and the CLI says what it actually knows instead of promising an install. It is daemon-lifetime state, so `false` means *"no feed pull seen from this board since this daemon started"* — never *"cannot pull"*. Same rule as `capturedAt`: unknown is its own answer, not a weaker version of no.

## Gate

`bridge/src/__tests__/esp32-ota-stage-key.test.ts`, 6 cases, pinning the polarity rather than today's fleet — adding a real pull-sync board needs no test edit.

Verified to **fail** against the pre-fix behaviour rather than merely passing after it:

```
× adverts an IP-targeted stage to the board that pulls the feed
  AssertionError: expected '192.168.68.74' to be 't_display_pro'
```

The test redirects `$HOME` to a tmpdir so it cannot touch the real `~/.agentdeck/staged-fw.json`.

## Checks

```
pnpm build            Done
pnpm test             207 files / 3245 tests pass
pnpm verify-version   compatibility line 1.0 synchronized
vitest --coverage     lines 55.8%, branches 50.4% (thresholds 17 / 14)
```

## Not in this PR

The board that surfaced this still needs a USB serial flash — a live WS board has no other path once WiFi OTA keeps flapping, and `--stage` was never one. That is hardware work, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)