### PR TITLE
Cut ESP32 1.0.6 for the one board whose screen changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,34 @@ inventing a changelog after the fact states things nobody measured:
 `streamdeck 1.0.4`–`1.0.5`, `esp32 1.0.2`–`1.0.4`, `ulanzi 1.0.2`.
 Their content is recoverable from the commit range between their tags.
 
+## 2026-08-19 — ESP32 1.0.6
+
+One fix, and it is worth saying how it was found.
+
+- The IPS 10.1" card header called a Kiro session `Agent`, while the office desk
+  beside it — on the same screen, for the same session — said `Kiro`.
+  `ui/agent_label.h` is the one place the firmware turns an agentType into a
+  brand name and names this exact surface as its consumer, but `hud_bar.cpp`
+  included it and then declared a private copy of the same map, written before
+  Kiro existed. The local map is now a call to `agentShortLabel`: every other
+  agent keeps its exact label, and an unknown agentType falls to its raw id
+  rather than to `Agent`
+  ([#235](https://github.com/puritysb/AgentDeck/pull/235)).
+
+No compiler or test could have caught this. A label map with a `default` is
+total — every input returns something — so what was missing was a distinction,
+not a case. It was found by rendering the screen in `esp32/sim`, which compiles
+these sources verbatim at each board's real resolution, and looking at it. That
+also discharges the caveat 1.0.5 shipped with ("this is code that compiles, not
+a screen that was looked at"): the boards were serial-attached and unflashable,
+but the simulator never needed them.
+
+**Only `ips_10` changes.** The edit sits behind
+`BOARD_IPS10 && BOARD_HAS_VOICE_CAPTURE`, so every other board's image differs
+from 1.0.5 by the version string alone. Firmware for all ten boards is published
+here regardless, since a release set that skips boards is how three of them
+ended up with no downloadable firmware at 1.0.1.
+
 ## 2026-08-18 — npm 1.0.21 · Apple 1.0.7 · Android 1.0.10 · Stream Deck 1.0.6 · ESP32 1.0.5
 
 One round, cut across five channels from the same commit, so the entries are

--- a/esp32/src/config.h
+++ b/esp32/src/config.h
@@ -22,7 +22,7 @@ constexpr uint16_t BRIDGE_PORT_MAX     = 9139;
 constexpr const char* MDNS_SERVICE     = "_agentdeck";
 constexpr const char* MDNS_PROTO       = "_tcp";
 constexpr const char* AP_SSID          = "AgentDeck-Setup";
-constexpr const char* FIRMWARE_VERSION = "1.0.5";
+constexpr const char* FIRMWARE_VERSION = "1.0.6";
 constexpr uint8_t PROTOCOL_REVISION    = 2;
 
 // ===== Build identity (injected by scripts/git_rev.py at compile time) =====


### PR DESCRIPTION
Bumps `FIRMWARE_VERSION` to `1.0.6` and adds its CHANGELOG entry, so `esp32-v1.0.6` can be tagged.

## Why a cut now

1.0.5 shipped with an explicit caveat:

> NOT visually verified — all six boards are serial-attached, which parks their WebSocket and rules out WiFi OTA […] this is code that compiles, not a screen that was looked at.

That reasoning had a hole. `esp32/sim` compiles these same sources at each board's real resolution and needs no board at all. Rendering `ips10 demo:kiro:idle` found a real defect in seconds — the card header called a Kiro session `Agent` while the desk beside it, same screen, same session, said `Kiro` (#235).

So this cut exists to carry that fix, and the notes say so instead of narrating a version bump.

## Scope

**Only `ips_10` changes.** The edit sits behind `BOARD_IPS10 && BOARD_HAS_VOICE_CAPTURE`, so every other board's image differs from 1.0.5 by the version string alone.

All ten boards are published regardless — a release set that skips boards is exactly how `t_embed`, `t_display_pro` and `esp32_c6_147` ended up with no downloadable firmware at 1.0.1.

## Checks

```
node scripts/verify-release-version.mjs esp32 1.0.6   matches source + CHANGELOG entry present
pnpm verify-version                                   line 1.0 synchronized (ESP32 1.0.6)
pnpm docs:check                                       108 files, links/anchors/H1 OK
node scripts/release-notes.mjs esp32-v1.0.6 …         body rendered and read, not assumed
```

## After merge

Tag `esp32-v1.0.6` → the release workflow builds all ten boards and renders this entry as the release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)