### PR TITLE
Finish the two counts the last pass stopped one file short of

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: stable
 owner: Design system maintainers
-reviewed: 2026-07-18
-revision: 2026-07-18
+reviewed: 2026-08-20
+revision: 2026-08-20
 source_of_truth: DESIGN.md
 validators: [python3 design/verify-tokens-sync.py, bash design/lint.sh]
 ---
@@ -262,7 +262,7 @@ Mono caption inside: 12px, `--ink-500`, 0.04em tracked, e.g. `// menubar popup �
 - `antigravity.svg` — Antigravity · `#5F6368`, rainbow on color, monochrome on e-ink
 - `kiro.svg` — Kiro CLI / Kiro IDE · `#7C3AED`. One mark for both ids: they are the same agent seen through two front ends
 
-All six come from one upstream package and stand or fall together — the provenance, the npm integrity hash, and the trademark holder per mark are recorded once in [design/RESOURCES.md § Third-party brand provenance](design/RESOURCES.md). Do not attribute one mark here and leave the rest silent: a lopsided record reads as though the named one is the mark with a licensing question.
+All six come from one upstream package and stand or fall together — the provenance, the npm integrity hash, and the trademark holder per mark are recorded once in [design/RESOURCES.md § Third-party brand provenance](design/RESOURCES.md#third-party-brand-provenance). Do not attribute one mark here and leave the rest silent: a lopsided record reads as though the named one is the mark with a licensing question.
 
 The six SVGs live **only** in `design/brand/`, which is the canonical source. Runtime path constants and firmware bitmaps are generated or contract-tested mirrors; they are not alternate design sources. Full-vector surfaces preserve the exact path geometry. Pixel-constrained displays may use reviewed raster or hand-tuned reductions that preserve the identifying silhouette and cutouts. Do not substitute provider-company marks (for example the generic OpenAI or Anthropic logo), redraw the vector on capable surfaces, or add a second logo dump elsewhere.
 
@@ -361,10 +361,11 @@ android/app/.../ui/theme/DesignTokens.kt       ← Compose binding
 
 `design/tokens.css` is the **single source of truth.** Every other token file
 (`tokens.js`, `design-tokens.ts`, `DesignTokens.swift`, `DesignTokens.kt`, plus
-the embedded copies in the APME dashboard HTML and the Stream Deck PI
-`design-tokens.css`) is a mirror — when CSS values change, all six mirrors must
-be updated in the same commit. Verify with `python3 design/verify-tokens-sync.py`,
-which gates exactly that mirror set.
+the embedded copies in the APME dashboard HTML, the Stream Deck PI
+`design-tokens.css`, and the Build Health generator `scripts/generate-html-report.py`)
+is a mirror — when CSS values change, all seven mirrors must be updated in the same
+commit. Verify with `python3 design/verify-tokens-sync.py`; its footer prints the
+count it actually checked, which is the number to trust over this sentence.
 
 When adding a new component:
 1. Define its tokens in `design/tokens.css` if you need new ones (rare).

