### PR TITLE
Correct three release rows that had drifted from the stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | Channel | Tag | Status |
 |---|---|---|
 | **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.21](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.21) live on the registry |
-| **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [1.0.6 live](https://apps.apple.com/app/id6784822497) on both platforms — build 5101. `1.0.7` (build 5201) approved for iPhone/iPad and propagating; still in review for macOS |
+| **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [1.0.7 live on iPhone/iPad](https://apps.apple.com/app/id6784822497) — build 5201, released 2026-08-18 (verified against the store's own record, not the approval mail). macOS is still on `1.0.6`; `1.0.7` (same build) is in review there |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.6 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) (published 2026-08-18); **`1.0.6` published 2026-08-18** |
-| **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.3 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.3); submitted 2026-08-07 and **still under review** — nothing published on the Marketplace yet ([details](marketplace/ulanzi/LISTING.md)) |
+| **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.3 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.3); submitted 2026-08-07, **still under review**. The reviewer confirmed on 2026-08-14 that review had begun with no outstanding issues; nothing published on the Marketplace yet ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.10](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.10) |
-| **GitHub Release** — ESP32 firmware | `esp32-v*` | [1.0.5](https://github.com/puritysb/AgentDeck/releases/tag/esp32-v1.0.5) — one binary per Shipping board |
+| **GitHub Release** — ESP32 firmware | `esp32-v*` | [1.0.6](https://github.com/puritysb/AgentDeck/releases/tag/esp32-v1.0.6) — one binary per Shipping board. Only `ips_10` differs from 1.0.5 in anything but the version string |
 | **Google Play** — Android AAB | `android-v*` | [1.0.9 live](https://play.google.com/store/apps/details?id=dev.agentdeck) (versionCode 11, updated 2026-08-15); `1.0.10` (versionCode 12) in review since 2026-08-19. Listing copy, assets and the console runbook are in [marketplace/play/](marketplace/play/LISTING.md) |
 
 ---


### PR DESCRIPTION
The README release table is read as the answer to *"what is actually out there"*, so a row that lags is worse than no row. All three corrections were **measured today from the stores themselves**, not inferred from notification mail.

| row | was | is |
|---|---|---|
| Apple | `1.0.6 live on both platforms`; 1.0.7 "approved for iPhone/iPad and propagating" | **iPhone/iPad 1.0.7 live** (build 5201, released 2026-08-18T17:06Z). **macOS still 1.0.6**, 1.0.7 in review |
| ESP32 | 1.0.5 | **1.0.6**, with the scope stated inline |
| Ulanzi | "submitted 2026-08-07 and still under review" | same, plus: the reviewer confirmed on **2026-08-14** that review had begun with no outstanding issues |

## Why Apple is split into two answers

`itunes.apple.com/lookup?id=6784822497` answers with the **iOS** record only, and App Store Connect shows macOS separately — `1.0.7 심사 중` over a live `1.0.6`. One tag, two platform states.

That distinction is exactly what the previous row lost. Apple's "eligible for distribution" mail reads identically for iOS and macOS apart from a parenthetical in the subject, which is the documented way this repo has gotten the answer wrong before. The row now names the platform in every clause.

## ESP32 scope, stated inline

`1.0.6` publishes ten board binaries, but only `ips_10` differs from `1.0.5` in anything but the version string (the fix is behind `BOARD_IPS10 && BOARD_HAS_VOICE_CAPTURE`). Without that sentence a ten-asset release reads as ten changed boards.

## Checks

`pnpm docs:check` — 108 Markdown files, local targets/anchors and H1 structure verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)