### PR TITLE
Unblock master: ESP32 1.0.8 release notes + the two preview mirrors fae46ef0 left behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,47 @@ The browser flasher at [/flash/](https://puritysb.github.io/AgentDeck/flash/)
 deploys from `master` and already carries both fixes; this release is the
 terminal half.
 
+## 2026-08-23 — ESP32 1.0.8
+
+A small screen that runs out of room used to just stop drawing sessions. The
+T-Display Pro said `+N more`, the general HUD had no bound at all, and InkDeck's
+fixed grid simply ended — so a session waiting on your input could vanish behind
+a full screen with nothing saying it had. Every ESP32 surface now shares one
+glance order — **input → working → quiet context** — and states what it left
+out: `4 idle hidden`, `hidden: 2 input / 3 working`. What is dropped is now a
+fact on screen rather than an absence.
+
+InkDeck applies the same order past its card capacity and prints the per-state
+hidden counts in its header. The dense terrarium keeps the names of sessions
+that are working or waiting and folds only the idle tags, so the creatures and
+the summary roster split the job instead of competing for the same pixels.
+
+### The IPS 10.1 office says state in more than one channel
+
+The tiny `w` / `z` / `?` letter codes are gone. Idle is still and dimmed with no
+badge at all, working is a cyan spark with a floor halo, awaiting input is an
+amber `!`, error a coral `!`. Shape, motion and contrast now carry the state
+redundantly with colour, so it survives distance and a washed-out panel. In a
+narrow cell the session card gives the one-line name priority over the
+decorative glyph — `OpenCode` and `Antigravity` no longer break mid-name.
+
+### Two rendering defects
+
+- **TC001's awaiting-input pulse went black.** The brightness curve ran through
+  its negative half, so the one state that must never be missed disappeared for
+  part of every cycle. Floored at 45%.
+- **The new bounds allocate nothing.** Fixed arrays and stack buffers only —
+  a render loop that allocates is how a no-PSRAM board OOMs under exactly the
+  crowded scene these bounds exist to handle.
+
+### Verified
+
+Pixel-exact simulator scenes for IPS 10.1 dense and permission, Box dense,
+T-Display Pro crowded Sessions, TC001 permission, and InkDeck dense — plus a new
+10-session `dense` scene kept for future regressions. The e-ink layout
+regression tests pass, as do the PlatformIO builds for `ips35`, `box_86`,
+`led8x32`, `inkdeck`, `t_display_pro` and `ips10`.
+
 ## 2026-08-22 — npm 1.0.23 · ESP32 1.0.7
 
 Firmware was building correctly for ten boards every release and piling up


### PR DESCRIPTION
**Unblocks master.** CI has been red since c1a17a02, with **two** independent defects from `fae46ef0` — and only one of them was visible.

## 1. ESP32 1.0.8 had no release notes

`fae46ef0` bumped `esp32/src/config.h` `FIRMWARE_VERSION` 1.0.7 → 1.0.8 without a matching `CHANGELOG.md` section:

```
AssertionError: CHANGELOG.md has no section for esp32 1.0.8: expected null not to be null
```

That section *is* the GitHub Release body, so the gate is doing its job. Content is taken from the `DEVELOPMENT_LOG.md` entry `fae46ef0` wrote for itself, not composed from the diff. `esp32-v1.0.8` is not tagged — writing the section before the cut is the order `verify-release-version.mjs` expects, since it is the first step of the release workflow.

## 2. The second defect was hiding behind the first

CI's `test` job dies at the **Test** step; **Preview mirror sync check** is a later step and had therefore never run on master. With the CHANGELOG fixed it ran, and reported two stale `SYNC-HASH` pins — the same commit changed `eink_display.cpp` and `matrix_pages.cpp` without re-syncing the Swift mirrors that pin them.

### `MatrixTerminalPreviews.swift`

Awaiting amber `(130, 78, 0)` → `(145, 87, 0)`. The mirror freezes animation at "mid-pulse", and that convention is *the normalized envelope at 0.5* — Claude `(125,75,56)`, Codex `(65,65,160)` and Kiro `(98,60,174)` all fall out of `pulse = 0.5` exactly, and the firmware's Kiro comment pins the correspondence in writing. Awaiting was the one case outside it; the firmware's new `wave = 0.5 + 0.5*sin` brings it back in, so `0.45 + 0.55*0.5 = 0.725`.

`drawStateDot`'s matching floor changes nothing on this mirror — its only callers are `renderUsage` and `renderCodex`, and this preview draws the AGENTS page. That is checked (call sites counted), not assumed.

### `InkDeckPreview.swift`

The glance order (input → working → quiet context), the card capacity, and the `hidden: …` header were **never mirrored at all**. Manual mode clamps `sessionCount` to `{0,1,2,4}` while capacity is 6, so none of the three can change a pixel there — a surface that never runs the code cannot show that it drifted. So this adds a 10-session live snapshot scene, `inkdeck-dense-hidden`, the counterpart to the firmware's own 10-session `dense` simulator scene.

That scene immediately found two more things:

- The longer header can overflow. The firmware answers by dropping to `CLASSIC_FONT`, so the mirror shrinks (`minimumScaleFactor`) rather than truncates — truncating would eat the tally the line exists for.
- The file's *"the first awaiting card inverts to solid black"* was wrong. `drawSessionCard` branches on `awaiting`; `firstAwaiting` gates only the option list on a tall card. Manual mode never produces a second awaiting session, so nothing had contradicted it.

## Verification

Rendered and read the dense scene rather than trusting the gate:

- 6 cards on a 3×2 grid, **all four awaiting first**, then two processing
- header reads `10 sessions | hidden: 2 working / 2 idle`, no truncation
- the four hidden are exactly the 2 processing + 2 idle the header names

Gates: `check-preview-mirror-sync` 10/10 in sync · `AgentDeckTests_macOS` green (full suite, local `xcodebuild test`) · `AgentDeck_macOS` builds · `release-notes.test.ts` 11 passed (was 1 failed) · `docs:check`, `design-system:check` pass.

Pins were recomputed from the files with `git hash-object`, not copied out of the CI message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)