### PR TITLE
Record that a channel going live leaves a doc set no gate covers

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,54 @@
 
 ---
 
+## 2026-08-21 — Play는 왜 다운로드가 없는가, 그리고 라이브 전환 뒤 아무 게이트도 보지 않는 문서 집합
+
+### 문제
+
+"Android는 왜 다운로드가 발생하지 않을까?" 라는 질문에서 출발했다. Play는 08-15부터
+서비스 중이고 08-19에 1.0.10(vc 12)이 177개국 100%로 게시됐는데 공개 카운터가 `0+`
+였다. 차단인지 수요인지 먼저 갈라야 했고, 그 다음 질문("소개 페이지가 덜 업데이트된 건
+아닌가")에서 진짜 구조적 원인 하나가 나왔다.
+
+### 해결
+
+**차단 가설은 전부 기각.** 리스팅 200 응답, 등급 Everyone, `uses-feature` 0건(기기
+필터링 없음, minSdk 29 / targetSdk 36), `AgentDeck` 검색 **1위**. 반면 의도 검색어
+4종(`Claude Code`, `AI agent dashboard`, `coding agent monitor`, `Stream Deck AI`)은
+전부 미노출 — 이름을 이미 아는 사람만 도달 가능한 상태였다. 상류도 작다: npm 주간
+bridge 442 / setup 412, GitHub APK는 릴리스당 1~3건, 그리고 Android는 데몬 없이는
+값이 0인 2차 표면이다.
+
+**유일하게 구조적이었던 것**은 `.github/release-notes/android.md` — 모든 Android
+GitHub Release 하단에 붙는 설치 안내가 APK 사이드로딩 단독이었고 Play 링크가 0건이었다.
+릴리스 페이지에 온 사람을 스토어 반대쪽으로 보내고 있었다. 같은 드리프트가 세 곳 더:
+`docs/roadmap.md`의 `- [ ] Play Store distribution` 미체크와 "iPhone/iPad 미출시·
+재제출 대기"(실제로는 iOS 1.0.7 08-18, macOS 1.0.7 08-19 라이브), `marketplace/play/
+LISTING.md`의 "1.0.9 submitted; 1.0.6 live" 고정. **`docs:check`와
+`design-system:check`는 그동안 계속 green** 이었다 — 링크·앵커·카탈로그 커버리지는
+보지만 문장이 아직 참인지는 보지 않는다. PR #250으로 네 곳 정정, 발행된
+`android-v1.0.10` 릴리스 본문도 갱신.
+
+### 핵심 설계 결정
+
+- **라이브 전환은 게이트 없는 문서 집합을 남긴다.** 채널이 state 5에 도달하면
+  랜딩/README → `docs/roadmap.md` → `marketplace/<channel>/LISTING.md` →
+  `.github/release-notes/<channel>.md` 순으로 쓸어야 한다. 마지막 것이 가장 잘
+  잊히면서 사용자의 다음 행동을 결정하는 유일한 파일이다. RELEASING.md에 절차로 박았다.
+- **Play도 상당 부분 로그인 없이 읽힌다.** 리스팅 HTML에 다운로드 버킷·등급·
+  `Updated on`·현지화 What's new가 들어 있고 `store/search?q=`로 검색 순위까지 측정된다.
+  덕분에 1.0.10 릴리스 노트를 **지어내지 않고 스토어에서 전사**해 LISTING.md에 넣었다.
+  로그인이 필요한 건 설치 실수치와 획득 퍼널뿐이며, 그 둘이 "아무도 안 왔다"와
+  "와서 설치를 안 했다"를 가르는 지표다.
+- **`0+`는 0의 증명이 아니다.** Play 공개 버킷은 `0+ → 1+ → 5+ → 10+` 해상도에 지연이
+  있어 설치 수를 위에서 바운드할 뿐이다. 측정하지 않은 값을 단정하지 않기 위해 문서에도
+  버킷이라고 명시했다.
+- **소급 편집은 태그 고정 링크를 되돌려야 한다.** `release-notes.mjs`는 `Full
+  changelog`를 태그에 고정하는데, `android-v1.0.10` 태그 트리에는 08-18에 쓰인 자기
+  자신의 CHANGELOG 항목이 없다. 발행 후 편집분만 `master` 링크를 유지했다.
+
+---
+
 ## 2026-08-21 — 첫 외부 프로토콜 소비자 수용, 그리고 컴파일된 적 없는 표면의 마지막 구멍
 
 ### 문제

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ locale: en
 canonical: true
 status: required
 owner: Release maintainers
-reviewed: 2026-08-20
-revision: 2026-08-20
+reviewed: 2026-08-21
+revision: 2026-08-21
 source_of_truth: RELEASING.md
 validators: [node scripts/build-design-system-viewer.mjs --check, pnpm verify-version]
 ---
@@ -54,6 +54,14 @@ On 2026-08-09 an agent with those tools loaded from the first turn never invoked
 ### Apple build numbers are per-platform — read them, do not compute them
 
 `CURRENT_PROJECT_VERSION` comes from `run_number * 100 + run_attempt`, so it is tempting to derive. Do not: **`build-macos` and `build-ios` are separate jobs, and a rerun of one advances only that one.** `apple-v1.0.5` shipped macOS as **4701** (attempt 1) and iOS as **4702** (attempt 2, after the iOS archive was rerun past a certificate cap). One number reported for both is wrong for one of them. Read each platform's build from App Store Connect.
+
+### Reaching state 5 leaves a doc set behind, and no gate covers it
+
+Going live changes what the repository should say, and nothing in CI notices when it doesn't. Google Play served AgentDeck from 2026-08-15; six days later `docs/roadmap.md` still carried `- [ ] Play Store distribution` unchecked and still described the iPhone/iPad companion as unreleased and awaiting resubmission, `marketplace/play/LISTING.md` was pinned at *"1.0.9 submitted; 1.0.6 live"*, and `.github/release-notes/android.md` — the install text appended to **every** Android GitHub Release — routed every visitor to sideloading with no Play link at all. `docs:check` and `design-system:check` were green the whole time: they verify links, anchors, and catalog coverage, never whether a sentence is still true.
+
+So when a channel first goes live, sweep the surfaces that state its status: the landing page and `README.md` first, then `docs/roadmap.md`, then `marketplace/<channel>/LISTING.md`, then `.github/release-notes/<channel>.md`. The last one is the easiest to forget and the only one that shapes what a user does next.
+
+**Play's live state reads without a console login.** `curl "https://play.google.com/store/apps/details?id=dev.agentdeck&hl=en"` returns the download bucket, the content rating, `Updated on`, and the localized *What's new* — so the notes a store is actually serving can be transcribed instead of reconstructed from the changelog — and `store/search?q=<term>&c=apps` measures whether the listing surfaces for anything besides its own name. Only the exact install count and the acquisition funnel (listing views versus installs) need the owner's login; that pair is what separates "nobody arrived" from "arrived and did not install".
 
 ## Compatible line, independent patch and delivery
 
@@ -108,6 +116,13 @@ round shipped a whole new observed agent across five channels with no line about
 it anywhere a user could read. Each release workflow now fails at its
 `verify-release-version` step when the entry is missing — before anything is
 built, published, or tagged.
+
+Back-filling an **already published** body needs one correction to the rendered
+output: `release-notes.mjs` pins its `Full changelog` link to the tag, which is
+right at cut time and wrong retroactively. `android-v1.0.10` was cut on 08-17
+and the entry describing it was written on 08-18, so that tag's tree holds a
+`CHANGELOG.md` without this release's own notes — keep the link on `master`
+when editing a published body.
 
 ## Channel release steps
 
@@ -201,11 +216,11 @@ pnpm analytics:apple -- fetch --request REQUEST_ID --days 30
 
 Run `snapshot` once when onboarding an existing app, save the returned request id, and fetch that id to capture all historical data Apple makes available. Keep the `ONGOING` request for new daily batches. Apple normally needs 1–2 days to produce a new request. `--days` filters **report processing dates**, not the event dates inside the downloaded rows, so it does not limit a snapshot to the last 30 days. Exports land under the gitignored `reports/app-store-connect/` directory. Usage rows represent only users who enabled sharing with Apple and developers, and low-volume rows can be absent because Apple applies privacy thresholds; treat these as directional retention signals, not a census. Re-run `fetch` regularly because Apple can add late-arriving or corrected batches.
 
-### Android (APK / optional Play)
+### Android (Google Play + APK)
 
-1. Confirm the Android `versionName` remains on the shared compatibility line and increment `versionCode`.
+1. Confirm the Android `versionName` remains on the shared compatibility line and increment `versionCode`. Play refuses any upload whose `versionCode` is not strictly higher than the live one.
 2. Follow `.agents/workflows/build-android.md` for the signed release APK.
-3. Tag and push `android-v<ANDROID_VERSION>` to create the GitHub Release. Optional Play upload remains gated by `ANDROID_PLAY_ENABLED` and its service-account secret.
+3. Tag and push `android-v<ANDROID_VERSION>` to create the GitHub Release. CI's Play upload stays gated by `ANDROID_PLAY_ENABLED` and its service-account secret, so in practice the AAB is built locally (`./gradlew bundleRelease`) and uploaded through the console — see [marketplace/play/LISTING.md](marketplace/play/LISTING.md) for the runbook, including that saving a release is not submitting it and that release notes keep only the first language across a save.
 
 ### ESP32 firmware
 


### PR DESCRIPTION
Follow-up to #250, which fixed the drift. This records why it was invisible.

Google Play served AgentDeck from 2026-08-15. Six days later `docs/roadmap.md` still carried `- [ ] Play Store distribution` unchecked, `marketplace/play/LISTING.md` was pinned at "1.0.9 submitted; 1.0.6 live", and `.github/release-notes/android.md` — the install text appended to **every** Android GitHub Release — routed every visitor to sideloading with no Play link. `docs:check` and `design-system:check` were green the whole time: they verify links, anchors, and catalog coverage, never whether a sentence is still true.

## RELEASING.md

- **New subsection under the five states** — the sweep order after a channel reaches state 5: landing/README, `docs/roadmap.md`, `marketplace/<channel>/LISTING.md`, `.github/release-notes/<channel>.md`. The last is the easiest to forget and the only one that shapes what a user does next.
- **Play's live state reads without a console login** — the public listing HTML carries the download bucket, rating, `Updated on`, and the localized *What's new*, and `store/search?q=` measures whether it surfaces for anything besides its own name. Only the exact install count and the acquisition funnel need the owner's login.
- **Back-filling a published body** must keep its `Full changelog` link on `master`: `release-notes.mjs` pins it to the tag, but `android-v1.0.10` was cut 08-17 and the entry describing it was written 08-18, so that tag's tree holds a CHANGELOG without this release's own notes.
- Android channel steps renamed from "APK / optional Play" — Play is the live primary channel now, and the steps point at the console runbook.

## DEVELOPMENT_LOG.md

Entry for 2026-08-21 covering the original question (why no downloads), the measurements that rejected every blocking hypothesis, and the four decisions above — including that `0+` is Play's lowest bucket and therefore bounds installs rather than proving zero.

## Gates

`pnpm docs:check` (108 files) · `pnpm design-system:check` (29 documents). RELEASING.md is cataloged with no translations, so its `reviewed`/`revision` moved to 2026-08-21 and there are no locale mirrors to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)