--- a/agentdeck-design-system/viewer/app.js
+++ b/agentdeck-design-system/viewer/app.js
@@ -50,7 +50,7 @@
         reference: 'Reference surfaces',
       },
       assetGroupNotes: {
-        brand: 'The product mark and the five agent marks, verbatim upstream. DESIGN.md R6 — never redraw them.',
+        brand: 'The product mark and the six agent marks, verbatim upstream. DESIGN.md R6 — never redraw them.',
         masks: 'Rendered from the brand SVGs by `pnpm generate-micro-glyphs`, parsed here straight out of the generated file. Device code may add color, shading, and motion around a mask, but must never replace it with hand-drawn agent geometry — regression tests pin each mark’s defining negative space.',
         creatures: 'Creatures are rendered live on the Live Preview surface, from the geometry SSOT. They are deliberately not redrawn here.',
         icons: 'The one canonical UI icon system. Never substitute a generic icon font.',
@@ -102,7 +102,7 @@
         reference: '레퍼런스 표면',
       },
       assetGroupNotes: {
-        brand: '제품 마크와 5개 에이전트 마크를 업스트림 그대로 씁니다. DESIGN.md R6 — 다시 그리지 않아요.',
+        brand: '제품 마크와 6개 에이전트 마크를 업스트림 그대로 씁니다. DESIGN.md R6 — 다시 그리지 않아요.',
         masks: '`pnpm generate-micro-glyphs`가 브랜드 SVG에서 만든 마스크를, 생성 파일에서 직접 파싱해 표시해요. 기기 코드는 마스크 주위에 색·음영·모션을 더할 수 있지만 손으로 그린 에이전트 도형으로 대체하면 안 됩니다 — 각 마크의 여백을 회귀 테스트가 고정하고 있어요.',
         creatures: '크리처는 지오메트리 SSOT를 통해 Live Preview에서 실제로 렌더됩니다. 여기서 다시 그리지 않아요.',
         icons: '정본 UI 아이콘 시스템 하나뿐이에요. 범용 아이콘 폰트로 대체 금지.',
@@ -154,7 +154,7 @@
         reference: 'リファレンス面',
       },
       assetGroupNotes: {
-        brand: '製品マークと 5 つの agent マークを upstream のまま使います。DESIGN.md R6 — 描き直しません。',
+        brand: '製品マークと 6 つの agent マークを upstream のまま使います。DESIGN.md R6 — 描き直しません。',
         masks: '`pnpm generate-micro-glyphs` が brand SVG から生成した mask を、生成ファイルから直接 parse して表示します。デバイス側は mask の周囲に色・陰影・motion を足せますが、手描きの agent 図形に置き換えてはいけません — 各マークの余白は regression test が固定しています。',
         creatures: 'クリーチャーは geometry SSOT を通じて Live Preview で実際に描画されます。ここでは描き直しません。',
         icons: '正本の UI アイコンシステムはこれ一つ。汎用アイコンフォントで代替しないこと。',
@@ -415,7 +415,7 @@
         label: strings().assets,
         category: 'Preview',
         locale: 'live',
-        search: 'assets logo icon brands masks glyphs creatures reference mockups typography fonts plex jetbrains photography hardware photos captures claude codex openclaw opencode antigravity preview live',
+        search: 'assets logo icon brands masks glyphs creatures reference mockups typography fonts plex jetbrains photography hardware photos captures claude codex openclaw opencode antigravity kiro preview live',
       },
     );
     return items.filter((item) => !query || item.search.includes(query));


### PR DESCRIPTION
#239 corrected the token-mirror count in CLAUDE.md (three places) and
design/RESOURCES.md, and the brand-mark count in CLAUDE.md and DESIGN.md §6.1.
A contract review of the merged result found both fixes incomplete, in the two
files a text sweep is most likely to miss.

**DESIGN.md was left as the only file in the tree claiming six token mirrors** —
and it is the published spec, so the canonical document now contradicted CLAUDE.md
on the exact count the branch existed to correct. Worse than the number: it also
asserted the verifier "gates exactly that mirror set", which is provably false —
`verify-tokens-sync.py` has seven entries and prints the count itself. A reader
following DESIGN.md's list updates six files and gets a red CI the sentence says
cannot happen. Fixed to seven, naming `scripts/generate-html-report.py`, and the
false clause replaced by a pointer to the verifier's own footer.

**The viewer said "five agent marks" in all three locales** (`viewer/app.js:53`
en, `:105` ko, `:157` ja) while `loadBrandMarks()` enumerates `design/brand/` at
build time and renders every file in it. So the published Assets page drew six
marks under a caption claiming five — on the very surface CLAUDE.md rule 6 cites
as the one that could not draw Kiro or Antigravity. The Assets search keyword
string at `:418` also had no `kiro`, so searching the viewer for it matched
nothing. Both fixed.

Two reasons this was missed rather than deferred, worth writing down: the sweep
searched `.md`/`.html`/`.json` and the surviving claim was in `.js`, and it
searched for "six mirrors" where DESIGN.md says "all six mirrors". A count that
lives in prose has no gate, so the sweep IS the gate — and a sweep is only as
good as its file globs and its phrasings.

Also: DESIGN.md's citation of RESOURCES.md carried no `#anchor`, so `docs:check`
validated the file path and never the section name — rename the heading and the
citation drifts silently. Anchored now, and mutation-tested: pointing it at a
non-existent section fails the check with `missing Markdown anchor`. Frontmatter
`reviewed`/`revision` bumped to today, which two prior DESIGN.md edits skipped;
it is free here since DESIGN.md has no translation to invalidate.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

### Verification

- `pnpm docs:check` — 108 files ✓ · `pnpm design-system:check` — 29 documents ✓ · `verify-tokens-sync.py` — 7 mirrors in sync ✓
- Anchor gate mutation-tested: `design/RESOURCES.md#no-such-section` → `DESIGN.md:265: missing Markdown anchor`, exit 1. The gate is real.
- `loadBrandMarks()` (`scripts/build-design-system-viewer.mjs:357`) enumerates the directory, so the caption is now the only place the number is written by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)