### PR TITLE
A required status check cannot carry a paths filter

### DIFF
--- a/.github/workflows/esp32-sim.yml
+++ b/.github/workflows/esp32-sim.yml
@@ -9,19 +9,30 @@
 # real esp32/src headers — so it needs no Xtensa toolchain and no hardware.
 # It is a compile gate, not the hardware Robot suite; that stays hardware-only.
 #
-# The paths gate keeps the cost off unrelated PRs, mirroring android-test.yml /
-# apple-test.yml. The cache key is shared with test-report.yml on purpose:
-# master pushes keep the default-branch cache warm, and PR runs restore from it
-# (warm-cache full build is ~1–2 minutes; only a platformio.ini change pays the
-# cold toolchain download).
+# The scope check keeps the cost off unrelated PRs, but it is a STEP condition,
+# not a workflow-level `paths:` filter, because this is a required status check.
+# A `paths:`-filtered workflow does not run on a PR outside its paths, so its
+# context never reports at all — and branch protection cannot tell "did not
+# apply" from "has not finished yet". Measured on #248: a docs-only PR with
+# every other check green sat at BLOCKED / "Expected — waiting for status"
+# forever. So the job always runs and always reports; when nothing under esp32/
+# changed it reports success in ~15s without installing a toolchain.
+# (android-test.yml / apple-test.yml keep their `paths:` filters — neither is
+# required, so the same shape is fine there.)
+#
+# Detection is fail-safe in the compile direction: if the diff cannot be
+# resolved, compile rather than skip. A wrong skip is a green light on code no
+# compiler read, which is the exact hole #243 was opened to close.
+#
+# The cache key is shared with test-report.yml on purpose: master pushes keep
+# the default-branch cache warm, and PR runs restore from it (warm-cache full
+# build is ~1–2 minutes; a cold first run measured 3m47s, and only a
+# platformio.ini change pays the toolchain download again).
 name: ESP32 Sim Compile
 
 on:
   pull_request:
     branches: [master]
-    paths:
-      - 'esp32/**'
-      - '.github/workflows/esp32-sim.yml'
 
 permissions:
   contents: read
@@ -35,8 +46,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The merge commit plus both parents, so HEAD^1..HEAD is exactly the
+          # PR's net change against the base tip.
+          fetch-depth: 2
+
+      - name: Does this PR touch the ESP32 tree?
+        id: scope
+        run: |
+          if ! base=$(git rev-parse --verify --quiet HEAD^1); then
+            echo "No first parent (PR not mergeable?) — compiling to stay safe."
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$base" HEAD)
+          if grep -qE '^(esp32/|\.github/workflows/esp32-sim\.yml$)' <<<"$changed"; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo 'No `esp32/**` change in this PR — nothing to compile.' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Cache PlatformIO (sim)
+        if: steps.scope.outputs.run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -47,8 +79,10 @@ jobs:
           restore-keys: pio-sim-
 
       - name: Install PlatformIO
+        if: steps.scope.outputs.run == 'true'
         run: pip install platformio
 
       - name: Compile every sim env
+        if: steps.scope.outputs.run == 'true'
         working-directory: esp32/sim
         run: pio run

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -55,6 +55,23 @@ Discussions도 이 계기로 활성화.
 master 보호에는 그때까지 required status check가 **하나도** 없었다. `ESP32 Sim Compile`
 하나를 `strict: false`로 지정(기존 보호 설정은 전부 보존).
 
