### PR TITLE
The IPS10 card called a Kiro session "Agent"

### DIFF
--- a/esp32/src/ui/widgets/hud_bar.cpp
+++ b/esp32/src/ui/widgets/hud_bar.cpp
@@ -350,14 +350,14 @@ static void ips10FormatElapsed(uint32_t sec, char* out, size_t n) {
     else if (sec < 86400)    snprintf(out, n, "%luh", (unsigned long)(sec / 3600));
     else                     snprintf(out, n, "%lud", (unsigned long)(sec / 86400));
 }
-// Bold agent label for the card header (the project name goes on its own dim line).
+// Bold agent label for the card header (the project name goes on its own dim
+// line). Deliberately NOT a local map: this was one, it predated Kiro, and a
+// Kiro session rendered its card header as the generic "Agent" while the desk
+// beside it — which reads a different copy — said "Kiro". agent_label.h names
+// this exact surface as its consumer and the file already includes it, so the
+// local copy was shadowing the SSOT rather than filling a gap.
 static const char* ips10AgentLabel(const char* agentType) {
-    if (strstr(agentType, "openclaw") != nullptr) return "OpenClaw";
-    if (strstr(agentType, "codex") != nullptr)    return "Codex";
-    if (strstr(agentType, "opencode") != nullptr) return "OpenCode";
-    if (strstr(agentType, "antigravity") != nullptr) return "Antigravity";
-    if (strstr(agentType, "claude") != nullptr)   return "Claude";
-    return "Agent";
+    return agentShortLabel(agentType);
 }
 // Short uppercase pill text (D1 state pill).
 static const char* ips10StatePill(const char* state) {


### PR DESCRIPTION
## What the screen showed

Rendering `ips10 demo:kiro:idle` in `esp32/sim` (which compiles the firmware sources verbatim) put **two different labels for one session on one screen**: the office desk on the left said `Kiro`, the card on the right said `Agent`.

| | before | after |
|---|---|---|
| card header | `Agent` | `Kiro` |
| desk label | `Kiro` | `Kiro` |
| the other five cards | — | byte-for-byte unchanged |

## Why

`agent_label.h` says what it is for:

> The ONE place ESP32 turns an agentType id into a human-readable brand name, so the InkDeck ticker, **IPS10 mosaic card**, and any future timeline surface stop hand-rolling the same map.

`hud_bar.cpp` already `#include`s it — and then declared `ips10AgentLabel` anyway, a private copy written before Kiro existed. When #217 wired Kiro through every surface it updated the SSOT and `office.cpp`'s separate copy; this third one was shadowing, not filling a gap, so nothing pointed at it.

No compiler or test could catch this: a label map with a `default` is total — every input returns *something*. What was missing was a distinction, not a case.

## How it was found

By looking at the screen. That is precisely the caveat #217 left open:

> NOT visually verified — all six boards are serial-attached, which parks their WebSocket and rules out WiFi OTA […] this is code that compiles, not a screen that was looked at.

Measured since: the Kiro work *is* on the fleet (`fc64cc3a`, the boards' current buildHash, contains `terrarium/kiro.cpp`), so flashing was never what blocked the looking. The simulator was enough.

## The change

`ips10AgentLabel` becomes a one-line call to `agentShortLabel`.

- every previously handled agent keeps its exact label — `Codex`, `OpenCode`, `Claude`, `Antigravity`, `OpenClaw`
- Kiro gains `Kiro`
- an unknown `agentType` now falls to its **raw id** instead of `Agent` — the documented ESP32 fallback, which names the thing on screen rather than hiding it
- empty/null still reads `Agent`

Substring matching goes with it, and that is a fix rather than a loss: `strstr` labelled anything merely *containing* `"claude"` as Claude — the exact shape that reads a future agent as an existing one, which CLAUDE.md's unknown-agent rule forbids.

## Verified

- `ips10 demo:kiro:idle` re-rendered before/after (screenshots above describe the diff)
- `pio run -e ips10` → **SUCCESS**
- the block is guarded by `BOARD_IPS10 && BOARD_HAS_VOICE_CAPTURE`, so no other env compiles it

## Known remaining copy

`office.cpp`'s `agentShort()` is a third hand copy. It is currently **correct** (it has Kiro), and folding it would change its `strstr` fallback from `Agent` to a raw id inside a tiny desk-label box, so it is left alone rather than widened into this fix. Noted as the next hand-mirror to fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)