### PR TITLE
Delete two agent maps in the office scene that neither renderer reads

### DIFF
--- a/esp32/src/ui/terrarium/office.cpp
+++ b/esp32/src/ui/terrarium/office.cpp
@@ -56,23 +56,17 @@ static uint32_t agentColor(const char* t) {
     if (strstr(t, "claude"))   return 0xC07058;
     return 0x9aa0a8;
 }
-static const char* agentShort(const char* t) {
-    if (!t) return "Agent";
-    if (strstr(t, "openclaw")) return "OpenClaw";
-    if (strstr(t, "codex"))    return "Codex";
-    if (strstr(t, "opencode")) return "OpenCode";
-    if (strstr(t, "antigravity")) return "Antigravity";
-    if (strstr(t, "kiro"))    return "Kiro";
-    if (strstr(t, "claude"))   return "Claude";
-    return "Agent";
-}
-// state → bubble/accent color (STATE.*.color)
-static uint32_t stateColor(const char* s) {
-    if (strstr(s, "awaiting")) return 0xFFA93D;
-    if (strstr(s, "error") || strstr(s, "fail")) return 0xFF6B6B;
-    if (strcmp(s, "processing") == 0) return 0x3ED6E8;
-    return 0x7a8a9c;  // idle
-}
+// Two maps used to sit here and both were dead, for different reasons worth
+// keeping apart. `agentShort` never had a call site at all — this scene draws
+// project nameplates, not brand names, and if it ever grows a brand label it
+// comes from `../agent_label.h` (`agentShortLabel`), not from a copy. `stateColor`
+// did have two: desks were tinted by session state and the tint fed the redraw
+// signature, until de6b1519 ("Fix IPS10 HUD stack smash") removed both nine days
+// after the file was written; the bubble colours have been chosen inline in the
+// worker draw below ever since. Its idle value had already drifted from the live
+// one (0x7a8a9c here vs 0x9fb0ac inline), which is what a copy nothing reads does.
+// They were hand-maintained anyway, which is how the Kiro round paid to add a
+// `kiro` row to a table nothing read.
 static const uint8_t* agentGlyphA8(const char* t) {
     using namespace CreatureGlyphs;
     if (!t) return nullptr;


### PR DESCRIPTION
`agentShort` and `stateColor` in `esp32/src/ui/terrarium/office.cpp` are both dead, for **different reasons that are worth keeping apart** — an earlier draft of this PR flattened them into one story and got the second one wrong.

**`agentShort` never had a call site.** It appears exactly once in the repository — the definition — because this scene draws project nameplates, not brand names.

**`stateColor` had two**, at `office.cpp:555` and `:569` in the commit that created the file (#16, 2026-06-20): desks were tinted by session state and the tint fed the redraw signature hash. Both were removed nine days later by `de6b1519` *"Fix IPS10 HUD stack smash"*, and the bubble colours have been chosen inline in the worker draw (now `:581`–`:603`) ever since. Its idle value had already drifted from the live inline one — `0x7a8a9c` in the copy, `0x9fb0ac` inline. The copy stopped agreeing with the screen and nothing said so; that is the whole hazard.

Both are file-local `static` inside `namespace Office`, so the question is settled from one file: no call site in this translation unit means none anywhere. (`stateColor` is a common helper name here — `ring_leds.cpp` has a live one, and knob/pocket/ticker carry their own `stateColorOf`. None of them can see this copy.)

They were hand-maintained regardless. The Kiro round (#198) added `if (strstr(t, "kiro")) return "Kiro";` and a `0x7C3AED` row to `agentColor` in the same hunk — one of those two edits reached a renderer and the other did not, and nothing in the file said which.

### Why not fold it into the `agent_label.h` SSOT

That was the obvious move and it is the wrong one. An SSOT call for a function nobody calls is still a symbol nobody calls, and it would have carried a behaviour change: `agentShortLabel` matches **exactly** and returns the raw id for an unknown agent (the allow-list polarity CLAUDE.md requires), where this copy matched substrings and returned `"Agent"`. The narrow-label overflow question that change would have raised does not arise — there is no label box to overflow. The comment left at the deleted site records both histories, so `de6b1519` stays findable, and names `agent_label.h` for whoever gives this scene a brand label later.

### Verification — two instruments

**Rendered output.** `esp32/sim/render.sh ips10` builds clean and all six scenes are byte-identical to the same render from `32aef7af`:

```
IDENTICAL  ips10-{display-off,empty,idle,multi,permission,working}.png
```

**Firmware image.** Measured rather than asserted, and the first measurement was wrong. Building `ips10` before and after naively gave **269,905 differing bytes** — alarming until the instrument was checked: the "after" arm had an uncommitted `office.cpp`, so `git_rev.py` stamped `GIT_SHA` as `…-dirty`, and those six extra characters shift the whole string table. Holding the dirty flag constant across both arms:

| comparison | differing bytes |
|---|---|
| identical source, two builds (noise floor: `BUILD_EPOCH`) | 75 |
| master `office.cpp` vs this PR's, both dirty | **72** |

Below the noise floor — the deleted statics were never emitted. No firmware cut and no reflash; the 1.0.6 fleet is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
