### PR TITLE
Rank Codex usage snapshots by plan before age, not after

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,73 @@
 
 ---
 
+## 2026-08-22 — Codex 요금제를 올렸더니 사용량이 전부 사라졌다: void 판정이 선택보다 뒤에 있었다
+
+### 문제
+
+ChatGPT 요금제를 Plus → Pro Lite(`prolite`)로 올린 직후 모든 표면에서 Codex 게이지가
+사라졌다. 데몬 와이어 실측은 `codexRateLimits: { planType: "prolite" }` — 창이 하나도
+없는 void 블록. 규칙 자체는 설계대로였다: 스냅샷의 `plan_type`이 계정 티어와 다르면
+그 수치는 "오래된" 게 아니라 "무의미"하므로 버린다(`codexSnapshotMatchesAccountPlan`).
+
+문제는 그 불일치가 과도기가 아니라 **영구 상태로 고착**됐다는 것이다. 측정값:
+`auth.json` JWT는 갱신 즉시 `prolite`, 그런데 롤아웃 8,314줄(07-31~08-22)은 **전부**
+`plus`. Codex는 `plan_type`을 **프로세스가 시작할 때 들고 있던 토큰**에서 찍는다 —
+업그레이드 전에 열어 둔 세션은 살아 있는 한 계속 구 플랜을 찍고, 가장 바쁜 세션이므로
+**가장 최신 타임스탬프도 계속 갱신**한다. 업그레이드 후 시작한 새 세션은 정상적으로
+`prolite`를 찍었지만(01:43 실측), 최신순 선택이 매번 구 세션의 `plus`를 골라 void로
+버렸다. 유효한 스냅샷이 디스크에 있는데 한 번도 읽히지 않은 것이다.
+
+구제 경로도 두 겹으로 막혀 있었다. `shouldQueryCodexRateLimitsLive`는 패시브가 2분
+이내면 live 질의를 건너뛰고(= Codex를 쓰는 중엔 상시 skip), `pickFresherCodexRateLimits`는
+`capturedAt`만 비교해 정상적인 live 응답(`prolite`, 정상 창)을 더 최신인 `plus`에게
+지게 만들었다. **void 판정이 freshness 선택 *이후*에 적용**되므로 "곧 버려질 최신본"이
+"유효한 조금 덜 최신본"을 항상 이겼다.
+
+### 해결
+
+**plan 일치를 1순위 키로, 나이를 tie-break로** — `codexSnapshotOutranks`(SSOT
+`shared/src/format-utils.ts`)를 신설하고 양쪽 데몬의 롤아웃 선택기와 Node의 live/passive
+선택기가 모두 이것을 쓰게 했다. 이 함수는 **순서만 정하고 구제하지는 않는다**: 불일치
+스냅샷이 유일해서 이겼다면 downstream에서 그대로 void된다(그래야 티어만 실린 명시적
+windowless 페이로드가 유지된다 — retain-on-absent 래치 회피).
+
+- `shouldQueryCodexRateLimitsLive`에 `passivePlanMatchesAccount` 추가 — 불일치면
+  "패시브가 신선하다"는 skip 사유를 무시한다. 단, spawn 스로틀(5분 간격·실패 백오프)은
+  무조건 유지: 불일치는 live를 **선호할** 이유이지 매 빌드마다 서브프로세스를 띄울
+  면허가 아니다.
+- `pickFresherCodexRateLimits` → `pickBestCodexRateLimits`(이름이 규칙과 어긋났다).
+- 캐시 키에 계정 티어를 넣었다(Node·Swift 양쪽). 파일만으로 키를 잡으면 플랜이 바뀐
+  순간에도 어떤 롤아웃이 다시 touch될 때까지 업그레이드 이전 승자를 계속 서빙한다.
+- `formatChatGptPlan`을 shared SSOT `formatChatGptPlanName` + `CHATGPT_PLAN_DISPLAY_NAMES`로
+  올리고, Swift `ChatGPTPlan`(손 미러였다)을 생성 파일로 옮겼다. `prolite` 추가.
+  구분자를 제거해 키를 만들므로 `prolite`/`pro_lite`/`pro lite`가 한 플랜이다.
+
+### 핵심 설계 결정
+
+- **버려질 값이 먼저 선택을 이기면 안 된다.** 무효화 규칙과 선택 규칙이 따로 있으면
+  순서가 곧 버그다. 무효화가 존재하는 파이프라인에서 선택기는 반드시 무효화 기준을
+  알아야 한다 — 그렇지 않으면 "유효한 후보가 있는데도 전부 비었다"가 정상 동작처럼 보인다.
+- **Swift 단독(App Store) 모드가 이 수정의 진짜 수혜자다.** 샌드박스라 `codex app-server`를
+  띄울 수 없어 롤아웃 트리가 유일한 소스다 — Node에는 live 질의라는 두 번째 소스가
+  있지만 Swift에는 없으므로, 선택을 plan-aware로 만들지 않으면 복구 경로가 아예 없다.
+  두 데몬이 `timeline.json`처럼 교대로 9120을 소유하므로 규칙은 SSOT에서 생성해 미러한다.
+- **한 usage 프레임에는 티어가 하나.** 순위를 매길 때와 void할 때 계정 플랜을 따로 읽으면
+  토큰 갱신을 사이에 두고 서로 다른 플랜으로 판단할 수 있다. Node는 `buildUsage()`에서,
+  Swift는 `DaemonServer`에서 한 번 읽어 아래로 내린다.
+- **fixture는 지어내지 않고 복사했다.** 양쪽 데몬 테스트가 2026-08-22 실제 롤아웃 두
+  줄(구 세션 `plus` / 신 세션 `prolite`)을 **동일 바이트로** 물고 있다. 파서가 기대하는
+  모양으로 조립한 fixture는 실제 줄이 실패하는 방식으로 실패하지 못한다.
+
+### 검증
+
+- 실제 두 세션 트리(복사본)에서 plan-blind는 `plus`(→void), plan-aware는 `prolite` 선택 — 계측기 검증 완료.
+- 데몬 재시작 후 와이어 실측: `codexRateLimits.secondary` 7d 1% / resets 2026-08-28,
+  `planType: prolite`, 구독행 "ChatGPT Pro Lite"(이전 "ChatGPT Prolite").
+- vitest 3,267개 통과, macOS XCTest ProtocolTests 70개 통과, 생성 미러 drift 게이트 in sync.
+
+---
+
 ## 2026-08-21 — Play는 왜 다운로드가 없는가, 그리고 라이브 전환 뒤 아무 게이트도 보지 않는 문서 집합
 
 ### 문제

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/TopologyRail.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/TopologyRail.kt
@@ -54,6 +54,7 @@ import dev.agentdeck.state.DashboardState
 import dev.agentdeck.terrarium.TerrariumColors
 import dev.agentdeck.ui.component.AgentDeckMark
 import dev.agentdeck.ui.component.brandColorForAgent
+import dev.agentdeck.util.ChatGPTPlan
 import dev.agentdeck.util.DeviceProfileHolder
 import dev.agentdeck.util.codexLimitRows
 import dev.agentdeck.util.formatResetTime
@@ -814,20 +815,18 @@ private fun buildCodexRateChips(limits: CodexRateLimits?): List<RateChip> =
 
 /**
  * Friendly ChatGPT plan label from a raw `chatgpt_plan_type`. Returns null
- * when blank so the subtitle stays hidden. Mirrors iOS `chatGptPlanLabel`.
+ * when blank so the subtitle stays hidden.
+ *
+ * The tier table itself is NOT written here. This row formats the raw plan type
+ * rather than reading the pre-formatted `subscriptions[].name`, so a hand copy
+ * renders the fallback capitalisation for any tier this build predates while
+ * every other surface shows the real name — `prolite` read as "ChatGPT Prolite"
+ * on Android alone (2026-08-22). `ChatGPTPlan` is generated from the same SSOT
+ * as the Swift mirror (`shared/src/format-utils.ts` CHATGPT_PLAN_DISPLAY_NAMES).
  */
 private fun chatGptPlanLabel(raw: String?): String? {
     val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-    return when (trimmed.lowercase()) {
-        "free" -> "ChatGPT Free"
-        "plus" -> "ChatGPT Plus"
-        "pro" -> "ChatGPT Pro"
-        "team" -> "ChatGPT Team"
-        "enterprise" -> "ChatGPT Enterprise"
-        // Capitalize an unknown plan type rather than passing the lowercased
-        // raw value through next to Plus/Pro/Team.
-        else -> "ChatGPT " + trimmed.replaceFirstChar { it.uppercase() }
-    }
+    return ChatGPTPlan.displayName(trimmed)
 }
 
 /**

--- a/android/app/src/main/kotlin/dev/agentdeck/util/CodexFreshnessRules.generated.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/util/CodexFreshnessRules.generated.kt
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT.
 // Source of truth: shared/src/format-utils.ts (CODEX_SNAPSHOT_STALE_MS, codexUsageFootnote,
-// codexSnapshotMatchesAccountPlan)
+// codexSnapshotMatchesAccountPlan, codexSnapshotOutranks, CHATGPT_PLAN_DISPLAY_NAMES)
 // Regenerate: pnpm generate-codex-freshness-rules (drift gated by shared/src/__tests__/codex-freshness-rules.test.ts)
 package dev.agentdeck.util
 

--- a/android/app/src/main/kotlin/dev/agentdeck/util/CodexFreshnessRules.generated.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/util/CodexFreshnessRules.generated.kt
@@ -73,3 +73,31 @@ object CodexFreshnessRules {
         return formatSnapshotAge(capturedAt, nowMs) ?: "stale"
     }
 }
+
+/**
+ * Display name for a raw `chatgpt_plan_type`.
+ *
+ * Android is a pure consumer of the wire for the SNAPSHOT, but not for this:
+ * the Codex row subtitle formats `codexPlanType` itself rather than reading the
+ * pre-formatted `subscriptions[].name`, so a hand copy here renders the fallback
+ * capitalisation for any tier it predates while every other surface shows the
+ * real name (`prolite` -> "ChatGPT Prolite" vs "ChatGPT Pro Lite", 2026-08-22).
+ *
+ * Keys carry no separators: `prolite`, `pro_lite` and `pro lite` are one plan.
+ * An unrecognised tier is capitalised, never dropped and never shown raw.
+ */
+object ChatGPTPlan {
+    fun displayName(raw: String): String {
+        val trimmed = raw.trim()
+        val key = trimmed.lowercase().filterNot { it.isWhitespace() || it == '_' || it == '-' }
+        return when (key) {
+            "free" -> "ChatGPT Free"
+            "plus" -> "ChatGPT Plus"
+            "pro" -> "ChatGPT Pro"
+            "prolite" -> "ChatGPT Pro Lite"
+            "team" -> "ChatGPT Team"
+            "enterprise" -> "ChatGPT Enterprise"
+            else -> "ChatGPT " + trimmed.replaceFirstChar { it.uppercase() }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/dev/agentdeck/util/ChatGPTPlanTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/util/ChatGPTPlanTest.kt
@@ -31,6 +31,7 @@ class ChatGPTPlanTest {
         // Separators are stripped before lookup: one plan, three spellings.
         assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("pro_lite"))
         assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("pro-lite"))
+        assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("Pro-Lite"))
         assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName(" Pro Lite "))
     }
 

--- a/android/app/src/test/kotlin/dev/agentdeck/util/ChatGPTPlanTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/util/ChatGPTPlanTest.kt
@@ -1,0 +1,44 @@
+package dev.agentdeck.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The Codex row subtitle formats the raw `chatgpt_plan_type` itself rather than
+ * reading the pre-formatted `subscriptions[].name`, so Android is NOT a pure
+ * consumer of the wire for this field. It carried a hand copy of the tier table
+ * until 2026-08-22, when a `prolite` upgrade rendered as "ChatGPT Prolite" here
+ * and "ChatGPT Pro Lite" everywhere else.
+ *
+ * `ChatGPTPlan` is now generated from the TS SSOT
+ * (`shared/src/format-utils.ts` CHATGPT_PLAN_DISPLAY_NAMES); these cases mirror
+ * `shared/src/__tests__/codex-freshness-rules.test.ts` and the Swift
+ * `testChatGPTPlanNamesATierTheBuildPredates`.
+ */
+class ChatGPTPlanTest {
+    @Test
+    fun `names the known tiers`() {
+        assertEquals("ChatGPT Free", ChatGPTPlan.displayName("free"))
+        assertEquals("ChatGPT Plus", ChatGPTPlan.displayName("plus"))
+        assertEquals("ChatGPT Pro", ChatGPTPlan.displayName("pro"))
+        assertEquals("ChatGPT Team", ChatGPTPlan.displayName("team"))
+        assertEquals("ChatGPT Enterprise", ChatGPTPlan.displayName("enterprise"))
+    }
+
+    @Test
+    fun `spells a multi-word tier the same way every other surface does`() {
+        assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("prolite"))
+        // Separators are stripped before lookup: one plan, three spellings.
+        assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("pro_lite"))
+        assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName("pro-lite"))
+        assertEquals("ChatGPT Pro Lite", ChatGPTPlan.displayName(" Pro Lite "))
+    }
+
+    @Test
+    fun `capitalises a tier this build predates rather than dropping it`() {
+        // OpenAI mints plan names on its own schedule. An unrecognised tier must
+        // still read as a plan beside Plus/Pro/Team — never the raw lowercase
+        // token, and never nothing.
+        assertEquals("ChatGPT Nebula", ChatGPTPlan.displayName("nebula"))
+    }
+}

