### PR TITLE
Name the ESP32 sim job so branch protection can pin a meaningful context

### DIFF
--- a/.github/workflows/esp32-sim.yml
+++ b/.github/workflows/esp32-sim.yml
@@ -27,7 +27,11 @@ permissions:
   contents: read
 
 jobs:
+  # The job name — not the workflow name — is the status-check context branch
+  # protection pins, so it has to say which gate it is: an unnamed job here
+  # would be required as the bare `compile`.
   compile:
+    name: ESP32 Sim Compile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The gate #243 added has never run: it was committed straight to master, so no `pull_request` event ever fired it. This PR is its first run — `esp32-sim.yml` is in its own `paths` filter.

The change itself is the prerequisite for making it required. The status-check context GitHub exposes to branch protection is the **job** name, not the workflow name, and the job was unnamed — so it would have to be pinned as the bare `compile`, which names neither ESP32 nor the sim. `android-test.yml` (`Compile + JUnit`) and `design-system.yml` (`Token sync + lint regression`) both name their job for the same reason.

Verified locally at HEAD: `pio run` in `esp32/sim` builds all 11 envs green. The CI run on this PR is the cold-cache measurement.

Once this is green, `ESP32 Sim Compile` goes into `master`'s required status checks — which currently has none at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)