### PR TITLE
Catch the release docs up to the Play listing that shipped six days ago

### DIFF
--- a/.github/release-notes/android.md
+++ b/.github/release-notes/android.md
@@ -1,8 +1,19 @@
 E-ink dashboard app for monitoring coding agent sessions.
 
 ### Install
+
+**From Google Play (recommended)** —
+[AgentDeck on Google Play](https://play.google.com/store/apps/details?id=dev.agentdeck).
+Same app, same build, with automatic updates.
+
+**From the APK below** — for devices without Play services (many e-ink readers)
+or when you want this exact version pinned:
+
 1. Download the `agentdeck-v*.apk` below
 2. Transfer to your Android device
 3. Open the APK to install (enable "Install from unknown sources" if prompted)
-4. Launch AgentDeck and pair — over USB, by scanning the daemon's QR code, or
-   with a pairing code on a reader that has no camera
+
+Then launch AgentDeck and pair — over USB, by scanning the daemon's QR code, or
+with a pairing code on a reader that has no camera. AgentDeck for Android is a
+companion dashboard: keep the daemon running on a Mac, Windows, or Linux machine
+on the same network.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,11 +5,19 @@ Where AgentDeck is going. Shipped history lives in
 
 ## Next Milestones — Current Focus
 
-AgentDeck is actively working on the next Apple companion release and on personalized agent evaluation:
+Store distribution is complete on every channel that has one. The remaining focus is personalized agent evaluation:
 
-## 1. App Store Distribution (iOS / iPadOS)
+## 1. Store Distribution — shipped
 
-[AgentDeck Dashboard 1.0.2 is live on the Mac App Store](https://apps.apple.com/app/id6784822497). The iPhone/iPad companion is not released yet: its first submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept an activity indicator running after discovery had finished. The replacement build bounds that indicator and adds an offline Device Preview entry point; resubmission is pending. The macOS app ships a standalone in-process Swift daemon — mDNS discovery, native device modules, OpenClaw Gateway WebSocket client, hook ingestion, and HTTP + WebSocket server. App Store compliance is gated by the `AGENTDECK_APP_STORE` compile flag: no bundled Node.js / `adb` / D200H helper, no subprocess spawn, no AppleScript (per Apple Review Guideline 2.5.2). User data lives in `~/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/` (routed through `AgentDeckPaths.swift`; never hand-write the path). AgentDeck requests no USB HID entitlement — the D200H is driven solely by the Ulanzi Studio plugin. OpenClaw integration uses Gateway-native pairing (self-generated Ed25519 identity in Keychain + Gateway-issued device token) — no file read of `~/.openclaw/identity/`. `apple/scripts/verify-appstore-archive.sh` is wired into CI and asserts these invariants on every archive.
+Both app stores now carry AgentDeck, verified 2026-08-21 against the stores themselves rather than against approval mail:
+
+| Store | Live | Measured by |
+|---|---|---|
+| [Mac App Store](https://apps.apple.com/us/app/agentdeck-dashboard/id6784822497?platform=mac) | **1.0.7** (build 5201), 2026-08-19 | product page with `?platform=mac` |
+| [App Store — iPhone / iPad](https://apps.apple.com/us/app/agentdeck-dashboard/id6784822497) | **1.0.7** (build 5201), 2026-08-18 | `itunes.apple.com/lookup?id=6784822497` |
+| [Google Play](https://play.google.com/store/apps/details?id=dev.agentdeck) | **1.0.10** (versionCode 12), 2026-08-19, 177 countries | public listing HTML |
+
+One Apple submission does not release two platforms at once — the same build 5201 went live 29 hours apart, so a macOS approval says nothing about iOS or the reverse. The iOS record got there the hard way: the first submission, 1.0.2 (3901), was rejected on 2026-08-04 under Guideline 2.1(a) because the disconnected screen kept an activity indicator running after discovery had finished; the fix bounds that indicator and adds an offline Device Preview entry point. The macOS app ships a standalone in-process Swift daemon — mDNS discovery, native device modules, OpenClaw Gateway WebSocket client, hook ingestion, and HTTP + WebSocket server. App Store compliance is gated by the `AGENTDECK_APP_STORE` compile flag: no bundled Node.js / `adb` / D200H helper, no subprocess spawn, no AppleScript (per Apple Review Guideline 2.5.2). User data lives in `~/Library/Containers/bound.serendipity.agent.deck/Data/Library/Application Support/AgentDeck/` (routed through `AgentDeckPaths.swift`; never hand-write the path). AgentDeck requests no USB HID entitlement — the D200H is driven solely by the Ulanzi Studio plugin. OpenClaw integration uses Gateway-native pairing (self-generated Ed25519 identity in Keychain + Gateway-issued device token) — no file read of `~/.openclaw/identity/`. `apple/scripts/verify-appstore-archive.sh` is wired into CI and asserts these invariants on every archive.
 
 ## 2. Personalized Agent Evaluation System (APME)
 
@@ -34,7 +42,7 @@ Eval results broadcast to every device simultaneously (Stream Deck/Apple/Android
 - [x] Apple iOS/iPad/macOS dashboard (SwiftUI multiplatform)
 - [x] macOS in-process Swift daemon (Node.js-free macOS install)
 - [x] Apple TestFlight CI pipeline
-- [x] Mac App Store distribution — AgentDeck Dashboard 1.0.0 (2026-07-21), updated to 1.0.2 (2026-07-24)
+- [x] Mac App Store distribution — AgentDeck Dashboard 1.0.0 (2026-07-21), currently 1.0.7 (2026-08-19)
 - [x] ESP32 compact displays (Round AMOLED 1.8", IPS LCD 3.5", B86 Box 4", TTGO T-Display 1.14", IPS 10.1", Ulanzi TC001)
 - [x] InkDeck e-ink panel (Seeed TRMNL 7.5" OG DIY Kit, custom ESP32 firmware, WiFi/WS partial refresh, WiFi OTA updates)
 - [x] Ulanzi D200H Deck Dock (14-key HID + 960×540 LCD via official Ulanzi Studio plugin; direct-HID fallback retired)
@@ -50,17 +58,19 @@ Eval results broadcast to every device simultaneously (Stream Deck/Apple/Android
 - [x] Color E-ink support (Kaleido 3)
 - [x] Creature simulator demo page (GitHub Pages `/demo/`)
 - [x] APME — session dataset, 3-path ingestion (hook/timeline/PTY), 10-category classifier, category-aware evaluation (run-level coding + turn-level non-coding), composite score, local-only judge (MLX + OpenClaw), rubric auto-tuner, model recommender, device-wide eval broadcast
+- [x] **iPhone/iPad App Store distribution** — [AgentDeck Dashboard](https://apps.apple.com/us/app/agentdeck-dashboard/id6784822497) 1.0.7 (build 5201) went live for iOS on 2026-08-18 and for macOS on 2026-08-19. One submission, one build, two release times 29 hours apart — neither platform implies the other.
+- [x] **Windows daemon autostart** — `agentdeck daemon install` registers a per-user Scheduled Task (`AgentDeckDaemon`, logon trigger) so the daemon auto-starts in the interactive session, the Windows analog of the macOS LaunchAgent. See [daemon.md → Autostart](daemon.md#autostart-loginlogon).
+- [x] **Play Store distribution** — AgentDeck is live on [Google Play](https://play.google.com/store/apps/details?id=dev.agentdeck): first public build 1.0.6 (versionCode 8) on 2026-08-15, currently **1.0.10 (versionCode 12)** published 2026-08-19 at 100% across 177 countries. The GitHub APK stays as a second channel. Listing copy, assets and the console runbook are in [marketplace/play/](../marketplace/play/LISTING.md).
+- [x] **Stream Deck Marketplace registration** — first approved 2026-07-28 (1.0.2), Windows correction 1.0.3 on 2026-07-31, and **1.0.4 published 2026-08-05** at [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Listing assets and packages remain under `marketplace/elgato/`.
 
 ## In Progress
 
-- [ ] iPhone/iPad App Store review and public distribution
 - [ ] APME vibe-labeling accumulation → Stage 4 OPRO rubric auto-tuner activation (needs ≥30 disagreement samples)
 
 ## Planned
 
-- [x] **Windows daemon autostart** — `agentdeck daemon install` registers a per-user Scheduled Task (`AgentDeckDaemon`, logon trigger) so the daemon auto-starts in the interactive session, the Windows analog of the macOS LaunchAgent. See [daemon.md → Autostart](daemon.md#autostart-loginlogon).
-- [ ] Play Store distribution (Android app)
-- [x] **Stream Deck Marketplace registration** — first approved 2026-07-28 (1.0.2), Windows correction 1.0.3 on 2026-07-31, and **1.0.4 published 2026-08-05** at [AgentDeck on the Elgato Marketplace](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464). Listing assets and packages remain under `marketplace/elgato/`.
+Nothing queued beyond the In Progress item above — every previously planned
+distribution and autostart item shipped and moved into **Achieved**.
 
 ---
 

--- a/marketplace/play/LISTING.md
+++ b/marketplace/play/LISTING.md
@@ -8,15 +8,28 @@ created after 2023-11-13 does not apply — production is reachable directly.
 The APK on GitHub Releases stays; Play is an additional channel, not a
 replacement. Nothing in the app changes between them.
 
-## Account state — 1.0.9 submitted; 1.0.6 live (2026-08-15)
+## Account state — 1.0.10 live (2026-08-19)
 
-Both account verification steps are **done**, and AgentDeck 1.0.6 (versionCode
-8) is live on the public [Google Play listing](https://play.google.com/store/apps/details?id=dev.agentdeck):
+Both account verification steps are **done**, and AgentDeck **1.0.10
+(versionCode 12)** is live on the public [Google Play listing](https://play.google.com/store/apps/details?id=dev.agentdeck):
 
-AgentDeck 1.0.9 (versionCode 11) was uploaded to production on 2026-08-15 as a
-100% rollout to all 177 target countries and submitted for review together with
-the revised short and full descriptions. Until Google approves that submission,
-the public listing and installs remain on 1.0.6.
+It was published on 2026-08-19 as a 100% rollout to all 177 target countries,
+superseding 1.0.9 (versionCode 11, uploaded 2026-08-15) and the first public
+build 1.0.6 (versionCode 8). Store assets are still the set captured for
+1.0.6 — the listing has not been re-shot since.
+
+**Read without a console login** (measured 2026-08-21). The public listing page
+carries more than the marketing copy: `curl` it and the HTML contains the
+download bucket, the content rating, the `Updated on` date, and the localized
+*What's new* text. On that date the listing answered `200`, was rated
+*Everyone*, ranked **first** for the query `AgentDeck` in Play search — and
+reported its download bucket as **`0+`**, Play's lowest step, which bounds
+installs from above rather than proving zero. Discovery-intent queries
+(`Claude Code`, `AI agent dashboard`, `coding agent monitor`, `Stream Deck AI`)
+did not surface it at any rank. The two figures that do need the owner's login
+are the exact install count and the acquisition funnel — listing views versus
+installs, which is what separates "nobody arrived" from "arrived and did not
+install".
 
 | Field | Value |
 |---|---|
@@ -156,7 +169,42 @@ AgentDeck is an independent project and is not affiliated with or endorsed by An
 
 Privacy policy: <https://puritysb.github.io/AgentDeck/#privacy>
 
-## Release notes — 1.0.9
+## Release notes — 1.0.10 (live)
+
+Transcribed 2026-08-21 from the public listing itself (`?hl=en` / `?hl=ko` /
+`?hl=ja`), so this is what the store is serving rather than what was drafted.
+
+### English (US)
+
+```
+Kiro joins your deck. Kiro CLI and Kiro IDE sessions now appear alongside Claude Code, Codex and OpenCode — in the session list, on the timeline, and as their own creature in the terrarium.
+Also in this release:
+• A live count of the subagents working under each session
+• A badge showing which provider actually answered
+• A clearer approval prompt for OpenClaw
+```
+
+### Korean
+
+```
+이제 Kiro도 함께 보입니다. Kiro CLI와 Kiro IDE 세션이 Claude Code, Codex, OpenCode와 나란히 세션 목록과 타임라인에 나타나고, 테라리움에서는 자기만의 크리처로 헤엄칩니다.
+이번 버전의 다른 개선 사항:
+• 각 세션 아래에서 일하는 서브에이전트 수를 실시간으로 표시
+• 어느 제공자가 실제로 응답했는지 배지로 표시
+• OpenClaw 승인 요청을 더 읽기 쉽게 개선
+```
+
+### Japanese
+
+```
+Kiroが仲間入りしました。Kiro CLIとKiro IDEのセッションが、Claude Code・Codex・OpenCodeと並んでセッション一覧とタイムラインに表示され、テラリウムでは専用のクリーチャーとして泳ぎます。
+このバージョンのその他の改善:
+• 各セッションで動いているサブエージェントの数をリアルタイムに表示
+• どのプロバイダーが実際に応答したかをバッジで表示
+• OpenClawの承認リクエストをより読みやすく改善
+```
+
+## Release notes — 1.0.9 (superseded)
 
 ### English (US)
 
@@ -208,10 +256,10 @@ cd android && ./gradlew bundleRelease     # → app/build/outputs/bundle/release
 ```
 
 Signing comes from `android/signing.properties` + `agentdeck-release.jks`
-(both gitignored, both local). The submitted bundle is **1.0.9 / versionCode
-11**, 5.2 MB, `targetSdkVersion 36`. Play accepted it for production review on
-2026-08-15. Play requires a strictly higher `versionCode` on every subsequent
-upload; production continues to serve 1.0.6 / versionCode 8 until approval.
+(both gitignored, both local). The live bundle is **1.0.10 / versionCode 12**,
+`targetSdkVersion 36`, published 2026-08-19; 1.0.9 / versionCode 11 (5.2 MB,
+uploaded 2026-08-15) preceded it. Play requires a strictly higher `versionCode`
+on every subsequent upload.
 
 **2. Create the app.** Console home → *앱 만들기 / Create app*. App name
 `AgentDeck`, default language, **App** (not game), **Free**. Accept the


### PR DESCRIPTION
Google Play has served AgentDeck since 2026-08-15 and **1.0.10 (versionCode 12)** since 08-19, but three documents still described the state before that. The landing page and README were already correct — this is the trailing set.

## What was stale

| File | Was | Now |
|---|---|---|
| `docs/roadmap.md` | `- [ ] Play Store distribution` unchecked; "Current Focus" said the iPhone/iPad companion was unreleased and awaiting resubmission after the 08-04 rejection; Mac App Store listed at 1.0.2 | Three-store table with the version, date, **and the instrument each was measured with** |
| `.github/release-notes/android.md` | APK sideloading only — no Play link on any Android GitHub Release | Play first, APK kept for Play-less e-ink readers and version pinning |
| `marketplace/play/LISTING.md` | "1.0.9 submitted; 1.0.6 live (2026-08-15)"; no record of the notes 1.0.10 shipped with | 1.0.10 / vc12 live; the live What's new transcribed in en/ko/ja |

## Measured, not assumed

Verified 2026-08-21 against the stores themselves, since approval mail is an event stream and not a state:

- iOS `1.0.7` build 5201 live **08-18** (`itunes.apple.com/lookup?id=6784822497`)
- macOS `1.0.7` live **08-19** (product page with `?platform=mac`)
- Play `1.0.10` vc12, 177 countries, rated Everyone, **rank 1** for the query `AgentDeck` (public listing HTML + `store/search`)

Two by-products worth keeping: Play's public listing exposes the download bucket, rating, `Updated on`, and localized *What's new* **without a console login** — only the exact install count and the acquisition funnel need one; and the 1.0.10 release notes are transcribed from the live listing rather than reconstructed from the changelog.

The published `android-v1.0.10` release body was updated to match. Its changelog link stays on `master`: the tag tree predates the 2026-08-18 CHANGELOG entry, so pinning it to the tag would point at a file without this release's own notes.

## Gates

`pnpm docs:check` (108 files) · `pnpm design-system:check` (29 documents) · `pnpm vitest run scripts/__tests__/release-notes.test.ts` (11 tests) — all green. `docs/roadmap.md` is a documented catalog exclusion, so no locale mirrors to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)