+**그리고 그 지정이 곧바로 리포 전체를 잠갔다.** `paths:` 필터가 걸린 워크플로는 자기
+경로 밖 PR에서 아예 **돌지 않고**, 브랜치 보호는 "해당 없음"과 "아직 안 끝남"을
+구분하지 못한다 — 둘 다 그냥 컨텍스트가 보고되지 않은 상태다. 추측하지 않고 이 PR로
+측정했다: docs 한 파일만 고친 PR에서 `test`와 `Token sync + lint regression`이 전부
+green인데도 `mergeStateStatus: BLOCKED`, 영원히 "Expected — waiting for status".
+
+`enforce_admins: false`라 소유자는 우회할 수 있으므로 로컬에서는 증상이 안 보인다.
+막히는 쪽은 **외부 기여자**다 — 바로 어제 #246으로 처음 생긴 그 인구.
+
+그래서 필터를 워크플로 레벨에서 **스텝 조건으로 내렸다**. job은 항상 돌고 항상 보고하되,
+`esp32/**` 변경이 없으면 툴체인 설치 없이 ~15초에 success. 판정은 컴파일 쪽으로
+fail-safe다 — diff를 못 구하면 스킵이 아니라 컴파일한다. 잘못된 스킵은 컴파일러가 읽지
+않은 코드에 green을 주는 것이고, 그건 #243이 닫으려던 구멍 그 자체다.
+
+일반 규칙: **required로 올릴 체크에는 `paths:` 필터를 달 수 없다.** required가 아닌
+android-test.yml / apple-test.yml은 지금 형태 그대로 둔다.
+
 ---
 
 ## 2026-08-20 — OS가 죽이는 자식을 60초마다 되살린 루프, 그리고 Rosetta가 통과한 probe

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -38,6 +38,23 @@ Discussions도 이 계기로 활성화.
   게이트 패턴으로 마지막 미컴파일 표면(C++)을 닫았다. 이제 PR에서 컴파일러가 한 번도
   읽지 않는 소스 트리는 없다. required check 지정은 첫 esp32 PR이 게이트를 지난 뒤.
 
+### 후속 — 게이트를 required로 올리면서 드러난 두 가지 (#247)
+
+"첫 esp32 PR이 게이트를 지난 뒤"를 확인하러 갔더니 **게이트는 한 번도 돈 적이 없었다**.
+#243은 이슈였고 그 수정 커밋은 master로 직접 갔으므로 `pull_request` 이벤트가 발생한
+적이 없다 — 워크플로 실행 이력이 0건. 게이트를 신설한 커밋 자체가 그 게이트를
+통과하지 않는다는 것은 path-scoped PR 게이트의 일반적 성질이다.
+
+첫 실행을 만들면서 required 지정의 선결 조건 하나를 먼저 고쳤다. **브랜치 보호가
+고정하는 status check context는 워크플로 이름이 아니라 job 이름이다.** `compile` job에
+`name:`이 없었으므로 required로 올릴 이름은 ESP32도 sim도 말하지 않는 맨 `compile`이
+됐을 것이다. `name: ESP32 Sim Compile`을 붙였고, 이 편집 자체가 `esp32-sim.yml`을
+건드리므로 그 PR이 게이트의 최초 실행이 됐다 — 콜드 캐시 11개 env 전부 green, 3m47s
+(워크플로 주석이 예상한 웜 캐시 1–2분과 정합).
+
+master 보호에는 그때까지 required status check가 **하나도** 없었다. `ESP32 Sim Compile`
+하나를 `strict: false`로 지정(기존 보호 설정은 전부 보존).
+
 ---
 
 ## 2026-08-20 — OS가 죽이는 자식을 60초마다 되살린 루프, 그리고 Rosetta가 통과한 probe


### PR DESCRIPTION
Follow-up to #247, and the fix for what promoting that gate to a required check actually did.

**Measured, not assumed.** This PR started as a docs-only change whose whole purpose was to answer one question: `esp32-sim.yml` was `paths`-filtered and `ESP32 Sim Compile` is now required — does the context report on a PR outside those paths? It does not. With `test` and `Token sync + lint regression` both green, the PR sat at `mergeStateStatus: BLOCKED`, "Expected — waiting for status," permanently. Branch protection cannot tell "this check does not apply" from "this check has not finished."

`enforce_admins: false`, so the owner can merge straight past it and never sees the symptom. The population that cannot is external contributors — which #246 created yesterday.

**The fix** moves the filter from the workflow trigger down to a step condition, so the job always runs and always reports. A PR with nothing under `esp32/**` finishes in ~15s without installing a toolchain. Detection is fail-safe toward compiling: if the diff cannot be resolved it compiles rather than skips, because a wrong skip is a green light on code no compiler read — exactly the hole #243 was opened to close.

`android-test.yml` and `apple-test.yml` keep their `paths:` filters. Neither is required, so the shape is safe there; the constraint is specifically "required check ⇒ no paths filter."

This PR touches `esp32-sim.yml`, so it exercises the compile branch. The skip branch gets its own verification on the next docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)