--- a/apple/AgentDeck/Daemon/Core/UsageAPIClient.swift
+++ b/apple/AgentDeck/Daemon/Core/UsageAPIClient.swift
@@ -191,9 +191,25 @@ final class UsageAPIClient: Sendable {
     var antigravityStatus: AntigravityStatus? { readAntigravityStatus() }
 
     /// Latest Codex usage limits from local rollout files. Cached by active
-    /// rollout path + mtime so repeated polls don't re-read an unchanged file.
+    /// rollout path + mtime + account tier so repeated polls don't re-read an
+    /// unchanged file, while a plan change still re-ranks the same rollouts.
+    ///
+    /// The tier is resolved OUTSIDE `codexRateLimitsQueue` — `codexAuthStatus`
+    /// takes `codexAuthQueue`, and nesting the two locks in one order here while
+    /// some future caller nests them the other way is how a daemon deadlocks.
     var codexRateLimits: CodexRateLimitsLocal? {
-        codexRateLimitsQueue.sync { readCodexRateLimitsLocked() }
+        codexRateLimits(accountPlan: codexAuthStatus?.planType)
+    }
+
+    /// Same read, with the caller's already-resolved account tier.
+    ///
+    /// The payload builder reconciles the snapshot against a tier it read for
+    /// itself; handing that same value down keeps ONE plan per usage frame. Two
+    /// independent reads can straddle a token refresh — and a build that ranks
+    /// rollouts under the new plan and then voids them against the old one (or
+    /// the reverse) blanks the gauges for reasons neither read can explain.
+    func codexRateLimits(accountPlan: String?) -> CodexRateLimitsLocal? {
+        codexRateLimitsQueue.sync { readCodexRateLimitsLocked(accountPlan: accountPlan) }
     }
 
     // MARK: - Fetch
@@ -579,28 +595,39 @@ final class UsageAPIClient: Sendable {
     /// Must only be invoked inside `codexRateLimitsQueue.sync { ... }`. The
     /// whole find-newest-file + tail-read runs inside `withCodexBase` so the
     /// security scope (App Store sandbox) stays active during the file read.
-    private func readCodexRateLimitsLocked() -> CodexRateLimitsLocal? {
+    private func readCodexRateLimitsLocked(accountPlan: String?) -> CodexRateLimitsLocal? {
         withCodexBase { base in
             let candidates = Self.codexRolloutCandidates(sessionsDir: base.appendingPathComponent("sessions"))
             guard !candidates.isEmpty else { return nil }
-            let key = Self.codexRolloutCacheKey(candidates)
+            let key = Self.codexRolloutCacheKey(candidates, accountPlan: accountPlan)
             if let cached = self.codexRateLimitsCache, cached.key == key { return cached.value }
 
-            let parsed = Self.parseFirstUsableCodexRollout(candidates)
+            let parsed = Self.parseFirstUsableCodexRollout(candidates, accountPlan: accountPlan)
             self.codexRateLimitsCache = (key, parsed)
             return parsed
         }
     }
 
-    /// Scan every candidate and return the usable snapshot with the newest
-    /// CAPTURE timestamp. File mtime decides which rollouts are worth inspecting,
-    /// not which account snapshot wins: concurrent Codex sessions can append
-    /// ordinary lines to one file after another file wrote a newer rate_limits
-    /// line. Stamps missing `capturedAt` from file mtime. Mirrors
-    /// `parseFirstUsable` in bridge/src/codex-rate-limits.ts.
-    static func parseFirstUsableCodexRollout(_ candidates: [(url: URL, mtime: TimeInterval)]) -> CodexRateLimitsLocal? {
-        var newest: CodexRateLimitsLocal?
-        var newestCapturedAt = Date.distantPast
+    /// Scan every candidate and return the best usable snapshot. File mtime
+    /// decides which rollouts are worth inspecting, not which account snapshot
+    /// wins: concurrent Codex sessions can append ordinary lines to one file
+    /// after another file wrote a newer rate_limits line. Stamps missing
+    /// `capturedAt` from file mtime. Mirrors `parseFirstUsable` in
+    /// bridge/src/codex-rate-limits.ts.
+    ///
+    /// `accountPlan` (the live tier from `auth.json`) makes the ranking
+    /// plan-aware — `CodexPlanRules.snapshotOutranks`. Without it a Codex session
+    /// left open across a plan change wins on recency forever with a snapshot
+    /// that `codexRateLimitsPayload` voids one step later, blanking every gauge
+    /// while a valid snapshot sits unread in another rollout. This matters most
+    /// for the App Store daemon, which cannot spawn `codex app-server` and has
+    /// no second source to fall back on.
+    static func parseFirstUsableCodexRollout(
+        _ candidates: [(url: URL, mtime: TimeInterval)],
+        accountPlan: String? = nil
+    ) -> CodexRateLimitsLocal? {
+        var best: CodexRateLimitsLocal?
+        var bestCapturedAt = TimeInterval(-Double.greatestFiniteMagnitude)
         for candidate in candidates {
             guard let tail = readCodexRolloutTail(candidate.url),
                   var parsed = parseCodexRateLimits(tail) else { continue }
@@ -609,18 +636,33 @@ final class UsageAPIClient: Sendable {
             }
             guard let stamp = parsed.capturedAt,
                   let capturedAt = codexCaptureDate(stamp) else { continue }
-            if newest == nil || capturedAt > newestCapturedAt {
-                newest = parsed
-                newestCapturedAt = capturedAt
+            let capturedAtSeconds = capturedAt.timeIntervalSince1970
+            if best == nil || CodexPlanRules.snapshotOutranks(
+                candidatePlan: parsed.planType,
+                candidateCapturedAt: capturedAtSeconds,
+                incumbentPlan: best?.planType,
+                incumbentCapturedAt: bestCapturedAt,
+                account: accountPlan
+            ) {
+                best = parsed
+                bestCapturedAt = capturedAtSeconds
             }
         }
-        return newest
+        return best
     }
 
     /// A concurrent session outside candidates[0] can write the newest account
-    /// snapshot. The cache key must therefore cover every inspected rollout.
-    static func codexRolloutCacheKey(_ candidates: [(url: URL, mtime: TimeInterval)]) -> String {
-        candidates.map { "\($0.url.path):\($0.mtime)" }.joined(separator: "|")
+    /// snapshot. The cache key must therefore cover every inspected rollout — and
+    /// the account tier, because the selection is plan-aware: the same set of
+    /// rollouts ranks differently the instant the user's plan changes, and a
+    /// files-only key would serve the pre-upgrade winner until some rollout
+    /// happened to be touched again.
+    static func codexRolloutCacheKey(
+        _ candidates: [(url: URL, mtime: TimeInterval)],
+        accountPlan: String? = nil
+    ) -> String {
+        let files = candidates.map { "\($0.url.path):\($0.mtime)" }.joined(separator: "|")
+        return "\(accountPlan ?? "")|\(files)"
     }
 
     /// Gather rollout files across the newest few day-directories of the

--- a/apple/AgentDeck/Daemon/Core/UsageAPIClient.swift
+++ b/apple/AgentDeck/Daemon/Core/UsageAPIClient.swift
@@ -190,24 +190,18 @@ final class UsageAPIClient: Sendable {
     }
     var antigravityStatus: AntigravityStatus? { readAntigravityStatus() }
 
-    /// Latest Codex usage limits from local rollout files. Cached by active
-    /// rollout path + mtime + account tier so repeated polls don't re-read an
-    /// unchanged file, while a plan change still re-ranks the same rollouts.
+    /// Latest Codex usage limits from local rollout files, ranked against the
+    /// caller's already-resolved account tier. Cached by active rollout path +
+    /// mtime + tier so repeated polls don't re-read an unchanged file, while a
+    /// plan change still re-ranks the same rollouts.
     ///
-    /// The tier is resolved OUTSIDE `codexRateLimitsQueue` — `codexAuthStatus`
-    /// takes `codexAuthQueue`, and nesting the two locks in one order here while
-    /// some future caller nests them the other way is how a daemon deadlocks.
-    var codexRateLimits: CodexRateLimitsLocal? {
-        codexRateLimits(accountPlan: codexAuthStatus?.planType)
-    }
-
-    /// Same read, with the caller's already-resolved account tier.
-    ///
-    /// The payload builder reconciles the snapshot against a tier it read for
-    /// itself; handing that same value down keeps ONE plan per usage frame. Two
-    /// independent reads can straddle a token refresh — and a build that ranks
-    /// rollouts under the new plan and then voids them against the old one (or
-    /// the reverse) blanks the gauges for reasons neither read can explain.
+    /// The tier is a PARAMETER, deliberately — there is no zero-argument spelling
+    /// that resolves it here. The payload builder reconciles the snapshot against
+    /// a tier it read for itself, so a convenience overload reading its own would
+    /// let one build rank rollouts under the new plan and void them against the
+    /// old one (or the reverse) whenever the two reads straddle a token refresh —
+    /// the hazard this signature exists to close, reintroduced across the pair
+    /// instead of within it. One tier per usage frame, passed down.
     func codexRateLimits(accountPlan: String?) -> CodexRateLimitsLocal? {
         codexRateLimitsQueue.sync { readCodexRateLimitsLocked(accountPlan: accountPlan) }
     }

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -7957,8 +7957,13 @@ final class DaemonServer {
         if let codex = codexAuth {
             Self.writeCodexAuthStatus(codex, into: &e)
         }
+        // One tier per usage frame: the same `codexAuth` that decides which
+        // snapshot WINS also decides whether it is voided. Reading the plan twice
+        // could straddle a token refresh and rank under one plan while voiding
+        // against another.
+        let codexAccountPlan = codexAuth?.planType
         if let payload = Self.codexRateLimitsPayload(
-            usageAPI.codexRateLimits, accountPlan: codexAuth?.planType
+            usageAPI.codexRateLimits(accountPlan: codexAccountPlan), accountPlan: codexAccountPlan
         ) {
             e["codexRateLimits"] = payload
         }

--- a/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
+++ b/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT.
 // Source of truth: shared/src/format-utils.ts (CODEX_SNAPSHOT_STALE_MS, codexUsageFootnote,
-// codexSnapshotMatchesAccountPlan)
+// codexSnapshotMatchesAccountPlan, codexSnapshotOutranks, CHATGPT_PLAN_DISPLAY_NAMES)
 // Regenerate: pnpm generate-codex-freshness-rules (drift gated by shared/src/__tests__/codex-freshness-rules.test.ts)
 
 import Foundation
@@ -103,7 +103,64 @@ enum CodexPlanRules {
         return snap == acct
     }
 
+    /// Rank one snapshot against another for the live account tier.
+    ///
+    /// Recency alone is the wrong ordering: a snapshot that will be VOIDED a step
+    /// later must not first win the selection. Codex stamps `plan_type` from the
+    /// auth token the WRITING PROCESS started with, so a session opened before a
+    /// plan change keeps appending old-plan snapshots for as long as it stays
+    /// open — and, being the busiest session, keeps minting the newest timestamps
+    /// too. A newest-wins picker hands the void rule a mismatched snapshot on
+    /// every build and every gauge goes blank, while a valid same-plan snapshot
+    /// sits unread in another rollout.
+    ///
+    /// Plan agreement is the PRIMARY key, age only the tie-break; exact ties keep
+    /// the incumbent. This orders snapshots, it never rescues one — a mismatched
+    /// snapshot that wins for lack of a peer is still voided downstream.
+    ///
+    /// Capture stamps are seconds-since-epoch so "unknown" can be `-.infinity`
+    /// and order without a second date parse.
+    static func snapshotOutranks(
+        candidatePlan: String?,
+        candidateCapturedAt: TimeInterval,
+        incumbentPlan: String?,
+        incumbentCapturedAt: TimeInterval,
+        account: String?
+    ) -> Bool {
+        let candidateMatches = snapshotMatchesAccountPlan(snapshot: candidatePlan, account: account)
+        let incumbentMatches = snapshotMatchesAccountPlan(snapshot: incumbentPlan, account: account)
+        if candidateMatches != incumbentMatches { return candidateMatches }
+        return candidateCapturedAt > incumbentCapturedAt
+    }
+
     private static func normalized(_ value: String?) -> String {
         return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+/// Display name for a raw `chatgpt_plan_type`.
+///
+/// Generated so the daemons cannot disagree about what an account is called. The
+/// mapping had already drifted into three hand-written Swift call sites once,
+/// each passing an unrecognised plan through verbatim; keeping it hand-mirrored
+/// against the TS copy repeated that at the platform level — OpenAI mints tiers
+/// on its own schedule (`prolite` arrived unannounced) and whichever copy was
+/// not updated renders the fallback capitalisation for the same account.
+///
+/// Keys carry no separators: `prolite`, `pro_lite` and `pro lite` are one plan.
+/// An unrecognised tier is capitalised, never dropped and never shown raw.
+enum ChatGPTPlan {
+    static func displayName(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = trimmed.lowercased().filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
+        switch key {
+        case "free": return "ChatGPT Free"
+        case "plus": return "ChatGPT Plus"
+        case "pro": return "ChatGPT Pro"
+        case "prolite": return "ChatGPT Pro Lite"
+        case "team": return "ChatGPT Team"
+        case "enterprise": return "ChatGPT Enterprise"
+        default: return "ChatGPT " + trimmed.prefix(1).uppercased() + trimmed.dropFirst()
+        }
     }
 }

--- a/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
+++ b/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
@@ -96,6 +96,11 @@ enum CodexPlanRules {
     /// Unknown on either side matches: absence is "no information", never a
     /// licence to void real data (an API-key install reports no account tier, a
     /// pre-`plan_type` rollout reports no snapshot tier).
+    ///
+    /// The emptiness test MUST stay ahead of the equality test: `planKey` strips
+    /// separators, so two separator-only values both reduce to "" and, reordered,
+    /// would compare equal and report a positive plan MATCH where the answer is
+    /// "neither side named a tier".
     static func snapshotMatchesAccountPlan(snapshot: String?, account: String?) -> Bool {
         let snap = planKey(snapshot)
         let acct = planKey(account)

--- a/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
+++ b/apple/AgentDeck/Model/CodexFreshnessRules.generated.swift
@@ -89,7 +89,7 @@ enum CodexUsageFreshness {
 enum CodexPlanRules {
     /// True when the ChatGPT tier carries no paid Codex subscription.
     static func isFreePlan(_ plan: String?) -> Bool {
-        return normalized(plan) == "free"
+        return planKey(plan) == "free"
     }
 
     /// True when the snapshot still belongs to the plan the account holds.
@@ -97,8 +97,8 @@ enum CodexPlanRules {
     /// licence to void real data (an API-key install reports no account tier, a
     /// pre-`plan_type` rollout reports no snapshot tier).
     static func snapshotMatchesAccountPlan(snapshot: String?, account: String?) -> Bool {
-        let snap = normalized(snapshot)
-        let acct = normalized(account)
+        let snap = planKey(snapshot)
+        let acct = planKey(account)
         if snap.isEmpty || acct.isEmpty { return true }
         return snap == acct
     }
@@ -133,8 +133,19 @@ enum CodexPlanRules {
         return candidateCapturedAt > incumbentCapturedAt
     }
 
-    private static func normalized(_ value: String?) -> String {
-        return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    /// The one comparison form for a raw `chatgpt_plan_type`: trimmed,
+    /// lowercased, separators stripped. `prolite`, `pro_lite` and `pro lite` are
+    /// one plan, so they must key the display table AND compare equal — the two
+    /// sides of the plan check come from different producers (the auth token for
+    /// the account tier, the rollout stamp for the snapshot), and normalizing
+    /// only one path would land every candidate in the "mismatch" class for a
+    /// spelling the table exists to absorb. A value that is nothing but
+    /// separators normalizes to "", which reads as unknown, not as void.
+    static func planKey(_ value: String?) -> String {
+        return (value ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
     }
 }
 
@@ -152,8 +163,7 @@ enum CodexPlanRules {
 enum ChatGPTPlan {
     static func displayName(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let key = trimmed.lowercased().filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
-        switch key {
+        switch CodexPlanRules.planKey(trimmed) {
         case "free": return "ChatGPT Free"
         case "plus": return "ChatGPT Plus"
         case "pro": return "ChatGPT Pro"

--- a/apple/AgentDeck/Model/Protocol.swift
+++ b/apple/AgentDeck/Model/Protocol.swift
@@ -696,26 +696,9 @@ struct ScopedUsageLimit: Codable, Sendable {
     }
 }
 
-/// Display name for a raw `chatgpt_plan_type`.
-///
-/// One copy on purpose: this mapping had drifted into three Swift call sites
-/// (topology rail, state holder, daemon payload) and each one passed an
-/// unrecognized plan through verbatim — so a "free" account read as
-/// "ChatGPT free", the only lowercase entry next to Plus/Pro/Team.
-enum ChatGPTPlan {
-    static func displayName(_ raw: String) -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        switch trimmed.lowercased() {
-        case "free": return "ChatGPT Free"
-        case "plus": return "ChatGPT Plus"
-        case "pro": return "ChatGPT Pro"
-        case "team": return "ChatGPT Team"
-        case "enterprise": return "ChatGPT Enterprise"
-        // Capitalize an unknown plan rather than showing the raw lowercase value.
-        default: return "ChatGPT " + trimmed.prefix(1).uppercased() + trimmed.dropFirst()
-        }
-    }
-}
+// `ChatGPTPlan.displayName` lives in CodexFreshnessRules.generated.swift — the
+// tier table is generated from the TS SSOT (CHATGPT_PLAN_DISPLAY_NAMES) so the
+// two daemons cannot name the same account differently.
 
 struct UsageEvent: Codable, Sendable {
     let type: String  // "usage_update"

--- a/apple/AgentDeckTests/ProtocolTests.swift
+++ b/apple/AgentDeckTests/ProtocolTests.swift
@@ -762,6 +762,20 @@ final class ProtocolTests: XCTestCase {
         ))
     }
 
+    func testCodexPlanMatchUsesTheSameNormalizationAsTheDisplayTable() {
+        // The account tier comes from the auth token and the snapshot tier from
+        // the rollout stamp — different producers. A spelling the display table
+        // absorbs must not still read as a mismatch, or every candidate is voided
+        // and the sandboxed daemon (no live query) has nothing left to show.
+        XCTAssertTrue(CodexPlanRules.snapshotMatchesAccountPlan(snapshot: "pro_lite", account: "prolite"))
+        XCTAssertTrue(CodexPlanRules.snapshotMatchesAccountPlan(snapshot: "prolite", account: "pro lite"))
+        XCTAssertTrue(CodexPlanRules.snapshotMatchesAccountPlan(snapshot: "Pro-Lite", account: "prolite"))
+        XCTAssertFalse(CodexPlanRules.snapshotMatchesAccountPlan(snapshot: "plus", account: "pro_lite"))
+        // Nothing but separators is unknown, not void.
+        XCTAssertTrue(CodexPlanRules.snapshotMatchesAccountPlan(snapshot: "-", account: "prolite"))
+        XCTAssertTrue(CodexPlanRules.isFreePlan(" FREE "))
+    }
+
     func testChatGPTPlanNamesATierTheBuildPredates() {
         // `prolite` arrived unannounced on 2026-08-22. An unrecognised tier is
         // capitalised, never dropped and never shown as the raw token.

--- a/apple/AgentDeckTests/ProtocolTests.swift
+++ b/apple/AgentDeckTests/ProtocolTests.swift
@@ -647,6 +647,131 @@ final class ProtocolTests: XCTestCase {
         XCTAssertTrue(before.contains(secondary.path))
     }
 
+    // MARK: - Plan-aware rollout selection (mirror of codexSnapshotOutranks)
+
+    /// Both lines are VERBATIM from `~/.codex/sessions` on 2026-08-22, minutes
+    /// after a ChatGPT plan upgrade. Codex stamps `plan_type` from the auth token
+    /// its process started with, so a session opened BEFORE the upgrade keeps
+    /// writing the retired tier — and, being the busy session, keeps minting the
+    /// newest timestamps too. A newest-wins picker therefore feeds
+    /// `codexRateLimitsPayload` a snapshot it voids one step later, and every
+    /// Codex gauge goes blank while a valid snapshot sits unread on disk.
+    ///
+    /// This matters most for the sandboxed App Store daemon: it cannot spawn
+    /// `codex app-server`, so the rollout tree is its ONLY source. The Node
+    /// daemon gates the identical bytes in
+    /// bridge/src/__tests__/codex-rate-limits.test.ts — a fixture composed from
+    /// what the parser expects cannot fail the way a real line does.
+    private var retiredPlanRolloutLine: String {
+        #"{"timestamp":"2026-08-21T16:52:53.766Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":65005105,"cached_input_tokens":63284992,"cache_write_input_tokens":0,"output_tokens":269731,"reasoning_output_tokens":64427,"total_tokens":65274836},"last_token_usage":{"input_tokens":164545,"cached_input_tokens":163840,"cache_write_input_tokens":0,"output_tokens":140,"reasoning_output_tokens":47,"total_tokens":164685},"model_context_window":258400},"rate_limits":{"limit_id":"codex_bengalfox","limit_name":"GPT-5.3-Codex-Spark","primary":{"used_percent":0.0,"window_minutes":300,"resets_at":1787349167},"secondary":{"used_percent":0.0,"window_minutes":10080,"resets_at":1787934922},"credits":{"has_credits":false,"unlimited":false,"balance":"0"},"individual_limit":null,"spend_control_reached":null,"plan_type":"plus","rate_limit_reached_type":null}}}"#
+    }
+
+    private var currentPlanRolloutLine: String {
+        #"{"timestamp":"2026-08-21T16:43:09.009Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":17356,"cached_input_tokens":11008,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":17361},"last_token_usage":{"input_tokens":17356,"cached_input_tokens":11008,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":17361},"model_context_window":258400},"rate_limits":{"limit_id":"codex","limit_name":null,"primary":{"used_percent":0.0,"window_minutes":10080,"resets_at":1787934975},"secondary":null,"credits":{"has_credits":false,"unlimited":false,"balance":"0"},"individual_limit":null,"spend_control_reached":null,"plan_type":"prolite","rate_limit_reached_type":null}}}"#
+    }
+
+    func testCodexRolloutSelectionPrefersTheAccountPlanOverRecency() throws {
+        let root = try makeCodexSessionsTree([
+            // Pre-upgrade session: newer capture AND newer mtime.
+            ("2026/08/21/rollout-2026-08-21T20-35-38-old.jsonl",
+             retiredPlanRolloutLine + "\n",
+             "2026-08-21T16:51:26Z"),
+            // Post-upgrade session: older, and the only usable snapshot.
+            ("2026/08/22/rollout-2026-08-22T01-43-04-new.jsonl",
+             currentPlanRolloutLine + "\n",
+             "2026-08-21T16:43:10Z"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let candidates = UsageAPIClient.codexRolloutCandidates(sessionsDir: root)
+        let parsed = UsageAPIClient.parseFirstUsableCodexRollout(candidates, accountPlan: "prolite")
+        XCTAssertEqual(parsed?.planType, "prolite")
+        XCTAssertEqual(parsed?.capturedAt, "2026-08-21T16:43:09.009Z")
+    }
+
+    func testCodexRolloutSelectionKeepsNewestWinsWhenAccountPlanUnknown() throws {
+        // An API-key install reports no account tier. Absence is "no
+        // information" — it must never reshuffle real data.
+        let root = try makeCodexSessionsTree([
+            ("2026/08/21/rollout-old.jsonl", retiredPlanRolloutLine + "\n", "2026-08-21T16:51:26Z"),
+            ("2026/08/22/rollout-new.jsonl", currentPlanRolloutLine + "\n", "2026-08-21T16:43:10Z"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parsed = UsageAPIClient.parseFirstUsableCodexRollout(
+            UsageAPIClient.codexRolloutCandidates(sessionsDir: root)
+        )
+        XCTAssertEqual(parsed?.planType, "plus")
+    }
+
+    func testCodexRolloutSelectionStillReturnsASoleMismatchedSnapshot() throws {
+        // Ranking orders snapshots; it never rescues one. `codexRateLimitsPayload`
+        // voids this downstream — but "no snapshot" and "a voided snapshot" are
+        // different wire payloads, and only the second carries the live tier that
+        // keeps the subscription row readable.
+        let root = try makeCodexSessionsTree([
+            ("2026/08/21/rollout-old.jsonl", retiredPlanRolloutLine + "\n", "2026-08-21T16:51:26Z"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parsed = UsageAPIClient.parseFirstUsableCodexRollout(
+            UsageAPIClient.codexRolloutCandidates(sessionsDir: root), accountPlan: "prolite"
+        )
+        XCTAssertEqual(parsed?.planType, "plus")
+    }
+
+    func testCodexRolloutCacheKeyTracksTheAccountPlan() {
+        // The selection is plan-aware, so the same files rank differently the
+        // instant the tier changes. A files-only key would serve the pre-upgrade
+        // winner until some rollout happened to be touched again.
+        let rollout = URL(fileURLWithPath: "/tmp/rollout-leading.jsonl")
+        XCTAssertNotEqual(
+            UsageAPIClient.codexRolloutCacheKey([(rollout, 200)], accountPlan: "plus"),
+            UsageAPIClient.codexRolloutCacheKey([(rollout, 200)], accountPlan: "prolite")
+        )
+    }
+
+    func testCodexSnapshotOutranksPutsPlanAgreementAboveAge() {
+        // Mirror of the TS `codexSnapshotOutranks` cases.
+        XCTAssertTrue(CodexPlanRules.snapshotOutranks(
+            candidatePlan: "prolite", candidateCapturedAt: 100,
+            incumbentPlan: "plus", incumbentCapturedAt: 100_000,
+            account: "prolite"
+        ))
+        XCTAssertFalse(CodexPlanRules.snapshotOutranks(
+            candidatePlan: "plus", candidateCapturedAt: 100_000,
+            incumbentPlan: "prolite", incumbentCapturedAt: 100,
+            account: "prolite"
+        ))
+        // Same match class → recency; exact tie keeps the incumbent.
+        XCTAssertTrue(CodexPlanRules.snapshotOutranks(
+            candidatePlan: "prolite", candidateCapturedAt: 101,
+            incumbentPlan: "prolite", incumbentCapturedAt: 100,
+            account: "prolite"
+        ))
+        XCTAssertFalse(CodexPlanRules.snapshotOutranks(
+            candidatePlan: "prolite", candidateCapturedAt: 100,
+            incumbentPlan: "prolite", incumbentCapturedAt: 100,
+            account: "prolite"
+        ))
+        // Unknown account tier → pure recency, nothing reshuffled.
+        XCTAssertTrue(CodexPlanRules.snapshotOutranks(
+            candidatePlan: "plus", candidateCapturedAt: 101,
+            incumbentPlan: "prolite", incumbentCapturedAt: 100,
+            account: nil
+        ))
+    }
+
+    func testChatGPTPlanNamesATierTheBuildPredates() {
+        // `prolite` arrived unannounced on 2026-08-22. An unrecognised tier is
+        // capitalised, never dropped and never shown as the raw token.
+        XCTAssertEqual(ChatGPTPlan.displayName("prolite"), "ChatGPT Pro Lite")
+        XCTAssertEqual(ChatGPTPlan.displayName("pro_lite"), "ChatGPT Pro Lite")
+        XCTAssertEqual(ChatGPTPlan.displayName(" Pro Lite "), "ChatGPT Pro Lite")
+        XCTAssertEqual(ChatGPTPlan.displayName("plus"), "ChatGPT Plus")
+        XCTAssertEqual(ChatGPTPlan.displayName("nebula"), "ChatGPT Nebula")
+    }
+
     private func codexRolloutLine(usedPercent: Double, timestamp: String?) -> String {
         let ts = timestamp.map { "\"timestamp\":\"\($0)\"," } ?? ""
         return "{\(ts)\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"rate_limits\":"

--- a/bridge/src/__tests__/codex-rate-limits-live.test.ts
+++ b/bridge/src/__tests__/codex-rate-limits-live.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import {
   parseLiveCodexRateLimits,
-  pickFresherCodexRateLimits,
+  pickBestCodexRateLimits,
   shouldQueryCodexRateLimitsLive,
   queryCodexRateLimitsLive,
   codexSpawnPlan,
@@ -70,7 +70,7 @@ describe('parseLiveCodexRateLimits', () => {
   });
 });
 
-describe('pickFresherCodexRateLimits', () => {
+describe('pickBestCodexRateLimits', () => {
   const at = (iso: string, usedPercent: number) => ({
     primary: { usedPercent, windowMinutes: 10080 },
     capturedAt: iso,
@@ -79,26 +79,47 @@ describe('pickFresherCodexRateLimits', () => {
   it('prefers the newer capture', () => {
     const passive = at('2026-08-04T18:38:42.076Z', 94);
     const live = at('2026-08-05T12:18:00.000Z', 100);
-    expect(pickFresherCodexRateLimits(passive, live)).toBe(live);
+    expect(pickBestCodexRateLimits(passive, live)).toBe(live);
   });
 
   it('keeps a passive reading that is newer than the cached live one', () => {
     const passive = at('2026-08-05T13:00:00.000Z', 3);
     const live = at('2026-08-05T12:18:00.000Z', 100);
-    expect(pickFresherCodexRateLimits(passive, live)).toBe(passive);
+    expect(pickBestCodexRateLimits(passive, live)).toBe(passive);
   });
 
   it('handles either side being absent', () => {
     const live = at('2026-08-05T12:18:00.000Z', 100);
-    expect(pickFresherCodexRateLimits(null, live)).toBe(live);
-    expect(pickFresherCodexRateLimits(live, null)).toBe(live);
-    expect(pickFresherCodexRateLimits(null, null)).toBeNull();
+    expect(pickBestCodexRateLimits(null, live)).toBe(live);
+    expect(pickBestCodexRateLimits(live, null)).toBe(live);
+    expect(pickBestCodexRateLimits(null, null)).toBeNull();
   });
 
   it('lets a stamped snapshot beat an unstamped one', () => {
     const unstamped = { primary: { usedPercent: 94, windowMinutes: 10080 } };
     const live = at('2026-08-05T12:18:00.000Z', 100);
-    expect(pickFresherCodexRateLimits(unstamped, live)).toBe(live);
+    expect(pickBestCodexRateLimits(unstamped, live)).toBe(live);
+  });
+
+  it('takes the live reading over a NEWER rollout minted under the old plan', () => {
+    // The 2026-08-22 upgrade: a Codex session opened before the plan change kept
+    // writing `plus` snapshots with the newest timestamps, so the live answer —
+    // correct, current, and the only source carrying the new tier — lost every
+    // comparison and was then voided as a mismatch. Recency picked the one
+    // snapshot guaranteed to be discarded.
+    const passive = { ...at('2026-08-21T16:40:29.100Z', 66), planType: 'plus' };
+    const live = { ...at('2026-08-21T16:35:00.000Z', 0), planType: 'prolite' };
+    expect(pickBestCodexRateLimits(passive, live, 'prolite')).toBe(live);
+    // Without a known account tier nothing is reshuffled: recency still rules.
+    expect(pickBestCodexRateLimits(passive, live, undefined)).toBe(passive);
+  });
+
+  it('still prefers a fresh passive reading once the rollout carries the new plan', () => {
+    // The rescue must not become permanent: a rollout written by a session
+    // started after the upgrade is the cheaper, more exact source again.
+    const passive = { ...at('2026-08-22T01:43:09.000Z', 12), planType: 'prolite' };
+    const live = { ...at('2026-08-22T01:35:00.000Z', 0), planType: 'prolite' };
+    expect(pickBestCodexRateLimits(passive, live, 'prolite')).toBe(passive);
   });
 });
 
@@ -123,6 +144,45 @@ describe('shouldQueryCodexRateLimitsLive', () => {
         lastAttemptMs: 0,
         consecutiveFailures: 0,
         passiveCapturedAtMs: now - 30 * 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('queries a fresh passive snapshot when its plan is one the account no longer holds', () => {
+    // "The rollout is writing fresh readings" is only a reason to skip if those
+    // readings are usable. A snapshot stamped with a retired plan is voided
+    // downstream, so honouring its freshness suppressed the one source that
+    // still had a number — precisely while Codex was being used hardest.
+    expect(
+      shouldQueryCodexRateLimitsLive({
+        nowMs: now,
+        lastAttemptMs: 0,
+        consecutiveFailures: 0,
+        passiveCapturedAtMs: now - 30 * 1000,
+        passivePlanMatchesAccount: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not let a plan mismatch defeat the spawn throttles', () => {
+    // A mismatch is a reason to PREFER the live read, never a licence to spawn a
+    // subprocess on every usage build (they are built several times a minute).
+    expect(
+      shouldQueryCodexRateLimitsLive({
+        nowMs: now,
+        lastAttemptMs: now - 60 * 1000,
+        consecutiveFailures: 0,
+        passiveCapturedAtMs: now - 30 * 1000,
+        passivePlanMatchesAccount: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldQueryCodexRateLimitsLive({
+        nowMs: now,
+        lastAttemptMs: now - 6 * 60 * 1000,
+        consecutiveFailures: 3,
+        passiveCapturedAtMs: now - 30 * 1000,
+        passivePlanMatchesAccount: false,
       }),
     ).toBe(false);
   });

--- a/bridge/src/__tests__/codex-rate-limits.test.ts
+++ b/bridge/src/__tests__/codex-rate-limits.test.ts
@@ -276,6 +276,94 @@ describe('pickCodexRateLimits (file selection across day-dirs)', () => {
  * no `rate_limits`, so mtime drifts forward while the newest usage reading stays
  * put, under-reporting the age of exactly the frozen snapshot it must expose.
  */
+/**
+ * Plan-aware selection. Both lines below are VERBATIM from
+ * `~/.codex/sessions` on 2026-08-22, minutes after a ChatGPT plan upgrade:
+ *
+ *   • the `plus` line comes from a Codex session opened BEFORE the upgrade and
+ *     still running — Codex stamps `plan_type` from the auth token its process
+ *     started with, so it keeps writing the retired tier, and being the busy
+ *     session it also keeps minting the newest timestamps (16:50 here).
+ *   • the `prolite` line comes from a session started AFTER the upgrade. Older
+ *     (16:43), and the only snapshot the account can actually use.
+ *
+ * A newest-wins picker returns the `plus` one, `normalizeCodexRateLimits` voids
+ * it as a plan mismatch, and every Codex gauge goes blank for as long as the old
+ * session stays open — with a valid snapshot unread on disk the whole time.
+ *
+ * Fixtures are copied, not composed: a line built from what the parser expects
+ * cannot fail the way a real one does.
+ */
+describe('pickCodexRateLimits (plan-aware selection)', () => {
+  const tmpRoots: string[] = [];
+
+  afterEach(() => {
+    for (const r of tmpRoots.splice(0)) {
+      try {
+        fs.rmSync(r, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  // Captured verbatim from a rollout written by a pre-upgrade Codex session.
+  const retiredPlanLine =
+    "{\"timestamp\":\"2026-08-21T16:51:25.441Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":64019700,\"cached_input_tokens\":62304000,\"cache_write_input_tokens\":0,\"output_tokens\":269177,\"reasoning_output_tokens\":64317,\"total_tokens\":64288877},\"last_token_usage\":{\"input_tokens\":163728,\"cached_input_tokens\":162816,\"cache_write_input_tokens\":0,\"output_tokens\":81,\"reasoning_output_tokens\":29,\"total_tokens\":163809},\"model_context_window\":258400},\"rate_limits\":{\"limit_id\":\"codex_bengalfox\",\"limit_name\":\"GPT-5.3-Codex-Spark\",\"primary\":{\"used_percent\":0.0,\"window_minutes\":300,\"resets_at\":1787349069},\"secondary\":{\"used_percent\":0.0,\"window_minutes\":10080,\"resets_at\":1787934922},\"credits\":{\"has_credits\":false,\"unlimited\":false,\"balance\":\"0\"},\"individual_limit\":null,\"spend_control_reached\":null,\"plan_type\":\"plus\",\"rate_limit_reached_type\":null}}}";
+  // Captured verbatim from a rollout written by a post-upgrade Codex session.
+  const currentPlanLine =
+    "{\"timestamp\":\"2026-08-21T16:43:09.009Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":17356,\"cached_input_tokens\":11008,\"cache_write_input_tokens\":0,\"output_tokens\":5,\"reasoning_output_tokens\":0,\"total_tokens\":17361},\"last_token_usage\":{\"input_tokens\":17356,\"cached_input_tokens\":11008,\"cache_write_input_tokens\":0,\"output_tokens\":5,\"reasoning_output_tokens\":0,\"total_tokens\":17361},\"model_context_window\":258400},\"rate_limits\":{\"limit_id\":\"codex\",\"limit_name\":null,\"primary\":{\"used_percent\":0.0,\"window_minutes\":10080,\"resets_at\":1787934975},\"secondary\":null,\"credits\":{\"has_credits\":false,\"unlimited\":false,\"balance\":\"0\"},\"individual_limit\":null,\"spend_control_reached\":null,\"plan_type\":\"prolite\",\"rate_limit_reached_type\":null}}}";
+
+  function makeTree(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-plan-'));
+    tmpRoots.push(root);
+    const files: Record<string, { content: string; mtimeMs: number }> = {
+      // The pre-upgrade session is the busiest one, so it also has the newest
+      // mtime — it wins the candidate ordering too, not just the timestamps.
+      '2026/08/21/rollout-2026-08-21T20-35-38-old.jsonl': {
+        content: retiredPlanLine + '\n',
+        mtimeMs: Date.parse('2026-08-21T16:51:26.000Z'),
+      },
+      '2026/08/22/rollout-2026-08-22T01-43-04-new.jsonl': {
+        content: currentPlanLine + '\n',
+        mtimeMs: Date.parse('2026-08-21T16:43:10.000Z'),
+      },
+    };
+    for (const [rel, { content, mtimeMs }] of Object.entries(files)) {
+      const full = path.join(root, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+      const t = new Date(mtimeMs);
+      fs.utimesSync(full, t, t);
+    }
+    return root;
+  }
+
+  it('takes the older snapshot that matches the account tier', () => {
+    const result = pickCodexRateLimits(makeTree(), 'prolite');
+    expect(result).not.toBeNull();
+    expect(result!.planType).toBe('prolite');
+  });
+
+  it('keeps pure newest-wins when the account tier is unknown', () => {
+    // An API-key install reports no tier. Absence must not reshuffle real data.
+    const result = pickCodexRateLimits(makeTree(), undefined);
+    expect(result!.planType).toBe('plus');
+  });
+
+  it('still returns a mismatched snapshot when it is the only one', () => {
+    // Ranking orders snapshots; it never rescues one. The caller voids this
+    // downstream — but "no snapshot at all" and "a voided snapshot" are
+    // different wire payloads, and only the second one carries the live tier.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-plan-solo-'));
+    tmpRoots.push(root);
+    const full = path.join(root, '2026/08/21/rollout-old.jsonl');
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, retiredPlanLine + '\n');
+    expect(pickCodexRateLimits(root, 'prolite')!.planType).toBe('plus');
+  });
+});
+
 describe('capturedAt (snapshot freshness anchor)', () => {
   const tmpRoots: string[] = [];
 

--- a/bridge/src/bridge-core.ts
+++ b/bridge/src/bridge-core.ts
@@ -405,6 +405,12 @@ export class BridgeCore {
   /** Build and return a usage event */
   buildUsage(): BridgeEvent {
     const snapshot = this.stateMachine.getSnapshot();
+    // Read the account tier ONCE and hand the same value to every consumer: the
+    // rollout picker, the live-query gate and the void rule all reconcile against
+    // it, and two reads a moment apart could straddle a token refresh and
+    // disagree about which plan this build belongs to.
+    const codexAuth = readCodexAuthStatus();
+    const codexAccountPlan = codexAuth?.planType;
     return buildUsageEvent(
       snapshot,
       this.cachedApiUsage,
@@ -412,7 +418,7 @@ export class BridgeCore {
       this.cachedOllamaStatus,
       this.cachedMlxModels,
       this.apiUsageStale,
-      readCodexAuthStatus(),
+      codexAuth,
       snapshot.billingType,
       this.cachedModelCatalog,
       this.cachedAntigravityStatus,
@@ -422,7 +428,17 @@ export class BridgeCore {
       // — including the moment it hits the wall — so the daemon backs it with a
       // throttled live query against the user's own `codex app-server`. Session
       // bridges keep the passive read only (no host-side processes there).
-      this.isDaemon ? codexRateLimitsWithLiveRefresh(readCodexRateLimits()) : readCodexRateLimits(),
+      // The account tier rides into both readers: a rollout stamped with a plan
+      // the account no longer holds is voided downstream, so it must not win the
+      // selection on recency (a Codex session left open across a plan change
+      // keeps minting exactly such snapshots), and its freshness must not
+      // suppress the live query that carries the only usable number.
+      this.isDaemon
+        ? codexRateLimitsWithLiveRefresh(
+            readCodexRateLimits(undefined, codexAccountPlan),
+            codexAccountPlan,
+          )
+        : readCodexRateLimits(undefined, codexAccountPlan),
     );
   }
 

--- a/bridge/src/codex-rate-limits-live.ts
+++ b/bridge/src/codex-rate-limits-live.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { codexSnapshotMatchesAccountPlan, codexSnapshotOutranks } from '@agentdeck/shared';
 import type { CodexCredits, CodexRateLimits, CodexRateLimitWindow } from '@agentdeck/shared';
 
 /**
@@ -238,17 +239,31 @@ function capturedAtMs(rl?: CodexRateLimits | null): number {
 }
 
 /**
- * Choose the snapshot that was captured more recently. A snapshot with no
- * `capturedAt` at all loses to a stamped one; ties keep the passive reading,
- * which is the on-disk ground truth. Exported for unit testing.
+ * Choose between the passive rollout reading and the live app-server reading.
+ *
+ * Plan agreement first, capture time second (`codexSnapshotOutranks`). Recency
+ * alone let the wrong one win in exactly the case the live query exists to
+ * cover: a Codex session opened before a plan change keeps writing old-plan
+ * rollout snapshots with ever-newer timestamps, so the live answer — correct,
+ * current, and the ONLY source carrying the new tier — lost every comparison and
+ * was then voided as a mismatch. A snapshot with no `capturedAt` at all loses to
+ * a stamped one within its match class; ties keep the passive reading, which is
+ * the on-disk ground truth. Exported for unit testing.
  */
-export function pickFresherCodexRateLimits(
+export function pickBestCodexRateLimits(
   passive: CodexRateLimits | null,
   live: CodexRateLimits | null,
+  accountPlan?: string,
 ): CodexRateLimits | null {
   if (!live) return passive;
   if (!passive) return live;
-  return capturedAtMs(live) > capturedAtMs(passive) ? live : passive;
+  return codexSnapshotOutranks(
+    { planType: live.planType, capturedAtMs: capturedAtMs(live) },
+    { planType: passive.planType, capturedAtMs: capturedAtMs(passive) },
+    accountPlan,
+  )
+    ? live
+    : passive;
 }
 
 /** Throttle policy, kept pure so the cadence is testable without spawning. */
@@ -257,13 +272,34 @@ export function shouldQueryCodexRateLimitsLive(input: {
   lastAttemptMs: number;
   consecutiveFailures: number;
   passiveCapturedAtMs: number;
+  /** False when the passive snapshot is stamped with a plan the account no
+   *  longer holds — i.e. it is about to be voided and carries no usable number.
+   *  Defaults to true so callers that know no account tier behave as before. */
+  passivePlanMatchesAccount?: boolean;
 }): boolean {
-  const { nowMs, lastAttemptMs, consecutiveFailures, passiveCapturedAtMs } = input;
+  const {
+    nowMs,
+    lastAttemptMs,
+    consecutiveFailures,
+    passiveCapturedAtMs,
+    passivePlanMatchesAccount = true,
+  } = input;
   const interval =
     consecutiveFailures >= MAX_CONSECUTIVE_FAILURES ? FAILURE_BACKOFF_MS : MIN_QUERY_INTERVAL_MS;
+  // Spawn throttles are unconditional: a mismatch is a reason to prefer the live
+  // read, never a licence to spawn a subprocess on every usage build.
   if (lastAttemptMs > 0 && nowMs - lastAttemptMs < interval) return false;
-  // Codex is mid-turn: the rollout is already writing fresh readings.
-  if (passiveCapturedAtMs > 0 && nowMs - passiveCapturedAtMs < PASSIVE_FRESH_MS) return false;
+  // Codex is mid-turn: the rollout is already writing fresh readings — but only
+  // if those readings are usable at all. A snapshot stamped with a retired plan
+  // is voided downstream, so "the passive read is fresh" would suppress the one
+  // source that still has a number, precisely while Codex is being used hardest.
+  if (
+    passivePlanMatchesAccount &&
+    passiveCapturedAtMs > 0 &&
+    nowMs - passiveCapturedAtMs < PASSIVE_FRESH_MS
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -278,12 +314,20 @@ export function getLiveCodexRateLimits(): CodexRateLimits | null {
 }
 
 /**
- * Daemon entry point: return the fresher of the passive and live readings, and
- * kick off a throttled background refresh when the passive one has gone quiet.
- * Fire-and-forget by design — the current call is answered from cache so usage
- * building never awaits a subprocess.
+ * Daemon entry point: return the better of the passive and live readings, and
+ * kick off a throttled background refresh when the passive one has gone quiet
+ * OR has been minted under a plan the account no longer holds. Fire-and-forget
+ * by design — the current call is answered from cache so usage building never
+ * awaits a subprocess.
+ *
+ * `accountPlan` is the live tier from `auth.json`. Passing it is what lets both
+ * halves of this function tell "old" from "void"; omitting it keeps the previous
+ * newest-wins behaviour.
  */
-export function codexRateLimitsWithLiveRefresh(passive: CodexRateLimits | null): CodexRateLimits | null {
+export function codexRateLimitsWithLiveRefresh(
+  passive: CodexRateLimits | null,
+  accountPlan?: string,
+): CodexRateLimits | null {
   if (process.env.AGENTDECK_CODEX_LIVE_USAGE !== '0') {
     const nowMs = Date.now();
     if (
@@ -293,6 +337,7 @@ export function codexRateLimitsWithLiveRefresh(passive: CodexRateLimits | null):
         lastAttemptMs,
         consecutiveFailures,
         passiveCapturedAtMs: capturedAtMs(passive),
+        passivePlanMatchesAccount: codexSnapshotMatchesAccountPlan(passive?.planType, accountPlan),
       })
     ) {
       inFlight = true;
@@ -314,7 +359,7 @@ export function codexRateLimitsWithLiveRefresh(passive: CodexRateLimits | null):
         });
     }
   }
-  return pickFresherCodexRateLimits(passive, cachedLive);
+  return pickBestCodexRateLimits(passive, cachedLive, accountPlan);
 }
 
 /** Test hook — clears the module-level cache and throttle state. */

--- a/bridge/src/codex-rate-limits.ts
+++ b/bridge/src/codex-rate-limits.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { codexSnapshotOutranks } from '@agentdeck/shared';
 import type { CodexCredits, CodexRateLimits, CodexRateLimitWindow } from '@agentdeck/shared';
 
 /**
@@ -114,17 +115,25 @@ function candidateRolloutFiles(root: string, maxDays = 3, maxFiles = 6): Rollout
   return files.slice(0, maxFiles);
 }
 
-/** Scan every candidate and return the usable rate-limits snapshot with the
- *  newest CAPTURE timestamp.
+/** Scan every candidate and return the best usable rate-limits snapshot.
  *
  * File mtime only identifies which rollouts are active enough to inspect. It
  * cannot decide which ACCOUNT snapshot is newest when several Codex sessions
  * append concurrently: a reasoning/tool line can make one file newest while
  * its last rate_limits line is older than a snapshot in another file. Choosing
- * the first usable file made usage move backwards or appear frozen. */
-function parseFirstUsable(candidates: RolloutCandidate[]): CodexRateLimits | null {
-  let newest: CodexRateLimits | null = null;
-  let newestCapturedAtMs = -Infinity;
+ * the first usable file made usage move backwards or appear frozen.
+ *
+ * `accountPlan` (the live tier from `auth.json`) makes the ranking plan-aware —
+ * see `codexSnapshotOutranks`. Without it a Codex session left open across a
+ * plan change wins on recency forever with a snapshot that is voided one step
+ * later, blanking every gauge while a valid snapshot sits in another rollout.
+ * Omitting it (tests, an API-key install with no tier) keeps pure newest-wins. */
+function parseFirstUsable(
+  candidates: RolloutCandidate[],
+  accountPlan?: string,
+): CodexRateLimits | null {
+  let best: CodexRateLimits | null = null;
+  let bestCapturedAtMs = -Infinity;
   for (const { full, mtime } of candidates) {
     const tail = readTail(full);
     const parsed = tail ? parseCodexRateLimitsFromText(tail) : null;
@@ -136,13 +145,20 @@ function parseFirstUsable(candidates: RolloutCandidate[]): CodexRateLimits | nul
       // snapshot this anchor exists to expose. mtime is the fallback.
       parsed.capturedAt = parsed.capturedAt ?? new Date(mtime).toISOString();
       const capturedAtMs = new Date(parsed.capturedAt).getTime();
-      if (!newest || capturedAtMs > newestCapturedAtMs) {
-        newest = parsed;
-        newestCapturedAtMs = capturedAtMs;
+      if (
+        !best ||
+        codexSnapshotOutranks(
+          { planType: parsed.planType, capturedAtMs },
+          { planType: best.planType, capturedAtMs: bestCapturedAtMs },
+          accountPlan,
+        )
+      ) {
+        best = parsed;
+        bestCapturedAtMs = capturedAtMs;
       }
     }
   }
-  return newest;
+  return best;
 }
 
 /**
@@ -150,8 +166,11 @@ function parseFirstUsable(candidates: RolloutCandidate[]): CodexRateLimits | nul
  * Exported (root-injectable) for unit testing; `readCodexRateLimits` wraps this
  * with mtime caching against the live `~/.codex/sessions` tree.
  */
-export function pickCodexRateLimits(root: string = defaultSessionsRoot()): CodexRateLimits | null {
-  return parseFirstUsable(candidateRolloutFiles(root));
+export function pickCodexRateLimits(
+  root: string = defaultSessionsRoot(),
+  accountPlan?: string,
+): CodexRateLimits | null {
+  return parseFirstUsable(candidateRolloutFiles(root), accountPlan);
 }
 
 /** Read the trailing bytes of a file without slurping the whole rollout (these
@@ -257,12 +276,19 @@ export function parseCodexRateLimitsFromText(text: string): CodexRateLimits | nu
 let cacheKey = '';
 let cacheValue: CodexRateLimits | null = null;
 
-export function readCodexRateLimits(root: string = defaultSessionsRoot()): CodexRateLimits | null {
+export function readCodexRateLimits(
+  root: string = defaultSessionsRoot(),
+  accountPlan?: string,
+): CodexRateLimits | null {
   const candidates = candidateRolloutFiles(root);
-  const key = candidates.map(({ full, mtime }) => `${full}:${mtime}`).join('|');
-  if (key && key === cacheKey) return cacheValue;
+  // The account tier is part of the key, not just the files: the selection is
+  // plan-aware, so the same set of rollouts ranks differently the instant the
+  // user's plan changes. Keying on files alone would serve the pre-upgrade
+  // winner until some rollout happened to be touched again.
+  const key = `${accountPlan ?? ''}|${candidates.map(({ full, mtime }) => `${full}:${mtime}`).join('|')}`;
+  if (candidates.length > 0 && key === cacheKey) return cacheValue;
 
-  const parsed = parseFirstUsable(candidates);
+  const parsed = parseFirstUsable(candidates, accountPlan);
   cacheKey = key;
   cacheValue = parsed;
   return parsed;

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -3369,6 +3369,19 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       // So split the event by half instead of by event: the ACCOUNT half (quota,
       // scoped caps, extra usage, subscriptions, Codex/Ollama, usageStale) comes
       // from the daemon's authoritative aggregate, the SESSION half from the relay.
+      //
+      // That split applies on the `else` branch ONLY. When the relay carries
+      // Claude percentages its event goes out verbatim, so the account half —
+      // `codexRateLimits` included — is the BRIDGE's. Usually identical: both
+      // sides run the same plan-aware rollout read. They can differ only when no
+      // plan-matching rollout exists at all, since the daemon additionally holds
+      // a `codex app-server` reading that a session bridge structurally cannot
+      // (no host processes there) — then successive events alternate between a
+      // real Codex window and a voided one. Left as is deliberately: the only
+      // targeted fix is to overwrite the block from `core.buildUsage()` here, and
+      // that is the call which arms the throttled spawn, on the one path whose
+      // whole history is about not clobbering the dashboard. Tracked as issue
+      // #253, not just as this comment.
       if (hasClaudeData) {
         core.wsServer.broadcast(evt);
       } else {

--- a/bridge/src/usage-event.ts
+++ b/bridge/src/usage-event.ts
@@ -2,24 +2,14 @@ import type { StateSnapshot, UsageEvent } from './types.js';
 import type { ApiUsageData } from './usage-api.js';
 import { getTokenStatus } from './usage-api.js';
 import type { OllamaStatus } from './ollama-probe.js';
-import { adjustUsagePercent, codexSnapshotMatchesAccountPlan, isCodexWindowStale } from '@agentdeck/shared';
+import {
+  adjustUsagePercent,
+  codexSnapshotMatchesAccountPlan,
+  formatChatGptPlanName,
+  isCodexWindowStale,
+} from '@agentdeck/shared';
 import type { CodexAuthStatus } from './codex-auth.js';
 import type { AntigravityStatusInfo, BillingType, CodexRateLimits, CodexRateLimitWindow, ModelCatalogEntry, SubscriptionInfo } from './types.js';
-
-function formatChatGptPlan(planType?: string | null): string | undefined {
-  const raw = planType?.trim();
-  if (!raw) return undefined;
-  switch (raw.toLowerCase()) {
-    case 'free': return 'ChatGPT Free';
-    case 'plus': return 'ChatGPT Plus';
-    case 'pro': return 'ChatGPT Pro';
-    case 'team': return 'ChatGPT Team';
-    case 'enterprise': return 'ChatGPT Enterprise';
-    // Capitalize an unknown plan instead of passing the raw lowercase value
-    // through — it renders beside Plus/Pro/Team in the subscriptions footer.
-    default: return `ChatGPT ${raw.charAt(0).toUpperCase()}${raw.slice(1)}`;
-  }
-}
 
 function formatClaudeSubscription(
   apiUsage?: ApiUsageData | null,
@@ -38,7 +28,7 @@ export function buildSubscriptions(
   antigravityStatus?: AntigravityStatusInfo | null,
 ): SubscriptionInfo[] | undefined {
   const items: SubscriptionInfo[] = [];
-  const chatgptName = formatChatGptPlan(codexAuth?.planType);
+  const chatgptName = formatChatGptPlanName(codexAuth?.planType);
   if (chatgptName) {
     items.push({
       name: chatgptName,

--- a/scripts/generate-codex-freshness-rules.mjs
+++ b/scripts/generate-codex-freshness-rules.mjs
@@ -129,6 +129,11 @@ enum CodexPlanRules {
     /// Unknown on either side matches: absence is "no information", never a
     /// licence to void real data (an API-key install reports no account tier, a
     /// pre-\`plan_type\` rollout reports no snapshot tier).
+    ///
+    /// The emptiness test MUST stay ahead of the equality test: \`planKey\` strips
+    /// separators, so two separator-only values both reduce to "" and, reordered,
+    /// would compare equal and report a positive plan MATCH where the answer is
+    /// "neither side named a tier".
     static func snapshotMatchesAccountPlan(snapshot: String?, account: String?) -> Bool {
         let snap = planKey(snapshot)
         let acct = planKey(account)

--- a/scripts/generate-codex-freshness-rules.mjs
+++ b/scripts/generate-codex-freshness-rules.mjs
@@ -270,6 +270,31 @@ object CodexFreshnessRules {
         return formatSnapshotAge(capturedAt, nowMs) ?: "stale"
     }
 }
+
+/**
+ * Display name for a raw \`chatgpt_plan_type\`.
+ *
+ * Android is a pure consumer of the wire for the SNAPSHOT, but not for this:
+ * the Codex row subtitle formats \`codexPlanType\` itself rather than reading the
+ * pre-formatted \`subscriptions[].name\`, so a hand copy here renders the fallback
+ * capitalisation for any tier it predates while every other surface shows the
+ * real name (\`prolite\` -> "ChatGPT Prolite" vs "ChatGPT Pro Lite", 2026-08-22).
+ *
+ * Keys carry no separators: \`prolite\`, \`pro_lite\` and \`pro lite\` are one plan.
+ * An unrecognised tier is capitalised, never dropped and never shown raw.
+ */
+object ChatGPTPlan {
+    fun displayName(raw: String): String {
+        val trimmed = raw.trim()
+        val key = trimmed.lowercase().filterNot { it.isWhitespace() || it == '_' || it == '-' }
+        return when (key) {
+${Object.entries(rules.planNames)
+        .map(([key, name]) => `            "${key}" -> "${name}"`)
+        .join('\n')}
+            else -> "ChatGPT " + trimmed.replaceFirstChar { it.uppercase() }
+        }
+    }
+}
 `;
 }
 

--- a/scripts/generate-codex-freshness-rules.mjs
+++ b/scripts/generate-codex-freshness-rules.mjs
@@ -122,7 +122,7 @@ enum CodexUsageFreshness {
 enum CodexPlanRules {
     /// True when the ChatGPT tier carries no paid Codex subscription.
     static func isFreePlan(_ plan: String?) -> Bool {
-        return normalized(plan) == "free"
+        return planKey(plan) == "free"
     }
 
     /// True when the snapshot still belongs to the plan the account holds.
@@ -130,8 +130,8 @@ enum CodexPlanRules {
     /// licence to void real data (an API-key install reports no account tier, a
     /// pre-\`plan_type\` rollout reports no snapshot tier).
     static func snapshotMatchesAccountPlan(snapshot: String?, account: String?) -> Bool {
-        let snap = normalized(snapshot)
-        let acct = normalized(account)
+        let snap = planKey(snapshot)
+        let acct = planKey(account)
         if snap.isEmpty || acct.isEmpty { return true }
         return snap == acct
     }
@@ -166,8 +166,19 @@ enum CodexPlanRules {
         return candidateCapturedAt > incumbentCapturedAt
     }
 
-    private static func normalized(_ value: String?) -> String {
-        return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    /// The one comparison form for a raw \`chatgpt_plan_type\`: trimmed,
+    /// lowercased, separators stripped. \`prolite\`, \`pro_lite\` and \`pro lite\` are
+    /// one plan, so they must key the display table AND compare equal — the two
+    /// sides of the plan check come from different producers (the auth token for
+    /// the account tier, the rollout stamp for the snapshot), and normalizing
+    /// only one path would land every candidate in the "mismatch" class for a
+    /// spelling the table exists to absorb. A value that is nothing but
+    /// separators normalizes to "", which reads as unknown, not as void.
+    static func planKey(_ value: String?) -> String {
+        return (value ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
     }
 }
 
@@ -185,8 +196,7 @@ enum CodexPlanRules {
 enum ChatGPTPlan {
     static func displayName(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let key = trimmed.lowercased().filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
-        switch key {
+        switch CodexPlanRules.planKey(trimmed) {
 ${Object.entries(rules.planNames)
         .map(([key, name]) => `        case "${key}": return "${name}"`)
         .join('\n')}
@@ -312,6 +322,16 @@ async function main() {
     ));
   } catch {
     console.error('shared/dist not found — run `pnpm --filter @agentdeck/shared build` first');
+    process.exit(1);
+  }
+  // A STALE dist imports fine and then blows up inside the emitters with an
+  // opaque TypeError. Same cause as a missing dist, so give it the same message
+  // instead of a stack trace: every export this generator reads is checked here.
+  if (staleMs == null || planNames == null) {
+    console.error(
+      'shared/dist predates this generator (missing CODEX_SNAPSHOT_STALE_MS or '
+        + 'CHATGPT_PLAN_DISPLAY_NAMES) — run `pnpm --filter @agentdeck/shared build` first',
+    );
     process.exit(1);
   }
   const rules = { staleMs, planNames };

--- a/scripts/generate-codex-freshness-rules.mjs
+++ b/scripts/generate-codex-freshness-rules.mjs
@@ -26,7 +26,7 @@ const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '.
 const HEADER =
   'GENERATED FILE — DO NOT EDIT.\n' +
   'Source of truth: shared/src/format-utils.ts (CODEX_SNAPSHOT_STALE_MS, codexUsageFootnote,\n' +
-  'codexSnapshotMatchesAccountPlan)\n' +
+  'codexSnapshotMatchesAccountPlan, codexSnapshotOutranks, CHATGPT_PLAN_DISPLAY_NAMES)\n' +
   'Regenerate: pnpm generate-codex-freshness-rules (drift gated by shared/src/__tests__/codex-freshness-rules.test.ts)';
 
 function comment(prefix) {
@@ -136,8 +136,62 @@ enum CodexPlanRules {
         return snap == acct
     }
 
+    /// Rank one snapshot against another for the live account tier.
+    ///
+    /// Recency alone is the wrong ordering: a snapshot that will be VOIDED a step
+    /// later must not first win the selection. Codex stamps \`plan_type\` from the
+    /// auth token the WRITING PROCESS started with, so a session opened before a
+    /// plan change keeps appending old-plan snapshots for as long as it stays
+    /// open — and, being the busiest session, keeps minting the newest timestamps
+    /// too. A newest-wins picker hands the void rule a mismatched snapshot on
+    /// every build and every gauge goes blank, while a valid same-plan snapshot
+    /// sits unread in another rollout.
+    ///
+    /// Plan agreement is the PRIMARY key, age only the tie-break; exact ties keep
+    /// the incumbent. This orders snapshots, it never rescues one — a mismatched
+    /// snapshot that wins for lack of a peer is still voided downstream.
+    ///
+    /// Capture stamps are seconds-since-epoch so "unknown" can be \`-.infinity\`
+    /// and order without a second date parse.
+    static func snapshotOutranks(
+        candidatePlan: String?,
+        candidateCapturedAt: TimeInterval,
+        incumbentPlan: String?,
+        incumbentCapturedAt: TimeInterval,
+        account: String?
+    ) -> Bool {
+        let candidateMatches = snapshotMatchesAccountPlan(snapshot: candidatePlan, account: account)
+        let incumbentMatches = snapshotMatchesAccountPlan(snapshot: incumbentPlan, account: account)
+        if candidateMatches != incumbentMatches { return candidateMatches }
+        return candidateCapturedAt > incumbentCapturedAt
+    }
+
     private static func normalized(_ value: String?) -> String {
         return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+/// Display name for a raw \`chatgpt_plan_type\`.
+///
+/// Generated so the daemons cannot disagree about what an account is called. The
+/// mapping had already drifted into three hand-written Swift call sites once,
+/// each passing an unrecognised plan through verbatim; keeping it hand-mirrored
+/// against the TS copy repeated that at the platform level — OpenAI mints tiers
+/// on its own schedule (\`prolite\` arrived unannounced) and whichever copy was
+/// not updated renders the fallback capitalisation for the same account.
+///
+/// Keys carry no separators: \`prolite\`, \`pro_lite\` and \`pro lite\` are one plan.
+/// An unrecognised tier is capitalised, never dropped and never shown raw.
+enum ChatGPTPlan {
+    static func displayName(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = trimmed.lowercased().filter { !$0.isWhitespace && $0 != "_" && $0 != "-" }
+        switch key {
+${Object.entries(rules.planNames)
+        .map(([key, name]) => `        case "${key}": return "${name}"`)
+        .join('\n')}
+        default: return "ChatGPT " + trimmed.prefix(1).uppercased() + trimmed.dropFirst()
+        }
     }
 }
 `;
@@ -226,13 +280,16 @@ export const OUTPUTS = [
 
 async function main() {
   let staleMs;
+  let planNames;
   try {
-    ({ CODEX_SNAPSHOT_STALE_MS: staleMs } = await import('../shared/dist/format-utils.js'));
+    ({ CODEX_SNAPSHOT_STALE_MS: staleMs, CHATGPT_PLAN_DISPLAY_NAMES: planNames } = await import(
+      '../shared/dist/format-utils.js'
+    ));
   } catch {
     console.error('shared/dist not found — run `pnpm --filter @agentdeck/shared build` first');
     process.exit(1);
   }
-  const rules = { staleMs };
+  const rules = { staleMs, planNames };
   const check = process.argv.includes('--check');
   let drifted = false;
   for (const [rel, emit] of OUTPUTS) {

--- a/shared/src/__tests__/codex-freshness-rules.test.ts
+++ b/shared/src/__tests__/codex-freshness-rules.test.ts
@@ -14,11 +14,17 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { CODEX_SNAPSHOT_STALE_MS, codexUsageFootnote, formatSnapshotAge } from '../format-utils.js';
+import {
+  CHATGPT_PLAN_DISPLAY_NAMES,
+  CODEX_SNAPSHOT_STALE_MS,
+  codexUsageFootnote,
+  formatChatGptPlanName,
+  formatSnapshotAge,
+} from '../format-utils.js';
 import { OUTPUTS, emitSwift, emitKotlin } from '../../../scripts/generate-codex-freshness-rules.mjs';
 
 const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
-const rules = { staleMs: CODEX_SNAPSHOT_STALE_MS };
+const rules = { staleMs: CODEX_SNAPSHOT_STALE_MS, planNames: CHATGPT_PLAN_DISPLAY_NAMES };
 
 describe('codex freshness threshold invariants', () => {
   it('is an absolute duration, not a fraction of any window', () => {
@@ -62,6 +68,33 @@ describe('generated mirrors in sync', () => {
     expect(emitKotlin(rules)).not.toContain('CodexPlanRules');
   });
 
+  it('mirrors the plan-aware RANKING to Swift, not just the void rule', () => {
+    // Voiding alone is not enough on either daemon: a snapshot that will be
+    // voided must not first WIN the selection, or the valid same-plan snapshot
+    // sitting in another rollout is never read. The Swift daemon needs this most
+    // — sandboxed, it cannot spawn `codex app-server` and has no second source.
+    const swift = emitSwift(rules);
+    expect(swift).toContain('static func snapshotOutranks(');
+    // Plan agreement is the PRIMARY key; age only breaks a tie within a class.
+    expect(swift).toContain('if candidateMatches != incumbentMatches { return candidateMatches }');
+    expect(swift).toContain('return candidateCapturedAt > incumbentCapturedAt');
+    expect(emitKotlin(rules)).not.toContain('snapshotOutranks');
+  });
+
+  it('emits every plan display name from the SSOT table, Swift only', () => {
+    // The tier table is generated because OpenAI mints plans unannounced
+    // (`prolite`, 2026-08-22) and a hand mirror updated on one side renders the
+    // same account two different ways. Android consumes the formatted wire name.
+    const swift = emitSwift(rules);
+    expect(swift).toContain('enum ChatGPTPlan');
+    for (const [key, name] of Object.entries(CHATGPT_PLAN_DISPLAY_NAMES)) {
+      expect(swift).toContain(`case "${key}": return "${name}"`);
+    }
+    // Separators are stripped before lookup, so `pro_lite` cannot miss `prolite`.
+    expect(swift).toContain('$0 != "_"');
+    expect(emitKotlin(rules)).not.toContain('ChatGPTPlan');
+  });
+
   it('emits the same three footnote states the TS SSOT resolves', () => {
     for (const src of [emitSwift(rules), emitKotlin(rules)]) {
       expect(src).toContain('"stale"');   // window ended
@@ -75,6 +108,16 @@ describe('generated mirrors in sync', () => {
 describe('TS side still produces what the mirrors promise', () => {
   const NOW = Date.parse('2026-08-05T07:27:00.000Z');
   const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it('names a tier the build predates without dropping it or showing it raw', () => {
+    expect(formatChatGptPlanName('prolite')).toBe('ChatGPT Pro Lite');
+    expect(formatChatGptPlanName('pro_lite')).toBe('ChatGPT Pro Lite');
+    expect(formatChatGptPlanName(' Pro Lite ')).toBe('ChatGPT Pro Lite');
+    // Unrecognised: capitalised, never the raw token and never undefined.
+    expect(formatChatGptPlanName('nebula')).toBe('ChatGPT Nebula');
+    expect(formatChatGptPlanName('')).toBeUndefined();
+    expect(formatChatGptPlanName(undefined)).toBeUndefined();
+  });
 
   it('threshold boundary matches the emitted constant', () => {
     expect(codexUsageFootnote({ resetsAt: '2099-01-01T00:00:00Z' }, ago(CODEX_SNAPSHOT_STALE_MS), NOW))

--- a/shared/src/__tests__/codex-freshness-rules.test.ts
+++ b/shared/src/__tests__/codex-freshness-rules.test.ts
@@ -101,8 +101,16 @@ describe('generated mirrors in sync', () => {
       expect(kotlin).toContain(`"${key}" -> "${name}"`);
     }
     // Separators are stripped before lookup, so `pro_lite` cannot miss `prolite`.
-    expect(swift).toContain('$0 != "_"');
     expect(kotlin).toContain("it == '_'");
+    // ...and Swift strips them in exactly ONE place, shared by the display table
+    // and the match predicate. Two copies is how the display absorbs a spelling
+    // that the predicate then reads as a mismatch — every candidate voided, and
+    // the live query respawned forever to have its answer voided too.
+    expect(swift).toContain('static func planKey(');
+    expect(swift.match(/\$0 != "_"/g) ?? []).toHaveLength(1);
+    expect(swift).toContain('switch CodexPlanRules.planKey(trimmed)');
+    expect(swift).toContain('let snap = planKey(snapshot)');
+    expect(swift).toContain('return planKey(plan) == "free"');
   });
 
   it('emits the same three footnote states the TS SSOT resolves', () => {

--- a/shared/src/__tests__/codex-freshness-rules.test.ts
+++ b/shared/src/__tests__/codex-freshness-rules.test.ts
@@ -81,18 +81,28 @@ describe('generated mirrors in sync', () => {
     expect(emitKotlin(rules)).not.toContain('snapshotOutranks');
   });
 
-  it('emits every plan display name from the SSOT table, Swift only', () => {
+  it('emits every plan display name from the SSOT table to BOTH mirrors', () => {
     // The tier table is generated because OpenAI mints plans unannounced
     // (`prolite`, 2026-08-22) and a hand mirror updated on one side renders the
-    // same account two different ways. Android consumes the formatted wire name.
+    // same account two different ways.
+    //
+    // Kotlin gets a copy even though Android is a pure consumer of the SNAPSHOT:
+    // its Codex row formats the raw `codexPlanType` rather than reading the
+    // pre-formatted `subscriptions[].name`, so the hand copy it used to carry
+    // showed "ChatGPT Prolite" on Android alone while every other surface said
+    // "ChatGPT Pro Lite". Consuming the wire for one field is not consuming it
+    // for all of them.
     const swift = emitSwift(rules);
+    const kotlin = emitKotlin(rules);
     expect(swift).toContain('enum ChatGPTPlan');
+    expect(kotlin).toContain('object ChatGPTPlan');
     for (const [key, name] of Object.entries(CHATGPT_PLAN_DISPLAY_NAMES)) {
       expect(swift).toContain(`case "${key}": return "${name}"`);
+      expect(kotlin).toContain(`"${key}" -> "${name}"`);
     }
     // Separators are stripped before lookup, so `pro_lite` cannot miss `prolite`.
     expect(swift).toContain('$0 != "_"');
-    expect(emitKotlin(rules)).not.toContain('ChatGPTPlan');
+    expect(kotlin).toContain("it == '_'");
   });
 
   it('emits the same three footnote states the TS SSOT resolves', () => {

--- a/shared/src/__tests__/format-utils.test.ts
+++ b/shared/src/__tests__/format-utils.test.ts
@@ -301,6 +301,22 @@ describe('codexSnapshotMatchesAccountPlan', () => {
     expect(codexSnapshotMatchesAccountPlan(' Plus ', 'plus')).toBe(true);
   });
 
+  it('compares the same normalized form the display table is keyed by', () => {
+    // The two sides come from different producers — the auth token names the
+    // account tier, the rollout stamp names the snapshot's — so a spelling the
+    // display table absorbs must not still read as a mismatch here. Otherwise
+    // every candidate lands in the "mismatch" class, ranking has nothing to
+    // prefer, the winner is voided, and the live query is respawned every 5
+    // minutes forever only to have its answer voided too.
+    expect(codexSnapshotMatchesAccountPlan('pro_lite', 'prolite')).toBe(true);
+    expect(codexSnapshotMatchesAccountPlan('prolite', 'pro lite')).toBe(true);
+    expect(codexSnapshotMatchesAccountPlan('Pro-Lite', 'prolite')).toBe(true);
+    // Still a real mismatch when the tiers genuinely differ.
+    expect(codexSnapshotMatchesAccountPlan('plus', 'pro_lite')).toBe(false);
+    // A value that is nothing but separators is unknown, not void.
+    expect(codexSnapshotMatchesAccountPlan('-', 'prolite')).toBe(true);
+  });
+
   it('treats an unknown tier on either side as no information, never as licence to void', () => {
     // API-key installs report no account tier; pre-`plan_type` rollouts report
     // no snapshot tier. Voiding real data on absence is the bug, not the fix.

--- a/shared/src/__tests__/format-utils.test.ts
+++ b/shared/src/__tests__/format-utils.test.ts
@@ -11,6 +11,7 @@ import {
   formatSnapshotAge,
   isCodexSnapshotAged,
   codexSnapshotMatchesAccountPlan,
+  codexSnapshotOutranks,
   isCodexFreePlan,
   scopedLimitClaimsUsageKey,
   codexWindowsBeside,
@@ -306,6 +307,57 @@ describe('codexSnapshotMatchesAccountPlan', () => {
     expect(codexSnapshotMatchesAccountPlan('plus', undefined)).toBe(true);
     expect(codexSnapshotMatchesAccountPlan(undefined, 'free')).toBe(true);
     expect(codexSnapshotMatchesAccountPlan('', '')).toBe(true);
+  });
+});
+
+describe('codexSnapshotOutranks', () => {
+  const T0 = Date.parse('2026-08-22T00:00:00Z');
+
+  it('prefers a plan-matching snapshot over a NEWER mismatched one', () => {
+    // The upgrade case, measured 2026-08-22: a Codex session opened before the
+    // plan change keeps appending `plus` snapshots with ever-newer timestamps
+    // while a session started after it holds the only valid `prolite` reading.
+    // Newest-wins hands the void rule the `plus` one on every build and every
+    // gauge goes blank with a good snapshot unread on disk.
+    const valid = { planType: 'prolite', capturedAtMs: T0 };
+    const staleplan = { planType: 'plus', capturedAtMs: T0 + 600_000 };
+    expect(codexSnapshotOutranks(valid, staleplan, 'prolite')).toBe(true);
+    expect(codexSnapshotOutranks(staleplan, valid, 'prolite')).toBe(false);
+  });
+
+  it('falls back to recency within the same match class', () => {
+    const older = { planType: 'prolite', capturedAtMs: T0 };
+    const newer = { planType: 'prolite', capturedAtMs: T0 + 1 };
+    expect(codexSnapshotOutranks(newer, older, 'prolite')).toBe(true);
+    expect(codexSnapshotOutranks(older, newer, 'prolite')).toBe(false);
+    // Both mismatched: still ordered, because one of them will be all we have.
+    const oldMiss = { planType: 'plus', capturedAtMs: T0 };
+    const newMiss = { planType: 'plus', capturedAtMs: T0 + 1 };
+    expect(codexSnapshotOutranks(newMiss, oldMiss, 'prolite')).toBe(true);
+  });
+
+  it('keeps the incumbent on an exact tie — both scanners walk in priority order', () => {
+    const a = { planType: 'plus', capturedAtMs: T0 };
+    const b = { planType: 'plus', capturedAtMs: T0 };
+    expect(codexSnapshotOutranks(a, b, 'plus')).toBe(false);
+  });
+
+  it('orders an unstamped snapshot below a stamped one of the same class', () => {
+    const unstamped = { planType: 'plus', capturedAtMs: -Infinity };
+    const stamped = { planType: 'plus', capturedAtMs: T0 };
+    expect(codexSnapshotOutranks(unstamped, stamped, 'plus')).toBe(false);
+    // ...but plan agreement still outranks a stamp: an unstamped VALID snapshot
+    // beats a stamped void one, because the void one carries no usable number.
+    const unstampedValid = { planType: 'prolite', capturedAtMs: -Infinity };
+    expect(codexSnapshotOutranks(unstampedValid, stamped, 'prolite')).toBe(true);
+  });
+
+  it('degrades to pure recency when the account tier is unknown', () => {
+    // API-key installs report no tier. Absence must not reshuffle real data.
+    const older = { planType: 'plus', capturedAtMs: T0 };
+    const newer = { planType: 'prolite', capturedAtMs: T0 + 1 };
+    expect(codexSnapshotOutranks(newer, older, undefined)).toBe(true);
+    expect(codexSnapshotOutranks(older, newer, undefined)).toBe(false);
   });
 });
 

--- a/shared/src/format-utils.ts
+++ b/shared/src/format-utils.ts
@@ -314,6 +314,43 @@ export function codexWindowsBeside<T>(
 }
 
 /**
+ * Display name for a raw `chatgpt_plan_type`, keyed by the tier with every
+ * separator removed — `prolite`, `pro_lite` and `pro lite` are one plan.
+ *
+ * SSOT for both daemons: the Swift mirror (`ChatGPTPlan` in
+ * CodexFreshnessRules.generated.swift) is emitted from this table. It used to be
+ * a hand copy, and a tier missing from one copy does not degrade gracefully —
+ * it renders as the fallback capitalisation ("ChatGPT Prolite") on that surface
+ * only, so the same account reads differently on the dashboard and the deck.
+ */
+export const CHATGPT_PLAN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  free: 'ChatGPT Free',
+  plus: 'ChatGPT Plus',
+  pro: 'ChatGPT Pro',
+  prolite: 'ChatGPT Pro Lite',
+  team: 'ChatGPT Team',
+  enterprise: 'ChatGPT Enterprise',
+};
+
+/**
+ * Format a raw `chatgpt_plan_type` for display, or `undefined` when there is no
+ * tier to show.
+ *
+ * An unrecognised tier is capitalised rather than dropped: OpenAI mints new plan
+ * names on its own schedule (`prolite` arrived unannounced), and a tier this
+ * build predates must still read as a plan beside Plus/Pro/Team — never as the
+ * raw lowercase token, and never as nothing.
+ */
+export function formatChatGptPlanName(planType?: string | null): string | undefined {
+  const raw = planType?.trim();
+  if (!raw) return undefined;
+  const key = raw.toLowerCase().replace(/[\s_-]+/g, '');
+  const known = CHATGPT_PLAN_DISPLAY_NAMES[key];
+  if (known) return known;
+  return `ChatGPT ${raw.charAt(0).toUpperCase()}${raw.slice(1)}`;
+}
+
+/**
  * True when the ChatGPT tier carries no paid Codex subscription.
  *
  * The tier string comes from `~/.codex/auth.json` (`chatgpt_plan_type`), which is
@@ -349,6 +386,43 @@ export function codexSnapshotMatchesAccountPlan(
   const account = (accountPlan ?? '').trim().toLowerCase();
   if (!snap || !account) return true;
   return snap === account;
+}
+
+/**
+ * Rank one Codex usage snapshot against another for the live account tier.
+ *
+ * Recency alone is the wrong ordering, because a snapshot that will be VOIDED a
+ * step later must not first win the selection. Codex stamps `plan_type` from the
+ * auth token the WRITING PROCESS started with, so a Codex session opened before
+ * a plan change keeps appending old-plan snapshots for as long as it stays open
+ * — and, being the busiest session, it also keeps minting the newest timestamps.
+ * A newest-wins picker therefore hands `normalizeCodexRateLimits` a mismatched
+ * snapshot on every single build, the windows are voided, and every gauge goes
+ * blank even though a valid same-plan snapshot is sitting right there in another
+ * rollout (measured 2026-08-22: a 20:35 pre-upgrade session out-stamping a 01:43
+ * post-upgrade one indefinitely).
+ *
+ * So plan agreement is the PRIMARY key and age is only the tie-break:
+ *   1. a snapshot matching the account plan outranks one that does not, at any age
+ *   2. within the same match class, the newer `capturedAtMs` wins
+ *   3. exact ties keep the incumbent (both pickers scan in priority order)
+ *
+ * This orders snapshots; it never rescues one. A mismatched snapshot that wins
+ * because it is the only one left is still voided downstream — the point is that
+ * it must not displace a valid peer first.
+ *
+ * `capturedAtMs` is a number, not a string, so both a parsed rollout stamp and
+ * "unknown" (`-Infinity` / `-.infinity`) order without a second date parse.
+ */
+export function codexSnapshotOutranks(
+  candidate: { planType?: string | null; capturedAtMs: number },
+  incumbent: { planType?: string | null; capturedAtMs: number },
+  accountPlan?: string | null,
+): boolean {
+  const candidateMatches = codexSnapshotMatchesAccountPlan(candidate.planType, accountPlan);
+  const incumbentMatches = codexSnapshotMatchesAccountPlan(incumbent.planType, accountPlan);
+  if (candidateMatches !== incumbentMatches) return candidateMatches;
+  return candidate.capturedAtMs > incumbent.capturedAtMs;
 }
 
 /**

--- a/shared/src/format-utils.ts
+++ b/shared/src/format-utils.ts
@@ -344,10 +344,32 @@ export const CHATGPT_PLAN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
 export function formatChatGptPlanName(planType?: string | null): string | undefined {
   const raw = planType?.trim();
   if (!raw) return undefined;
-  const key = raw.toLowerCase().replace(/[\s_-]+/g, '');
-  const known = CHATGPT_PLAN_DISPLAY_NAMES[key];
+  const known = CHATGPT_PLAN_DISPLAY_NAMES[normalizeChatGptPlanKey(raw)];
   if (known) return known;
   return `ChatGPT ${raw.charAt(0).toUpperCase()}${raw.slice(1)}`;
+}
+
+/**
+ * The one comparison form for a raw `chatgpt_plan_type`.
+ *
+ * Trimmed, lowercased, and stripped of separators — `prolite`, `pro_lite` and
+ * `pro lite` are one plan, so they must key the display table AND compare equal.
+ * Normalizing only the display path was an internal contradiction with teeth:
+ * the two sides of the plan check come from different producers (the auth token
+ * for the account tier, the rollout stamp for the snapshot), so a spelling the
+ * table was written to absorb would still land every candidate in the "mismatch"
+ * class — ranking would have nothing to prefer, the winner would be voided, and
+ * on the Node daemon `passivePlanMatchesAccount` would be permanently false, so
+ * `codex app-server` would be spawned every 5 minutes forever and its answer
+ * voided too. The exact failure this module exists to prevent, via a different
+ * spelling.
+ *
+ * A value that is nothing but separators normalizes to `''` — i.e. "unknown",
+ * which the predicate already treats as no information rather than as a licence
+ * to void.
+ */
+export function normalizeChatGptPlanKey(value?: string | null): string {
+  return (value ?? '').trim().toLowerCase().replace(/[\s_-]+/g, '');
 }
 
 /**
@@ -358,7 +380,7 @@ export function formatChatGptPlanName(planType?: string | null): string | undefi
  * rollout snapshots below.
  */
 export function isCodexFreePlan(plan?: string | null): boolean {
-  return (plan ?? '').trim().toLowerCase() === 'free';
+  return normalizeChatGptPlanKey(plan) === 'free';
 }
 
 /**
@@ -382,8 +404,8 @@ export function codexSnapshotMatchesAccountPlan(
   snapshotPlan?: string | null,
   accountPlan?: string | null,
 ): boolean {
-  const snap = (snapshotPlan ?? '').trim().toLowerCase();
-  const account = (accountPlan ?? '').trim().toLowerCase();
+  const snap = normalizeChatGptPlanKey(snapshotPlan);
+  const account = normalizeChatGptPlanKey(accountPlan);
   if (!snap || !account) return true;
   return snap === account;
 }

--- a/shared/src/format-utils.ts
+++ b/shared/src/format-utils.ts
@@ -399,6 +399,13 @@ export function isCodexFreePlan(plan?: string | null): boolean {
  * Unknown on either side → matches. Absence is "no information", never a licence
  * to void real data: an API-key Codex install reports no account tier, and a
  * pre-`plan_type` rollout reports no snapshot tier.
+ *
+ * The emptiness test MUST stay ahead of the equality test, and not because it is
+ * a cheap early-out. Normalization strips separators, so two separator-only
+ * values (`"-"`, `" "`) both reduce to `''` — reordered, they would compare equal
+ * and report a positive plan MATCH where the answer is "neither side named a
+ * tier". Every current caller happens to act the same way on both answers, which
+ * is exactly why the difference would go unnoticed. Mirrored in Swift.
  */
 export function codexSnapshotMatchesAccountPlan(
   snapshotPlan?: string | null,


### PR DESCRIPTION
## Problem

Upgrading a ChatGPT plan (Plus → Pro Lite) blanked every Codex gauge on every surface. Measured on the daemon wire: `codexRateLimits: { planType: "prolite" }` — a block with no windows at all.

The void rule itself was right. A snapshot stamped with a plan the account no longer holds is *meaningless*, not merely old, and neither freshness axis can retire it (`stale` waits on `resetsAt`, which stays days in the future on a weekly window; `capturedAt` only dims). The defect is that voiding ran **after** the snapshot was selected, so the one snapshot guaranteed to be discarded won the selection on every build.

Codex stamps `plan_type` from the auth token its process started with. A session opened before the upgrade therefore keeps writing the retired tier for as long as it stays open — and, being the busiest session, keeps minting the newest timestamps too.

Measured 2026-08-22:

| source | plan | when |
|---|---|---|
| `~/.codex/auth.json` (live tier) | `prolite` | token refresh 01:35 KST |
| rollouts, 8,314 lines, 07-31 → 08-22 | `plus`, never once `prolite` | up to 01:40 KST |
| a session started *after* the refresh | `prolite`, 7d window, valid | 01:43 KST |
| `codex app-server` live read | `prolite`, valid | now |

So a valid snapshot was sitting unread on disk while a mismatched one was picked and voided, over and over.

The rescue path was blocked twice over:

- `shouldQueryCodexRateLimitsLive` skipped the live query whenever the passive read was under 2 minutes old — i.e. whenever Codex was being used at all.
- `pickFresherCodexRateLimits` compared only `capturedAt`, so a live answer that did arrive lost to the newer mismatched passive one, and was then voided as a mismatch.

## Fix

Plan agreement becomes the **primary** key and age the tie-break, via `codexSnapshotOutranks` in the shared SSOT. It orders snapshots and never rescues one: a mismatched snapshot that wins for lack of a peer is still voided downstream, so the explicit windowless payload carrying the live tier is preserved (clients merge retain-on-absent — omitting the key would pin the retired gauge forever).

- `shouldQueryCodexRateLimitsLive` takes `passivePlanMatchesAccount`. A mismatch defeats the freshness skip but **never** the spawn throttles — a mismatch is a reason to prefer the live read, not a licence to spawn a subprocess on every usage build.
- `pickFresherCodexRateLimits` → `pickBestCodexRateLimits` (the old name no longer described the rule).
- Both daemons key their rollout cache on the account tier as well as the files. A files-only key served the pre-upgrade winner until some rollout happened to be touched again.
- **One tier per usage frame**: the plan that ranks the snapshots is the same one that voids them, read once per build on both sides. Two reads a moment apart can straddle a token refresh.
- The plan display table moves to the shared SSOT (`CHATGPT_PLAN_DISPLAY_NAMES` / `formatChatGptPlanName`) and the hand-written Swift `ChatGPTPlan` becomes generated. `prolite` added; separators are stripped before lookup, so `prolite` / `pro_lite` / `pro lite` are one plan. Fixes the subscription row reading "ChatGPT Prolite".

## Why both daemons

Either daemon can own port 9120 and both PRODUCE the wire snapshot, so the rule is generated from the SSOT rather than hand-mirrored (`pnpm generate-codex-freshness-rules`, vitest drift gate). Kotlin gets no copy — Android only consumes the wire.

The Swift daemon is the real beneficiary: sandboxed, it cannot spawn `codex app-server`, so the rollout tree is its **only** source. Node has the live query as a second source; Swift has nothing, so a plan-blind picker leaves it with no recovery path at all.

| mode | path | covered |
|---|---|---|
| Node daemon | plan-aware passive + live rescue | ✅ verified on the wire |
| Node session bridge | plan-aware passive (no subprocess) | ✅ same code path |
| Swift standalone (App Store) | plan-aware passive, tier in the cache key | ✅ XCTest |
| both running (one binds, one relays) | one generated rule, two producers | ✅ drift gate |

## Review round (3 commits)

The first commit was reviewed and two of its findings were real defects, not polish. Both are fixed here rather than deferred, because each reproduced the very failure the PR exists to close:

- **Android was formatting the raw tier itself.** `TopologyRail.codexSubtitle` reads `codexPlanType`, not the pre-formatted `subscriptions[].name`, and carried its own copy of the table — so the same account read "ChatGPT Prolite" on Android and "ChatGPT Pro Lite" everywhere else. `ChatGPTPlan` is now generated for Kotlin too and the drift gate asserts both mirrors carry every SSOT entry. Consuming the wire for one field is not consuming it for all of them.
- **The fix contradicted itself on normalization.** `formatChatGptPlanName` stripped separators; `codexSnapshotMatchesAccountPlan` — which now drives *selection* as well as voiding — still compared raw strings. The two operands come from different producers (auth token vs rollout stamp), so a spelling the display table exists to absorb would still land every candidate in the mismatch class: nothing to prefer, winner voided, and `passivePlanMatchesAccount` permanently false, respawning `codex app-server` every 5 minutes forever only to void its answer too. `normalizeChatGptPlanKey` is now the one comparison form, with a single `CodexPlanRules.planKey` in Swift — and the gate asserts the stripping appears **exactly once** there, not merely that it appears.

Two smaller ones: the generator's "build shared first" guard only covered a *missing* `shared/dist` (a stale one threw an opaque `TypeError` inside the emitters — verified fixed by removing the export and re-running), and the zero-argument `UsageAPIClient.codexRateLimits` was left with no callers while resolving its own tier, which would reintroduce across the pair the hazard the parameterized signature closes within it.

## Known follow-up, deliberately not in this PR

`bridge/src/daemon-server.ts` (~3372) broadcasts a session bridge's usage event **verbatim** when it carries Claude percentages, so the account half — `codexRateLimits` included — comes from the bridge. Session bridges have no live-query path by design, so when *no* plan-matching rollout exists at all, the daemon can hold a valid live snapshot while the bridge relays a voided one, alternating on successive events.

Pre-existing (the bridge/daemon asymmetry predates this change), narrow (needs zero valid rollouts), and not reproducible locally — and the fix would touch the most flicker-sensitive path in the daemon, the one whose comment documents a Claude-gauge regression. Left as a follow-up rather than changed blind.

## Verification

- On a copy of the real two-session tree: plan-blind picks `plus` (→ voided), plan-aware picks `prolite`. The instrument distinguishes the two branches on real data.
- After a daemon restart, on the wire: `codexRateLimits.secondary` 7d 1% / resets 2026-08-28, `planType: prolite`, subscription row "ChatGPT Pro Lite".
- vitest 3,268 passed · macOS XCTest `ProtocolTests` 71 passed · Android JUnit 378 passed · generated mirrors in sync · docs / design-system / coverage gates green.
- CI green on all three commits (7/7 checks each).
- Re-measured under the adversarial condition an hour after the fix landed: the pre-upgrade session is *still* writing `plus` with the newest timestamps (17:08 vs the valid session's 17:04), and the wire still carries a real window — so the ranking is load-bearing right now, not masked by the old session having ended.

Test fixtures are the real 2026-08-22 rollout lines, byte-identical on both daemons — a line composed from what the parser expects cannot fail the way a real one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

