### PR TITLE
Record that an Apple submission is per platform, and that a dead session looks like a bad field

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ builds on [Releases](https://github.com/puritysb/AgentDeck/releases).
 | Channel | Tag | Status |
 |---|---|---|
 | **npm** — `@agentdeck/setup` | `npm-v*` | [1.0.22](https://github.com/puritysb/AgentDeck/releases/tag/npm-v1.0.22) live on the registry |
-| **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [1.0.7 live on both platforms](https://apps.apple.com/app/id6784822497) — build 5201, iPhone/iPad released 2026-08-18 and macOS 2026-08-19 (each verified against the store's own record, not the approval mail). **1.0.8 submitted 2026-08-22** |
+| **Apple App Store** — macOS + iPhone/iPad | `apple-v*` | [1.0.7 live on both platforms](https://apps.apple.com/app/id6784822497) — build 5201, iPhone/iPad released 2026-08-18 and macOS 2026-08-19 (each verified against the store's own record, not the approval mail). **1.0.8 submitted 2026-08-22 on build 5301, both platforms Waiting for Review** (each platform is its own submission draft in App Store Connect — one click per platform, not one for the app) |
 | **Elgato Marketplace** — Stream Deck plugin | `streamdeck-v*` | [1.0.6 live](https://marketplace.elgato.com/product/agentdeck-dce3806b-176e-40f2-be7d-e029bec0f464) — published 2026-08-18, `status: published` on the product page's own payload |
 | **Ulanzi Marketplace** — D200H plugin | `ulanzi-v*` | [1.0.3 release](https://github.com/puritysb/AgentDeck/releases/tag/ulanzi-v1.0.3); submitted 2026-08-07, **still under review** as of 2026-08-20 and never published. The reviewer confirmed on 2026-08-14 that review had begun with no outstanding issues ([details](marketplace/ulanzi/LISTING.md)) |
 | **GitHub Release** — Android APK | `android-v*` | [1.0.10](https://github.com/puritysb/AgentDeck/releases/tag/android-v1.0.10) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -182,6 +182,22 @@ While a version sits in **Waiting for Review**, do not upload a replacement buil
 
 **A rejection is the opposite case, and it moves the tag.** A rejected version keeps its `MARKETING_VERSION`, so the replacement ships under the same Apple version — and rule 6 below requires the tag to match that version exactly. Re-pointing `apple-v<VERSION>` at the fix commit and force-pushing is therefore the intended path (CI derives the build number from `run_number * 100 + run_attempt`, so it stays monotonic across re-tags). The cost is that the tag no longer identifies the commit that produced the build already in the store: after a re-tag, that commit is recoverable only from the earlier workflow run for the same tag (`gh run list --workflow=apple-release.yml`). Record it in the changelog entry rather than relying on the tag.
 
+**Submitting is per platform, and the portal will not tell you that.** `심사에 추가`
+on the iOS version creates an *iOS* submission draft; doing it on macOS creates a
+*second, separate* draft. The panel's back link shows both ("iOS 제출 초안(1개)",
+"macOS 제출 초안(1개)") and each needs its own `심사를 위해 제출`. Submitting one and
+walking away leaves the other sitting in `제출 준비 중` looking done — which is the
+same trap as reading an approval mail without its `(iOS)` / `(macOS)` suffix.
+
+**An App Store Connect session expires mid-edit and the UI does not say so.** The
+save button turns red with an error glyph and nothing explains why; the requests
+behind it are `401` on `PATCH /iris/v1/appStoreVersionLocalizations/…`. It looks
+exactly like a validation failure on the field you just typed. Check the network
+panel before hunting for a bad field, sign in again in the same tab, and press
+save once more — unsaved edits survive the re-auth, so nothing has to be retyped.
+Then reload and re-read every locale: a save that failed this way leaves the form
+looking correct while the server still holds the previous text.
+
 1. Confirm Apple `MARKETING_VERSION` matches between `apple/project.yml` and the Xcode project mirror (`pnpm verify-version` checks this).
 2. Run the Release build and App Store archive verifier described in `CLAUDE.md`.
 3. Tag and push `apple-v<APPLE_VERSION>`; CI archives and uploads to TestFlight.


### PR DESCRIPTION
Docs only, from cutting Apple 1.0.8. Both items read as something other than what they are.

**`심사에 추가` is per platform.** It creates an *iOS* submission draft; doing it on macOS creates a second, separate one. The panel lists both ("iOS 제출 초안(1개)", "macOS 제출 초안(1개)") and each needs its own `심사를 위해 제출` — submitting one leaves the other sitting in `제출 준비 중` looking done. Same shape as the approval mail that says nothing about the other platform, which RELEASING.md already warns about.

**An expired App Store Connect session presents as a validation error.** The save button turns red with an error glyph and no message; the requests behind it are `401` on `PATCH /iris/v1/appStoreVersionLocalizations/…`. Reading the network panel is what separates "your text is invalid" from "your session is gone". Re-authenticating in the same tab and pressing save again works — unsaved edits survive it, so nothing has to be retyped — but the form keeps displaying text the server never accepted, so every locale has to be re-read after a reload.

Also records 1.0.8 in the README delivery table: submitted 2026-08-22 on build 5301, both platforms Waiting for Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
