### PR TITLE
Port fae46ef0's render change into the two preview mirrors it left behind

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -69,6 +69,58 @@ platformio 의 `--no-stub` 에서 상속된 값인데, 그 핀은 2026-06 의 `2
 
 ---
 
+## 2026-08-23 — 두 번째 결함은 첫 번째 뒤에 숨어 있었다: master red 와 preview 미러 포팅
+
+### 문제
+
+master 가 `CHANGELOG.md has no section for esp32 1.0.8` 로 red 였다. fae46ef0 이
+FIRMWARE_VERSION 을 1.0.7 → 1.0.8 로 올리면서 CHANGELOG 섹션을 남기지 않았고, 그 섹션이 곧
+GitHub Release body 라 게이트가 막은 것이다.
+
+그런데 그걸 고치자 **두 번째** 실패가 드러났다: 같은 커밋이 `eink_display.cpp` 와
+`matrix_pages.cpp` 를 바꾸면서 Swift preview 미러의 SYNC-HASH 핀 2개를 갱신하지 않았다.
+CI 의 `test` job 은 vitest 단계에서 죽었고 `Preview mirror sync check` 는 **그 뒤 단계**라
+한 번도 실행된 적이 없다. master 는 두 결함을 안고 있었지만 로그에는 하나만 보였다.
+
+### 해결
+
+- CHANGELOG 에 ESP32 1.0.8 섹션 추가. 내용은 diff 가 아니라 fae46ef0 이 자기 devlog 에 쓴
+  기록에서 옮겼다.
+- 두 미러를 실제로 포팅하고 핀을 파일에서 재계산(`git hash-object`)해 갱신했다.
+
+### 핵심 설계 결정
+
+**"mid-pulse" 규약은 정규화된 envelope 을 0.5 로 평가하는 것이다.** MatrixTerminalPreviews
+는 애니메이션을 정지 프레임으로 미러링하는데, 그 값이 무엇인지 어디에도 적혀 있지 않았다.
+역산으로 확정했다 — Claude `(125,75,56)`, Codex `(65,65,160)`, Kiro `(98,60,174)` 가 모두
+`pulse = 0.5` 에서 정확히 나오고, 펌웨어의 Kiro 주석이 그 대응을 명시적으로 못 박고 있다.
+awaiting 은 이 규약을 벗어나 있었는데(`0.3+0.7*sin` 에 sin=0.5 를 대입한 값), 펌웨어가
+`wave = 0.5+0.5*sin` 로 정규화되면서 규약과 다시 맞았다: `0.45+0.55*0.5 = 0.725` →
+`(145,87,0)`.
+
+**`drawStateDot` 은 미러에 영향이 없다 — 확인해서 아는 것이지 추측이 아니다.** 호출부가
+`renderUsage` / `renderCodex` 뿐이고 미러는 AGENTS 페이지만 그린다. 게이트가 요구하는
+"영향 없음 확인"은 이렇게 호출부를 세어서만 할 수 있다.
+
+**InkDeck 미러는 우선순위·정원·hidden 헤더를 아예 구현한 적이 없었다.** 수동 모드
+sessionCount 가 {0,1,2,4} 로 고정이라 정원(6)을 넘을 수 없었고, 넘지 않으면 세 기능 모두
+아무 픽셀도 바꾸지 않는다. **표면이 그 코드를 한 번도 실행하지 않으면 미러가 드리프트한
+사실 자체가 보이지 않는다** — 그래서 10세션 live 스냅샷 씬(`inkdeck-dense-hidden`)을
+영구 아티팩트로 추가했다. 펌웨어가 같은 이유로 10세션 `dense` 시뮬레이터 씬을 둔 것과
+같은 대응이다.
+
+그 씬이 곧바로 두 가지를 더 잡았다. 헤더 문자열이 길어져 잘릴 수 있는데 펌웨어는 폰트를
+낮춰 대응하므로 미러도 `minimumScaleFactor` 로 줄이게 했다(잘라내면 추가한 이유인 tally 가
+사라진다). 그리고 파일 주석의 "the first awaiting card inverts" 는 **틀린 서술**이었다 —
+`drawSessionCard` 는 `awaiting` 으로 분기하고 `firstAwaiting` 은 tall 카드의 옵션 목록만
+게이트한다. 수동 모드가 awaiting 카드를 둘 이상 만들지 못해 반증될 기회가 없었을 뿐이다.
+
+**계측기부터 검증했다.** 스냅샷 하네스가 `TEST SUCCEEDED` 를 냈지만 PNG 는 7월 11일자
+그대로였다 — env 가 러너에 닿지 않아 XCTSkip 이 난 것을 성공으로 읽을 뻔했다. 출력 경로를
+찍어 확인한 뒤에야 렌더된 그림을 봤다.
+
+---
+
 ## 2026-08-23 — 펌웨어를 쓰는 것과 설치하는 것은 다르다: esp32-v1.0.7 / npm-v1.0.23 컷과 두 개의 리셋 결함
 
 ### 문제

--- a/apple/AgentDeck/UI/Preview/Devices/InkDeckPreview.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/InkDeckPreview.swift
@@ -5,15 +5,24 @@
 // the firmware now uses lives in esp32/src/ui/eink/eink_dashboard_layout.h
 // (AgentDeckEink::makeLayout) — a print-style 1-bit 800×480 page with
 //   - brand header: dome-over-deck mark + "AgentDeck" wordmark, a link
-//     chip (filled when connected), session count, double rule at y≈62;
+//     chip (filled when connected), session count, double rule at y≈62. When
+//     the fixed paper grid is full the count says what it collapsed —
+//     "10 sessions | hidden: 2 input / 3 working" — because a session that
+//     vanished behind a full page was indistinguishable from one that ended;
 //   - session card grid: double-outline rounded cards with the agent
 //     creature glyph + project name + state line + a TIMELINE-grade work
 //     summary; a card whose session has active subagents reserves a right
 //     strip for a static miniature orbit + child count (static by design —
-//     e-ink pays for animation in ghosting); the first awaiting card inverts
-//     to solid black with white ink.
+//     e-ink pays for animation in ghosting); every awaiting card inverts to
+//     solid black with white ink (drawSessionCard branches on `awaiting`, not
+//     on `firstAwaiting` — that flag gates only the option list on a tall
+//     card, and this line used to say "the first" because manual mode never
+//     produces a second awaiting session to contradict it).
 //     Columns are chosen by makeLayout: 1 for a lone session, 2 landscape,
-//     3 once five+ sessions share the 800px panel (rows capped at 2);
+//     3 once five+ sessions share the 800px panel (rows capped at 2). Cards
+//     are filled in the firmware's glance order — user input first, then live
+//     work, then quiet context, daemon order preserved within each tier — so
+//     what survives a full grid is what needs a human;
 //   - adaptive usage band (usageRowCount 0/1/2): provider rows (CLAUDE /
 //     CODEX, 5H/7D bar gauges) draw only for providers that actually report
 //     usage, and a missing window is dropped (present ones pack left) rather
@@ -29,7 +38,7 @@
 // fails CI when the firmware drifts ahead of this mirror. Update this view and
 // re-pin whenever the firmware layout changes.
 //
-// SYNC-HASH esp32/src/ui/eink/eink_display.cpp 77c388341d225a3513cb8383899ddc149f822b55
+// SYNC-HASH esp32/src/ui/eink/eink_display.cpp 4203816f0ffb7bc1fccf5495999159d35e6abe4c
 // SYNC-HASH esp32/src/ui/eink/eink_dashboard_layout.h 9179d41777d6e2caff02735607ad7ca210de8bb8
 
 import SwiftUI
@@ -85,8 +94,15 @@ struct InkDeckPreview: View {
                     .foregroundStyle(ink)
                 Spacer(minLength: 8)
                 if selection.sessionCount > 0 {
-                    Text("\(selection.sessionCount) session\(selection.sessionCount == 1 ? "" : "s")")
+                    // The firmware drops the count to CLASSIC_FONT when the
+                    // hidden tally no longer fits the space left of the chip
+                    // (`textWidth(cnt) <= available`). Shrinking is the same
+                    // decision here; truncating would cut the very tally the
+                    // line was added to show.
+                    Text(sessionCountLabel)
                         .font(.system(size: 9))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
                         .foregroundStyle(ink.opacity(0.8))
                 }
                 linkChip
@@ -116,14 +132,78 @@ struct InkDeckPreview: View {
             )
     }
 
+    // MARK: Glance order and hidden counts — prioritizedSessionOrder /
+    //       hiddenSessionSummary (eink_display.cpp)
+
+    /// Firmware glance order: user input first, then live work, then quiet
+    /// context, with daemon order preserved inside each tier. Attention and
+    /// processing used to share one tier, so a permission prompt could sort
+    /// behind a busy session and be the card that fell off the page.
+    private func prioritized(_ sessions: [PreviewDisplaySession]) -> [PreviewDisplaySession] {
+        sessions.filter { $0.state == .awaitingPrompt }
+            + sessions.filter { $0.state == .processing }
+            + sessions.filter { $0.state != .awaitingPrompt && $0.state != .processing }
+    }
+
+    private func columnCount(for count: Int) -> Int {
+        count <= 1 ? 1 : (count >= 5 ? 3 : 2)
+    }
+
+    /// `makeLayout`'s `capacity` — columns × rows, rows capped at 2 on this
+    /// 800×480 landscape page (the firmware additionally derives rows from the
+    /// available height; on a fixed panel that bound is never the tighter one).
+    private func cardCapacity(for count: Int, columns: Int) -> Int {
+        guard count > 0, columns > 0 else { return 0 }
+        return columns * min(2, (count + columns - 1) / columns)
+    }
+
+    /// "2 input / 3 working" — what the fixed paper grid collapsed, by state.
+    /// Empty when everything fits, which is what keeps the plain
+    /// "N sessions" wording for the ordinary case.
+    private func hiddenSummary(_ sessions: [PreviewDisplaySession]) -> String {
+        let columns = columnCount(for: sessions.count)
+        let dropped = prioritized(sessions)
+            .dropFirst(cardCapacity(for: sessions.count, columns: columns))
+        var input = 0, working = 0, idle = 0, offline = 0
+        for session in dropped {
+            switch session.state {
+            case .awaitingPrompt: input += 1
+            case .processing:     working += 1
+            case .idle:           idle += 1
+            case .disconnected:   offline += 1
+            }
+        }
+        return [(input, "input"), (working, "working"), (idle, "idle"), (offline, "offline")]
+            .filter { $0.0 > 0 }
+            .map { "\($0.0) \($0.1)" }
+            .joined(separator: " / ")
+    }
+
+    /// Firmware header count. The total stays `totalSessions` while the hidden
+    /// tally is computed over the rows actually on hand — the same split the
+    /// firmware makes between `s.totalSessions` and `s.rows`.
+    private var sessionCountLabel: String {
+        let total = selection.sessionCount
+        let hidden = hiddenSummary(selection.displaySessions)
+        if hidden.isEmpty {
+            return "\(total) session\(total == 1 ? "" : "s")"
+        }
+        return "\(total) sessions | hidden: \(hidden)"
+    }
+
     // MARK: Session grid — drawSessionGrid / drawSessionCard
 
     private var sessionGrid: some View {
-        let sessions = selection.displaySessions
+        // Glance order first, then the fixed capacity — the firmware fills
+        // cards from `prioritizedSessionOrder` and simply stops at
+        // `layout.capacity`, so what a full page drops is always the quietest
+        // thing, never whatever happened to sort last.
+        let ordered = prioritized(selection.displaySessions)
         // Column count mirrors AgentDeckEink::makeLayout for the 800×480
         // landscape panel: 1 for a lone session, 3 once five+ sessions pack the
         // panel, else 2. (Portrait X3/X4 use a single wide column — N/A here.)
-        let columns = sessions.count <= 1 ? 1 : (sessions.count >= 5 ? 3 : 2)
+        let columns = columnCount(for: ordered.count)
+        let sessions = Array(ordered.prefix(cardCapacity(for: ordered.count, columns: columns)))
         return Group {
             if sessions.isEmpty {
                 // Two distinct empty states, like the firmware: disconnected →
@@ -148,8 +228,9 @@ struct InkDeckPreview: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                // makeLayout caps the grid at 2 card rows; with ≤5 preview
-                // sessions and 2–3 columns the chunking never exceeds that.
+                // makeLayout caps the grid at 2 card rows; `sessions` is already
+                // trimmed to that capacity above, so the chunking cannot exceed
+                // it even in live-follow mode with a crowded daemon.
                 let rows = Array(sessions.enumerated()).chunked(into: columns)
                 VStack(spacing: 6) {
                     ForEach(rows, id: \.first!.offset) { rowEntries in

--- a/apple/AgentDeck/UI/Preview/Devices/MatrixTerminalPreviews.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/MatrixTerminalPreviews.swift
@@ -173,9 +173,11 @@ private struct PixooPixelGrid: View {
 // codex violet numeral + renderGaugePair) render on pages this preview does
 // not draw, so they leave the mirrored AGENTS pixels unchanged; they are
 // documented here so the pin bump below is a conscious "checked, does not
-// affect the AGENTS render" acknowledgement.
+// affect the AGENTS render" acknowledgement. The same applies to
+// drawStateDot's attention floor: that dot is drawn only by renderUsage and
+// renderCodex, never by renderAgents.
 //
-// SYNC-HASH esp32/src/ui/matrix/matrix_pages.cpp b82038ac26992af4ab927906675a7eff6ca69d81
+// SYNC-HASH esp32/src/ui/matrix/matrix_pages.cpp 2a7dce26966db94028f0d69e351e394e6a702501
 // scripts/check-preview-mirror-sync.mjs fails CI when the origin above drifts
 // from this pin — re-verify AGENTS-page parity and bump the hash together.
 
@@ -427,7 +429,12 @@ private enum Tc001Sprites {
             default:           rgb = (125, 75, 56)    // terracotta, mid-pulse
             }
         case .awaitingPrompt:
-            rgb = (130, 78, 0)                     // amber, mid-pulse
+            // Firmware floors the attention pulse at 45% luminance
+            // (`wave = 0.5 + 0.5*sin`, `pulse = 0.45 + 0.55*wave`) — the old
+            // 0.3 + 0.7*sin envelope reached -0.4, underflowed uint8_t and
+            // periodically rendered the whole glyph black. Mid-pulse is the
+            // normalized envelope at 0.5, i.e. 0.725 → (145, 87, 0).
+            rgb = (145, 87, 0)                     // amber, mid-pulse
         case .idle:
             switch agent {
             case .codex:       rgb = (30, 30, 80)

--- a/apple/AgentDeckTests/DevicePreviewSnapshotTests.swift
+++ b/apple/AgentDeckTests/DevicePreviewSnapshotTests.swift
@@ -121,6 +121,11 @@ final class DevicePreviewSnapshotTests: XCTestCase {
         // Round uses the tank-group HUD, IPS10 has its own office + cards pane,
         // TTGO the focused-session metric panel — all now live-aware.)
         try snapshot(InkDeckPreview(selection: livePixooSelection(.inkDeck)), name: "inkdeck-live-emulator")
+        // Dense page — more sessions than the fixed paper grid can hold. This
+        // is the case the glance order exists for: every awaiting card must
+        // survive and the header must name what was collapsed. The firmware
+        // keeps an equivalent 10-session `dense` simulator scene.
+        try snapshot(InkDeckPreview(selection: denseInkDeckSelection()), name: "inkdeck-dense-hidden")
         try snapshot(Esp32Ips10Preview(selection: livePixooSelection(.esp32Ips10)), name: "ips10-live-emulator")
         try snapshot(Esp3286BoxPreview(selection: livePixooSelection(.esp32_86box)), name: "86box-live-emulator")
         try snapshot(Esp32RoundPreview(selection: livePixooSelection(.esp32Round)), name: "round-live-emulator")
@@ -155,6 +160,39 @@ final class DevicePreviewSnapshotTests: XCTestCase {
                         alive: true, state: "idle", modelName: "gpt-5", startedAt: nil),
         ]
         var sel = selection(device, sessions: 2)
+        sel.live = LivePreviewData.from(state)
+        return sel
+    }
+
+    /// Ten live sessions on an 800×480 page that fits six — 4 awaiting,
+    /// 4 processing, 2 idle. Exercises the parts of drawBrandHeader /
+    /// drawSessionGrid that only appear over capacity: every awaiting card
+    /// survives the trim, and the header reports "hidden: 2 working / 2 idle"
+    /// instead of letting four sessions disappear silently.
+    private func denseInkDeckSelection() -> DevicePreviewSelection {
+        var state = DashboardState()
+        state.bridgeConnected = true
+        state.state = .awaitingPermission
+        state.agentType = "claude-code"
+        state.fiveHourPercent = 42
+        state.sevenDayPercent = 68
+        let plan: [(String, String, String)] = [
+            ("AgentDeck", "claude-code", "awaiting_permission"),
+            ("BabelForge", "codex-cli", "awaiting_permission"),
+            ("Terrarium", "opencode", "awaiting_permission"),
+            ("InkDeck", "kiro", "awaiting_permission"),
+            ("Pixoo", "claude-code", "processing"),
+            ("Bridge", "codex-cli", "processing"),
+            ("Flasher", "antigravity", "processing"),
+            ("Docs", "opencode", "processing"),
+            ("Sim", "claude-code", "idle"),
+            ("Plugin", "codex-cli", "idle"),
+        ]
+        state.siblingSessions = plan.enumerated().map { index, row in
+            SessionInfo(id: "d\(index)", port: 9121 + index, projectName: row.0, agentType: row.1,
+                        alive: true, state: row.2, modelName: nil, startedAt: nil)
+        }
+        var sel = selection(.inkDeck, state: .awaitingPrompt, sessions: plan.count)
         sel.live = LivePreviewData.from(state)
         return sel
     }


### PR DESCRIPTION
**Unblocks master**, which is red on `Preview mirror sync check` since b142f2b8.

This is the second half of #258. That PR merged its first commit only, which fixed the `CHANGELOG.md has no section for esp32 1.0.8` failure — and that failure was *hiding* this one: CI's `test` job dies at the **Test** step, and **Preview mirror sync check** is a later step, so on master it had never run. With the CHANGELOG fixed it ran, and reported two stale `SYNC-HASH` pins. `fae46ef0` changed `eink_display.cpp` and `matrix_pages.cpp` without re-syncing the Swift mirrors that pin them.

## `MatrixTerminalPreviews.swift`

Awaiting amber `(130, 78, 0)` → `(145, 87, 0)`.

The mirror freezes animation at "mid-pulse", and that convention is *the normalized envelope at 0.5* — Claude `(125,75,56)`, Codex `(65,65,160)` and Kiro `(98,60,174)` all fall out of `pulse = 0.5` exactly, and the firmware's Kiro comment pins the correspondence in writing. Awaiting was the one case outside it; the firmware's new `wave = 0.5 + 0.5*sin` brings it back in, so `0.45 + 0.55*0.5 = 0.725`.

`drawStateDot`'s matching attention floor changes nothing on this mirror — its only callers are `renderUsage` and `renderCodex`, and this preview draws the AGENTS page. Checked by counting call sites, not assumed.

## `InkDeckPreview.swift`

The glance order (input → working → quiet context), the card capacity, and the `hidden: …` header were **never mirrored at all**. Manual mode clamps `sessionCount` to `{0,1,2,4}` while capacity is 6, so none of the three can change a pixel there — a surface that never runs the code cannot show that it drifted.

So this also adds a 10-session live snapshot scene, `inkdeck-dense-hidden` — the counterpart to the firmware's own 10-session `dense` simulator scene, and the thing that keeps this from silently rotting again.

That scene immediately found two more things:

- The longer header can overflow. The firmware answers by dropping to `CLASSIC_FONT`, so the mirror shrinks (`minimumScaleFactor`) rather than truncates — truncating would eat the tally the line exists for.
- The file's *"the first awaiting card inverts to solid black"* was wrong. `drawSessionCard` branches on `awaiting`; `firstAwaiting` gates only the option list on a tall card. Manual mode never produces a second awaiting session, so nothing had contradicted it.

## Verification

Rendered the dense scene and read it, rather than trusting the gate:

- 6 cards on a 3×2 grid, **all four awaiting first**, then two processing
- header reads `10 sessions | hidden: 2 working / 2 idle`, no truncation
- the four hidden are exactly the 2 processing + 2 idle the header names

Gates run locally: `check-preview-mirror-sync` 10/10 in sync · `AgentDeckTests_macOS` full suite green (`xcodebuild test`) · `AgentDeck_macOS` builds · `docs:check` passes.

Pins were recomputed from the files with `git hash-object` on this branch, not copied out of the CI message — a generated value is never a merge side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)