### PR TITLE
Fix Codex dashboard limits and harden Pocket pull OTA

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,32 @@
 
 ---
 
+## 2026-08-26 — Codex Plus 5H 복귀와 Pro 7D-only를 모든 좁은 Dashboard가 그대로 말하게 한다
+
+Codex 사용량 생산자는 이미 `windowMinutes`로 5H/7D를 정규화하고 있었지만 세 소비자가
+그 계약을 끝까지 지키지 않았다. TUI는 `codexRateLimits`를 받으면서도 Claude 한도만
+그렸고, D200H의 고정 3키 usage strip은 Claude 5H/7D + Codex 5H/7D 중 네 번째인 Codex
+7D를 버렸다. TTGO/C6 1.47은 Claude 데이터가 있으면 Codex 전체를 숨기고, Pro 단독
+상태에서는 존재하지 않는 `CX 5h: --`를 만들었다.
+
+- TUI wide/standard/narrow가 Codex 창을 슬롯명이 아니라 `windowMinutes`로 라벨링한다.
+  Plus는 5H+7D, weekly window가 `primary`에 실린 Pro도 7D 한 행만 보인다.
+- D200H는 시계 옆 3키 예산을 늘리지 않는다. 4~5개 논리 한도가 들어오면 필요한
+  만큼만 같은 제공자의 5H+7D를 한 키의 이중 게이지로 압축한다. 일반 Plus는 Claude
+  두 키 + Codex pair 한 키, scoped cap까지 있으면 Claude pair + scoped + Codex pair다.
+  물리 기기 정본(shared TS)과 Apple Device Preview Swift 미러를 함께 갱신했다.
+- TTGO/C6의 두 텍스트 행은 양 제공자가 있을 때 제공자별 압축 행(`CL 5:… 7:…`,
+  `CX 5:… 7:…`)으로 바뀐다. 한 제공자만 있으면 실제로 존재하는 창의 행만 보여
+  Pro에 유령 5H가 생기지 않는다. 고정 버퍼만 사용해 no-PSRAM 보드의 heap 계약은
+  바꾸지 않았다.
+- E3의 “Codex 5H가 영구히 사라졌다”는 과거 주석과 테스트 설명을 현재의 동적
+  Plus/Pro 계약으로 정정했다.
+
+검증: Vitest 3,596/3,596, Apple XCTest 684개 중 682 pass·2 skip·0 fail,
+`pnpm build`, preview mirror sync, PlatformIO `ttgo` + `esp32_c6_147` 링크 빌드 통과.
+
+---
+
 ## 2026-08-25 — Ulanzi 플러그인에서 네이티브 바이너리를 전부 걷어낸다 (1.0.5)
 
 Ulanzi Studio 팀이 Apple Silicon에서 `resvgjs.darwin-arm64.node`에 macOS

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-08-26 — Pocket pull-OTA는 먼저 발견하고, 끊겨도 이어 받고, 설치 뒤 스스로 stage를 닫는다
+
+Pocket/XTeink의 약한 링크에서 full Feed를 받은 뒤 OTA를 발견하면 첫 요청 자체가 실패할
+수 있었고, 기존 클라이언트는 wake 한 번에 여섯 번만 GET하므로 128 KiB 고정 segment로는
+큰 이미지를 충분히 전진시키지 못했다. dual-homed Mac에서는 요청을 받은 인터페이스와
+device subnet 쪽 반환 경로가 달라 응답이 유실되는 실측 사례도 있었다.
+
+- staged firmware가 있으면 RSSI와 무관하게 full Feed를 cache-preserving `unchanged`
+  envelope로 줄여 OTA advert를 먼저 전달한다. 이미 conditional인 Feed는 건드리지 않는다.
+- legacy 기본 segment를 256 KiB로 올리고, foreground 클라이언트는 `limit`으로 32–512 KiB
+  범위의 cooperative response를 요청할 수 있다. resume offset은 계속 `from`이다.
+- Surface Feed GET, Glance Frame, pull OTA는 dual-homed host에서 device subnet 쪽 로컬
+  주소로 한 번 307 redirect한다. 오래된 클라이언트를 위해 Outbox POST는 redirect하지 않는다.
+- Pocket 이미지의 내장 `CrossPoint version`과 다음 Feed의 client version이 같으면 설치를
+  확인하고 persisted stage를 제거한다. 단, stage 파일의 size/MD5/version을 먼저 다시
+  계산하므로 같은 경로에 새 바이너리가 생긴 경우 완료로 오인해 버리지 않는다.
+
+검증: pull-OTA/Card Feed 회귀 테스트 61개, 전체 Vitest와 TypeScript build,
+Markdown 문서 검사 통과.
+
+---
+
 ## 2026-08-26 — Codex Plus 5H 복귀와 Pro 7D-only를 모든 좁은 Dashboard가 그대로 말하게 한다
 
 Codex 사용량 생산자는 이미 `windowMinutes`로 5H/7D를 정규화하고 있었지만 세 소비자가

--- a/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/D200HLayoutModel.swift
@@ -24,7 +24,7 @@
 // against; `scripts/check-preview-mirror-sync.mjs` verifies they match the
 // current `git hash-object` of each file and fails CI when the origin drifts
 // ahead of this mirror. Update them whenever you re-port.
-// SYNC-HASH shared/src/d200h-layout.ts 014062e44d2bf70f633285b6dd6b3a71ae008ed1
+// SYNC-HASH shared/src/d200h-layout.ts 684d497bd054842d4b4ac5afdd3509a5f95983e9
 // SYNC-HASH shared/src/session-utils.ts 3f6629cd69bd4d77f380cb5e37972f28863058e7
 //
 // INTENTIONALLY OMITTED (not needed by a read-only preview):
@@ -329,6 +329,15 @@ public enum D200HSlotKind: Equatable, Sendable {
     case nextPage
     /// A usage gauge tile (renderUsageGauge). `agent` = "claude"|"codex".
     case usageGauge(agent: String, window: String, percent: Double, known: Bool, stale: Bool, inactive: Bool, footnote: String?)
+    /// Two same-provider windows compacted into one physical usage key.
+    case usagePair(agent: String, windows: [D200HUsagePairWindow])
+}
+
+public struct D200HUsagePairWindow: Equatable, Sendable {
+    public let label: String
+    public let percent: Double
+    public let stale: Bool
+    public let footnote: String?
 }
 
 /// One key of the deck, addressed by `col`/`row` (index == row*GRID_COLS+col).
@@ -351,9 +360,9 @@ public enum D200HLayoutModel {
 
     /// D200H usage placement — the three bottom-row keys immediately left of the
     /// wide bottom-right clock widget, filled from the RIGHT end so a missing
-    /// tile frees the leftmost key instead of holing the strip. Its length also
-    /// caps usage at three keys (Claude prioritised). Mirrors the shared
-    /// `USAGE_PREFERRED_POS`.
+    /// tile frees the leftmost key instead of holing the strip. When more than
+    /// three logical limits exist, same-provider pairs compact so none drop.
+    /// Mirrors the shared `USAGE_PREFERRED_POS`.
     static let usagePreferredPositions = ["0_2", "1_2", "2_2"]
 
     static let offlineLabel = "OFFLINE"
@@ -414,7 +423,7 @@ public enum D200HLayoutModel {
         // strip left of the clock widget, filled from its right end; fall back to
         // trailing positions for strip keys the user didn't place. Never reserve
         // more than the strip is wide, nor more than slots.count - 1 so at least
-        // one key stays for sessions. Codex tiles drop first (Claude prioritised).
+        // one key stays for sessions. Same-provider pairs compact before reserve.
         var usageHere: [String: (D200HSlotKind, String, String)] = [:]
         if view.showUsage, let usage = input.usage {
             let usageTiles = buildUsageTiles(usage)
@@ -668,32 +677,38 @@ public enum D200HLayoutModel {
     /// when that window's quota is actually known, so fewer (or zero) tiles are
     /// reserved and the freed slots flow to session tiles.
     private static func buildUsageTiles(_ usage: D200HUsage) -> [(D200HSlotKind, String, String)] {
-        var tiles: [(D200HSlotKind, String, String)] = []
+        var claudeTiles: [(D200HSlotKind, String, String)] = []
+        var claudePair: [D200HUsagePairWindow] = []
         if usage.known, let p = usage.fiveHourPercent {
-            tiles.append((.usageGauge(agent: "claude", window: "5h", percent: p, known: true, stale: false, inactive: false, footnote: nil), "5H", "claude"))
+            claudeTiles.append((.usageGauge(agent: "claude", window: "5h", percent: p, known: true, stale: false, inactive: false, footnote: nil), "5H", "claude"))
+            claudePair.append(.init(label: "5H", percent: p, stale: false, footnote: nil))
         }
         if usage.known, let p = usage.sevenDayPercent {
-            tiles.append((.usageGauge(agent: "claude", window: "7d", percent: p, known: true, stale: false, inactive: false, footnote: nil), "7D", "claude"))
+            claudeTiles.append((.usageGauge(agent: "claude", window: "7d", percent: p, known: true, stale: false, inactive: false, footnote: nil), "7D", "claude"))
+            claudePair.append(.init(label: "7D", percent: p, stale: false, footnote: nil))
         }
-        // The worst per-model scoped weekly cap (e.g. "Fable") and the third strip
-        // key it competes with Codex for. Inclusion, placement and what Codex keeps
-        // come from the shared arbiters `scopedLimitClaimsUsageKey` /
-        // `codexWindowsBeside` (TS format-utils), restated here as the same
-        // clauses: an ACTIVE cap is the binding limit, goes AHEAD of Codex and
-        // TAKES one of its keys (a replacement, never a stack); an inactive one
-        // only lands on a key Codex left spare — the ordinary state of a free
-        // ChatGPT tier with nothing to meter. Rendered muted (informational cyan),
-        // never the critical ramp. Only cap[0] can reach the 3-slot usage region,
-        // matching the TS builder.
+        // The worst per-model scoped weekly cap (e.g. "Fable") claims one logical
+        // usage tile. An active cap is ordered ahead of Codex; an inactive cap is
+        // ordered after it. The fixed three-key strip retains every known reading
+        // by pairing a provider's two windows when the logical tile count exceeds
+        // the physical budget. Rendered muted (informational cyan), never the
+        // critical ramp. Only cap[0] can reach the usage region, matching TS.
         // Codex windows are labelled by their own length, never by slot: Codex now
         // sometimes reports the weekly (10080-min) window as `primary` with
         // `secondary` null, so a slot-based "7D = secondary" would drop the gauge.
         var codexTiles: [(D200HSlotKind, String, String)] = []
+        var codexPair: [D200HUsagePairWindow] = []
         if let p = usage.codexPrimaryPercent {
-            codexTiles.append((.usageGauge(agent: "codex", window: usageWindowKind(usage.codexPrimaryWindowMinutes), percent: p, known: true, stale: usage.codexPrimaryStale, inactive: false, footnote: codexFootnote(stale: usage.codexPrimaryStale, capturedAt: usage.codexCapturedAt)), usageWindowLabel(usage.codexPrimaryWindowMinutes), "codex"))
+            let label = usageWindowLabel(usage.codexPrimaryWindowMinutes)
+            let footnote = codexFootnote(stale: usage.codexPrimaryStale, capturedAt: usage.codexCapturedAt)
+            codexTiles.append((.usageGauge(agent: "codex", window: usageWindowKind(usage.codexPrimaryWindowMinutes), percent: p, known: true, stale: usage.codexPrimaryStale, inactive: false, footnote: footnote), label, "codex"))
+            codexPair.append(.init(label: label, percent: p, stale: usage.codexPrimaryStale, footnote: footnote))
         }
         if let s = usage.codexSecondaryPercent {
-            codexTiles.append((.usageGauge(agent: "codex", window: usageWindowKind(usage.codexSecondaryWindowMinutes), percent: s, known: true, stale: usage.codexSecondaryStale, inactive: false, footnote: codexFootnote(stale: usage.codexSecondaryStale, capturedAt: usage.codexCapturedAt)), usageWindowLabel(usage.codexSecondaryWindowMinutes), "codex"))
+            let label = usageWindowLabel(usage.codexSecondaryWindowMinutes)
+            let footnote = codexFootnote(stale: usage.codexSecondaryStale, capturedAt: usage.codexCapturedAt)
+            codexTiles.append((.usageGauge(agent: "codex", window: usageWindowKind(usage.codexSecondaryWindowMinutes), percent: s, known: true, stale: usage.codexSecondaryStale, inactive: false, footnote: footnote), label, "codex"))
+            codexPair.append(.init(label: label, percent: s, stale: usage.codexSecondaryStale, footnote: footnote))
         }
         let worstScoped = usage.known ? usage.scopedLimits.first : nil
         let scopedClaims = worstScoped != nil
@@ -706,8 +721,16 @@ public enum D200HLayoutModel {
             let capped = String(label.prefix(6))
             return (.usageGauge(agent: "claude", window: "7d", percent: s.percent, known: true, stale: false, inactive: !s.active, footnote: nil), capped.isEmpty ? "MODEL" : capped, "claude")
         }()
+        let logicalCount = claudeTiles.count + codexTiles.count + (scopedTile == nil ? 0 : 1)
+        let compactCodex = logicalCount > usagePreferredPositions.count && codexPair.count == 2
+        let compactClaude = logicalCount - (compactCodex ? 1 : 0) > usagePreferredPositions.count && claudePair.count == 2
+        func cells(_ agent: String, _ tiles: [(D200HSlotKind, String, String)], _ pair: [D200HUsagePairWindow], compact: Bool) -> [(D200HSlotKind, String, String)] {
+            compact ? [(.usagePair(agent: agent, windows: pair), pair.map(\.label).joined(separator: " · "), agent)] : tiles
+        }
+
+        var tiles = cells("claude", claudeTiles, claudePair, compact: compactClaude)
         if let scopedTile, worstScoped?.active == true { tiles.append(scopedTile) }
-        tiles.append(contentsOf: codexTiles)
+        tiles.append(contentsOf: cells("codex", codexTiles, codexPair, compact: compactCodex))
         if let scopedTile, worstScoped?.active != true { tiles.append(scopedTile) }
         return tiles
     }

--- a/apple/AgentDeck/UI/Preview/Devices/DeskPreviews.swift
+++ b/apple/AgentDeck/UI/Preview/Devices/DeskPreviews.swift
@@ -390,6 +390,49 @@ private struct D200HSlotTile: View {
                 }
                 .padding(size * 0.08)
             }
+        case .usagePair(let agent, let windows):
+            // Mirrors renderUsagePairGauge: two real windows share one physical
+            // key only when the fixed three-key strip would otherwise drop one.
+            ZStack(alignment: .topTrailing) {
+                VStack(spacing: size * 0.025) {
+                    ForEach(Array(windows.enumerated()), id: \.offset) { index, window in
+                        let dim = window.stale || (window.footnote?.isEmpty == false)
+                        VStack(spacing: size * 0.015) {
+                            HStack(alignment: .firstTextBaseline) {
+                                Text(window.label)
+                                    .font(.system(size: size * 0.13, weight: .bold, design: .monospaced))
+                                Spacer(minLength: 0)
+                                Text("\(Int(window.percent))%")
+                                    .font(.system(size: size * 0.14, weight: .heavy))
+                            }
+                            .padding(.trailing, index == 0 ? size * 0.12 : 0)
+                            .foregroundStyle(dim ? .white.opacity(0.45) : .white)
+                            if let note = window.footnote ?? (window.stale ? "stale" : nil) {
+                                Text(note)
+                                    .font(.system(size: size * 0.075, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(.white.opacity(0.45))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            GeometryReader { geo in
+                                ZStack(alignment: .leading) {
+                                    Rectangle().fill(.white.opacity(0.12))
+                                    Rectangle()
+                                        .fill(gaugeColor(percent: window.percent, known: true, stale: dim))
+                                        .frame(width: geo.size.width * min(1, max(0, window.percent / 100)))
+                                }
+                            }
+                            .frame(height: 2)
+                        }
+                    }
+                }
+                .padding(size * 0.08)
+                CanonicalCreatureView(
+                    agentType: agent == "codex" ? "codex-cli" : "claude-code",
+                    size: size * 0.14,
+                    color: StateColors.brand(agent: agent == "codex" ? "codex-cli" : "claude-code")
+                )
+                .padding(size * 0.055)
+            }
         case .info(_, _):
             Text(slot.label)
                 .font(.system(size: size * 0.11, weight: .semibold))

--- a/apple/AgentDeckTests/DevicePreviewSnapshotTests.swift
+++ b/apple/AgentDeckTests/DevicePreviewSnapshotTests.swift
@@ -214,8 +214,8 @@ final class DevicePreviewSnapshotTests: XCTestCase {
             navigable: false,
             focusedOptions: [],
             fiveHourPercent: 42, sevenDayPercent: 68, usageKnown: true,
-            codexPrimaryPercent: 23, codexPrimaryStale: false,
-            codexSecondaryPercent: 51, codexSecondaryStale: false
+            codexPrimaryPercent: 23, codexPrimaryWindowMinutes: 300, codexPrimaryStale: false,
+            codexSecondaryPercent: 51, codexSecondaryWindowMinutes: 10080, codexSecondaryStale: false
         )
         var sel = selection(.d200hDeck, sessions: 3)
         sel.live = live
@@ -312,5 +312,11 @@ final class DevicePreviewSnapshotTests: XCTestCase {
         // A pinned usage gauge tile is present (real 42% Claude 5H).
         let hasUsageGauge = slots.contains { if case .usageGauge = $0.kind { return true } else { return false } }
         XCTAssertTrue(hasUsageGauge, "expected pinned usage gauge tiles")
+        let codexPair = slots.compactMap { slot -> [D200HUsagePairWindow]? in
+            if case .usagePair(let agent, let windows) = slot.kind, agent == "codex" { return windows }
+            return nil
+        }.first
+        XCTAssertEqual(codexPair?.map(\.label), ["5H", "7D"])
+        XCTAssertEqual(codexPair?.map(\.percent), [23, 51])
     }
 }

--- a/bridge/src/__tests__/card-feed.test.ts
+++ b/bridge/src/__tests__/card-feed.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   classifySessionCard,
   buildCardFeed,
+  applyPullOtaBootstrap,
   applyOutboxDecisions,
   OutboxIdempotencyLedger,
   FeedPullTracker,
@@ -89,6 +90,31 @@ describe('buildCardFeed', () => {
     expect(buildCardFeed([session({ state: 'processing' })], NOW).nextPullSec).toBe(CARD_FEED_ACTIVE_PULL_SEC);
     expect(buildCardFeed([session({ state: 'awaiting_permission' })], NOW).nextPullSec).toBe(CARD_FEED_ACTIVE_PULL_SEC);
     expect(buildCardFeed([], NOW).nextPullSec).toBe(CARD_FEED_IDLE_PULL_SEC);
+  });
+});
+
+describe('pull OTA Feed bootstrap', () => {
+  it('replaces a full deck with a cache-preserving OTA bootstrap envelope', () => {
+    const feed = buildCardFeed([session()], NOW, undefined, {
+      glance: buildGlance({ sessions: [] }),
+    });
+
+    expect(applyPullOtaBootstrap(feed, true)).toBe(true);
+    expect(feed.cards).toEqual([]);
+    expect(feed.unchanged).toBe(true);
+    expect(feed.glance).toBeUndefined();
+  });
+
+  it('leaves ordinary and already-conditional feeds untouched', () => {
+    const ordinary = buildCardFeed([session()], NOW);
+    const ordinaryCards = ordinary.cards;
+    expect(applyPullOtaBootstrap(ordinary, false)).toBe(false);
+    expect(ordinary.cards).toBe(ordinaryCards);
+    expect(ordinary.unchanged).toBeUndefined();
+
+    const conditional = buildCardFeed([session()], NOW, undefined, { echoSig: ordinary.deckSig });
+    expect(applyPullOtaBootstrap(conditional, true)).toBe(false);
+    expect(conditional.unchanged).toBe(true);
   });
 });
 

--- a/bridge/src/__tests__/esp32-ota-stage-key.test.ts
+++ b/bridge/src/__tests__/esp32-ota-stage-key.test.ts
@@ -114,6 +114,41 @@ describe('pull-OTA staging', () => {
     expect(__wifiOtaTestApi.stagedFwAdvert('xteink_x3')).toBeUndefined();
   });
 
+  it('acknowledges an SD-installed staged image by its embedded client version', () => {
+    const version = '1.4.1-dev-pocket-w12345678';
+    const image = Buffer.concat([
+      Buffer.alloc(64, 0x5a),
+      Buffer.from(`CrossPoint version: ${version}\0`, 'ascii'),
+      Buffer.alloc(64, 0x5a),
+    ]);
+    writeFileSync(firmware, image);
+    const x3 = { productId: 'io.pocketdaily.reader', board: 'xteink_x3', updateChannel: 'stable' };
+    __wifiOtaTestApi.stageEsp32Fw('xteink_x3', firmware, x3);
+
+    expect(__wifiOtaTestApi.embeddedFirmwareVersion(image)).toBe(version);
+    expect(__wifiOtaTestApi.stagedFwAdvert('xteink_x3', x3, version)).toBeUndefined();
+    expect(__wifiOtaTestApi.getStagedFw(x3)).toBeUndefined();
+  });
+
+  it('refreshes a rebuilt-in-place image before accepting a version acknowledgement', () => {
+    const version = '1.4.1-dev-pocket-w12345678';
+    const image = (fill: number) => Buffer.concat([
+      Buffer.alloc(64, fill),
+      Buffer.from(`CrossPoint version: ${version}\0`, 'ascii'),
+      Buffer.alloc(64, fill),
+    ]);
+    writeFileSync(firmware, image(0x11));
+    const x3 = { productId: 'io.pocketdaily.reader', board: 'xteink_x3', updateChannel: 'stable' };
+    const staged = __wifiOtaTestApi.stageEsp32Fw('xteink_x3', firmware, x3);
+
+    writeFileSync(firmware, image(0x22));
+    const advert = __wifiOtaTestApi.stagedFwAdvert('xteink_x3', x3, version);
+
+    expect(advert).toMatchObject(x3);
+    expect(advert?.md5).not.toBe(staged.md5);
+    expect(__wifiOtaTestApi.getStagedFw(x3)?.md5).toBe(advert?.md5);
+  });
+
   it('rejects cross-product and cross-channel stages before persisting', () => {
     expect(() => __wifiOtaTestApi.stageEsp32Fw('xteink_x3', firmware, {
       productId: 'dev.agentdeck.dashboard-firmware', board: 'xteink_x3', updateChannel: 'stable',
@@ -134,13 +169,19 @@ describe('pull-OTA staging', () => {
     const tail = __wifiOtaTestApi.pullOtaSegment(image, second.from + second.body.length);
 
     expect(first).toMatchObject({ from: 0 });
-    expect(first.body).toHaveLength(128 * 1024);
-    expect(second).toMatchObject({ from: 128 * 1024 });
-    expect(second.body).toHaveLength(128 * 1024);
-    expect(second.body[0]).toBe(0x22);
-    expect(tail).toMatchObject({ from: 256 * 1024 });
-    expect(tail.body).toHaveLength(44 * 1024);
-    expect(tail.body[0]).toBe(0x33);
+    expect(first.body).toHaveLength(256 * 1024);
+    expect(second).toMatchObject({ from: 256 * 1024 });
+    expect(second.body).toHaveLength(44 * 1024);
+    expect(second.body[0]).toBe(0x33);
+    expect(tail).toMatchObject({ from: 300 * 1024 });
+    expect(tail.body).toHaveLength(0);
+  });
+
+  it('honors a bounded cooperative OTA segment limit', () => {
+    const image = Buffer.alloc(700 * 1024);
+    expect(__wifiOtaTestApi.pullOtaSegment(image, 0, 128 * 1024).body).toHaveLength(128 * 1024);
+    expect(__wifiOtaTestApi.pullOtaSegment(image, 0, 1).body).toHaveLength(32 * 1024);
+    expect(__wifiOtaTestApi.pullOtaSegment(image, 0, 2 * 1024 * 1024).body).toHaveLength(512 * 1024);
   });
 
   it('redirects dual-homed OTA traffic to the device-side Wi-Fi interface once', () => {

--- a/bridge/src/__tests__/tui-dashboard.test.ts
+++ b/bridge/src/__tests__/tui-dashboard.test.ts
@@ -31,6 +31,70 @@ function makeState(overrides: Partial<DashboardState> = {}): DashboardState {
 }
 
 describe('TUI dashboard models', () => {
+  it.each([
+    ['wide', 140],
+    ['standard', 100],
+    ['narrow', 70],
+  ])('renders Codex Plus 5h and 7d limits in the %s layout', (_layout, cols) => {
+    const output = stripAnsi(renderDashboard(
+      makeState({
+        usage: {
+          type: 'usage_update',
+          sessionDurationSec: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          toolCalls: 0,
+          codexRateLimits: {
+            primary: { usedPercent: 31, windowMinutes: 300 },
+            secondary: { usedPercent: 67, windowMinutes: 10080 },
+            planType: 'plus',
+          },
+        },
+      }),
+      cols,
+      34,
+      [],
+      0,
+      0,
+    ));
+
+    expect(output).toContain('Codex 5h');
+    expect(output).toContain('31%');
+    expect(output).toContain('Codex 7d');
+    expect(output).toContain('67%');
+  });
+
+  it.each([
+    ['wide', 140],
+    ['standard', 100],
+    ['narrow', 70],
+  ])('renders a Codex Pro weekly-only primary window without a phantom 5h row in the %s layout', (_layout, cols) => {
+    const output = stripAnsi(renderDashboard(
+      makeState({
+        usage: {
+          type: 'usage_update',
+          sessionDurationSec: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          toolCalls: 0,
+          codexRateLimits: {
+            primary: { usedPercent: 44, windowMinutes: 10080 },
+            planType: 'pro',
+          },
+        },
+      }),
+      cols,
+      34,
+      [],
+      0,
+      0,
+    ));
+
+    expect(output).toContain('Codex 7d');
+    expect(output).toContain('44%');
+    expect(output).not.toContain('Codex 5h');
+  });
+
   it('stores modelCatalog from state_update', () => {
     const state = makeState({
       modelCatalog: [{ name: 'old-model', role: 'configured', available: true }],

--- a/bridge/src/card-feed.ts
+++ b/bridge/src/card-feed.ts
@@ -469,6 +469,21 @@ function applyOne(d: OutboxDecision, deps: OutboxApplyDeps): OutboxDecisionResul
  *  the band is generous; anything outside it is a wake worth looking at. */
 export const PULL_CADENCE_TOLERANCE = 0.25;
 
+/**
+ * A staged image always takes precedence over a full portable Feed. The
+ * device already has a durable deck on SD, while the small `unchanged`
+ * envelope is the only prerequisite for entering the resumable OTA path.
+ * Making this RSSI-independent avoids unstable threshold crossings between
+ * discovery and the redirected request.
+ */
+export function applyPullOtaBootstrap(feed: CardFeedResponse, hasFirmwareAdvert: boolean): boolean {
+  if (!hasFirmwareAdvert || feed.unchanged) return false;
+  feed.cards = [];
+  feed.unchanged = true;
+  delete feed.glance;
+  return true;
+}
+
 export interface FeedPullEvent {
   /** Client IP — the only identity a `GET /feed` carries. */
   client: string;

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -540,9 +540,9 @@ function resolveStagedFwBoard(target: string): string {
   return puller?.board ?? target;
 }
 
-/** Stage a build for a board. Reads the file once to fingerprint it; the file
- *  itself is re-read at device download time (a rebuild at the same path is
- *  re-fingerprinted by re-staging).
+/** Stage a build for a board. Reads the file once to fingerprint it. The Feed
+ *  advert path re-fingerprints a rebuild at the same path before advertising,
+ *  and the download path re-reads the bytes that are actually served.
  *
  *  `pullSeen` reports whether this daemon has actually observed a feed pull
  *  from the board, because "staged" proves neither transfer nor install and a

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -203,6 +203,7 @@ import { getLanIp, stripUnsafeText, cleanRawText, prepareMarkdownDetail, normali
 import { injectOpenClawSession, OPENCLAW_SESSION_ID } from './openclaw-session.js';
 import {
   buildCardFeed, buildGlance, projectPortableReaderGlance, applyOutboxDecisions, FeedPullTracker, formatFeedPull,
+  applyPullOtaBootstrap,
   OutboxIdempotencyLedger,
   normalizeClientIp, parsePullTelemetry,
 } from './card-feed.js';
@@ -368,23 +369,35 @@ const glanceCalendar = new CalendarProvider();
 // the device downloads `GET /esp32/fw` + flashes itself on its next pull.
 // Persisted across daemon restarts; a device that already took an md5 skips it
 // (its applied-marker), so a stale staging is harmless.
-interface StagedFw { firmwarePath: string; md5: string; size: number; stagedAt: number; }
+interface StagedFw {
+  firmwarePath: string;
+  md5: string;
+  size: number;
+  stagedAt: number;
+  /** Build identity embedded by CrossPoint/Pocket Daily, when discoverable. */
+  firmwareVersion?: string;
+}
 interface PersistedStagedFwV2 {
   version: 2;
   identities: Array<StagedFw & SurfaceOtaIdentity>;
   legacy: Record<string, StagedFw>;
 }
-// Keep each response below the 256 KiB size that the measured X3 completed in
-// 1–2 seconds even on its lossy path. The device asks again immediately and
-// keeps six attempts per Sync, so 128 KiB segments make useful progress
-// durable before the 60-second socket timeout instead of gambling the whole
-// remaining image on one long response.
-const PULL_OTA_SEGMENT_BYTES = 128 * 1024;
+// Legacy firmware does only six GETs per awake pass, so its previous 128 KiB
+// response cap made at most 768 KiB progress before sleeping. 256 KiB was
+// measured to complete in 1–2 seconds on X3 and halves those reconnects. New
+// cooperative clients explicitly ask for a smaller `limit` when they need a
+// tighter UI-yield budget.
+const PULL_OTA_SEGMENT_BYTES = 256 * 1024;
+const PULL_OTA_MIN_SEGMENT_BYTES = 32 * 1024;
+const PULL_OTA_MAX_SEGMENT_BYTES = 512 * 1024;
 
-function pullOtaSegment(firmware: Buffer, requestedFrom: number): { from: number; body: Buffer } {
+function pullOtaSegment(firmware: Buffer, requestedFrom: number, requestedLimit?: number): { from: number; body: Buffer } {
   const from = Number.isFinite(requestedFrom) && requestedFrom > 0
     ? Math.min(Math.floor(requestedFrom), firmware.length) : 0;
-  return { from, body: firmware.subarray(from, Math.min(from + PULL_OTA_SEGMENT_BYTES, firmware.length)) };
+  const limit = Number.isFinite(requestedLimit) && requestedLimit! > 0
+    ? Math.max(PULL_OTA_MIN_SEGMENT_BYTES, Math.min(Math.floor(requestedLimit!), PULL_OTA_MAX_SEGMENT_BYTES))
+    : PULL_OTA_SEGMENT_BYTES;
+  return { from, body: firmware.subarray(from, Math.min(from + limit, firmware.length)) };
 }
 
 /** The route above keeps dual-homed hosts on the device-side Wi-Fi interface.
@@ -438,6 +451,25 @@ const stagedFwStatePath = (): string => join(getDataDir(), 'staged-fw.json');
 
 function otaIdentityKey(identity: SurfaceOtaIdentity): string {
   return JSON.stringify([identity.productId, identity.board, identity.updateChannel]);
+}
+
+/** Read the NUL-terminated build identity already present in Pocket images.
+ * This avoids inventing another manifest field and also repairs older persisted
+ * stages that predate firmwareVersion. */
+function embeddedFirmwareVersion(firmware: Buffer): string | undefined {
+  const marker = Buffer.from('CrossPoint version: ', 'ascii');
+  const start = firmware.indexOf(marker);
+  if (start < 0) return undefined;
+  const valueStart = start + marker.length;
+  let end = valueStart;
+  while (end < firmware.length && end - valueStart < 96) {
+    const byte = firmware[end]!;
+    if (byte === 0 || byte === 0x0a || byte === 0x0d) break;
+    if (byte < 0x20 || byte > 0x7e) return undefined;
+    end++;
+  }
+  if (end === valueStart || end - valueStart >= 96) return undefined;
+  return firmware.subarray(valueStart, end).toString('ascii');
 }
 
 function loadStagedFw(): void {
@@ -530,7 +562,13 @@ function stageEsp32Fw(
   }
   const firmware = readFileSync(firmwarePath);
   const md5 = createHash('md5').update(firmware).digest('hex');
-  const staged = { firmwarePath, md5, size: firmware.length, stagedAt: Date.now() };
+  const staged = {
+    firmwarePath,
+    md5,
+    size: firmware.length,
+    stagedAt: Date.now(),
+    firmwareVersion: embeddedFirmwareVersion(firmware),
+  };
   if (identity) stagedFwByIdentity.set(otaIdentityKey(identity), { ...staged, ...identity });
   else legacyStagedFwByBoard.set(board, staged);
   saveStagedFw();
@@ -548,6 +586,7 @@ function stageEsp32Fw(
 function stagedFwAdvert(
   board: string | undefined,
   identity?: SurfaceOtaIdentity,
+  clientVersion?: string,
 ): ({ size: number; md5: string } & Partial<SurfaceOtaIdentity>) | undefined {
   if (!board) return undefined;
   const validatedIdentity = identity ? validateSurfaceOtaIdentity(identity) : undefined;
@@ -558,13 +597,21 @@ function stagedFwAdvert(
   try {
     const firmware = readFileSync(staged.firmwarePath);
     const md5 = createHash('md5').update(firmware).digest('hex');
-    if (md5 !== staged.md5 || firmware.length !== staged.size) {
+    const firmwareVersion = embeddedFirmwareVersion(firmware);
+    if (md5 !== staged.md5 || firmware.length !== staged.size || firmwareVersion !== staged.firmwareVersion) {
       if (validatedIdentity) stagedFwByIdentity.set(otaIdentityKey(validatedIdentity), {
-        ...staged, ...validatedIdentity, md5, size: firmware.length,
+        ...staged, ...validatedIdentity, md5, size: firmware.length, firmwareVersion,
       });
-      else legacyStagedFwByBoard.set(board, { ...staged, md5, size: firmware.length });
+      else legacyStagedFwByBoard.set(board, { ...staged, md5, size: firmware.length, firmwareVersion });
       saveStagedFw();
       return { size: firmware.length, md5, ...(validatedIdentity ?? {}) };
+    }
+    if (clientVersion && firmwareVersion && clientVersion === firmwareVersion) {
+      if (validatedIdentity) stagedFwByIdentity.delete(otaIdentityKey(validatedIdentity));
+      else legacyStagedFwByBoard.delete(board);
+      saveStagedFw();
+      log(`[agentdeck] staged firmware acknowledged by ${validatedIdentity?.productId ?? 'legacy'}/${board}: v${clientVersion}`);
+      return undefined;
     }
     return { size: staged.size, md5: staged.md5, ...(validatedIdentity ?? {}) };
   } catch {
@@ -833,6 +880,7 @@ export const __wifiOtaTestApi = {
   resolveStagedFwBoard,
   stageEsp32Fw,
   stagedFwAdvert,
+  embeddedFirmwareVersion,
   pullOtaSegment,
   preferredPullOtaIp,
   feedPulls,
@@ -2167,7 +2215,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         // never converge there). The device appends whatever arrives and
         // re-asks from where it stopped, so partial transfers accumulate.
         const fromRaw = Number(parsedUrl.searchParams.get('from') ?? 0);
-        const { from, body } = pullOtaSegment(firmware, fromRaw);
+        const limitRaw = parsedUrl.searchParams.has('limit')
+          ? Number(parsedUrl.searchParams.get('limit')) : undefined;
+        const { from, body } = pullOtaSegment(firmware, fromRaw, limitRaw);
         log(`[agentdeck] pull-OTA download: ${board} (${ip}) ← ${body.length} bytes`
           + (from > 0 ? ` (resume from ${from}/${firmware.length})` : ''));
         // Early Pocket Daily builds persisted partial bodies but treated 206
@@ -2224,6 +2274,20 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           return;
         }
         throw err;
+      }
+      if (surfaceIdentity) {
+        const preferredIp = preferredPullOtaIp(ip, req.socket.localAddress ?? '');
+        if (preferredIp) {
+          const port = req.socket.localPort ?? 9120;
+          log(`[agentdeck] Surface path redirect: glance-frame ${surfaceIdentity.board} (${ip}) via ${preferredIp}`);
+          res.writeHead(307, {
+            Location: `http://${preferredIp}:${port}${parsedUrl.pathname}${parsedUrl.search}`,
+            'Cache-Control': 'no-store',
+            'Connection': 'close',
+          });
+          res.end();
+          return;
+        }
       }
       (async () => {
         const board = surfaceIdentity?.board ?? parsedUrl.searchParams.get('board') ?? 'xteink_x3';
@@ -2293,6 +2357,25 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         }
         throw err;
       }
+      // Redirect bodyless Feed GETs only. Pocket builds predating the explicit
+      // POST replay support cannot follow a 307 Outbox response and stall the
+      // whole Sync before Feed/OTA. Outbox is tiny and idempotency-keyed, so
+      // serving it on the accepted local interface is both compatible and
+      // safe; current clients still learn/promote the Wi-Fi origin from Feed.
+      if (surfaceIdentity && req.method === 'GET') {
+        const preferredIp = preferredPullOtaIp(ip, req.socket.localAddress ?? '');
+        if (preferredIp) {
+          const port = req.socket.localPort ?? 9120;
+          log(`[agentdeck] Surface path redirect: ${pathname.slice(1)} ${surfaceIdentity.board} (${ip}) via ${preferredIp}`);
+          res.writeHead(307, {
+            Location: `http://${preferredIp}:${port}${parsedUrl.pathname}${parsedUrl.search}`,
+            'Cache-Control': 'no-store',
+            'Connection': 'close',
+          });
+          res.end();
+          return;
+        }
+      }
       (async () => {
         if (req.method === 'GET') {
           const sessions = await core.buildSessionsSnapshot();
@@ -2321,14 +2404,22 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           // sleeping board learns about a staged build on any pull. Board
           // identity from the query (newer firmware) or the IP memory.
           const pullBoard = surfaceIdentity?.board ?? parsedUrl.searchParams.get('board') ?? boardForClientIp(ip);
-          if (!feed.unchanged) pocketAutonomy.observeDelivery(feed.cards, now, pullBoard ?? undefined);
           const otaIdentity = surfaceIdentity ? {
             productId: surfaceIdentity.productId,
             board: surfaceIdentity.board,
             updateChannel: surfaceIdentity.updateChannel,
           } : undefined;
-          const fwAdvert = stagedFwAdvert(pullBoard ?? undefined, otaIdentity);
+          const fwAdvert = stagedFwAdvert(pullBoard ?? undefined, otaIdentity, surfaceIdentity?.clientVersion);
           if (fwAdvert) feed.fw = fwAdvert;
+          const telemetry = parsePullTelemetry(parsedUrl.searchParams);
+          if (applyPullOtaBootstrap(feed, fwAdvert !== undefined)) {
+            // Do not make a weak-link X3 receive and parse a full content deck
+            // before it can discover the resumable image. `unchanged` tells it
+            // to retain the durable cards already on SD; after the update its
+            // next ordinary pull receives the complete current deck.
+            log(`[agentdeck] OTA-first Feed bootstrap: ${pullBoard ?? 'unknown'} (${ip})${telemetry.rssiDbm !== undefined ? ` rssi ${telemetry.rssiDbm}dBm` : ''}`);
+          }
+          if (!feed.unchanged) pocketAutonomy.observeDelivery(feed.cards, now, pullBoard ?? undefined);
           // A sleeping client's whole visit is this one request: no body, no
           // board id, nothing pushed. Record it, because the gap between two
           // pulls is the only evidence that the timer wake fired at all.
@@ -2338,7 +2429,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             cards: feed.cards.length,
             nextPullSec: feed.nextPullSec,
             unchanged: feed.unchanged === true,
-            telemetry: parsePullTelemetry(parsedUrl.searchParams),
+            telemetry,
           }))}`);
           return feed;
         }

--- a/bridge/src/tui/renderer.ts
+++ b/bridge/src/tui/renderer.ts
@@ -16,7 +16,7 @@ import {
 } from './ansi.js';
 import { blockGauge, resetTimeStr, formatTokens } from './gauge.js';
 import type { DashboardState, LayoutMode } from './dashboard.js';
-import type { ModelCatalogEntry, OllamaStatus, SessionInfo, TimelineEntry, TimelineEntryType } from '@agentdeck/shared';
+import type { CodexRateLimitWindow, ModelCatalogEntry, OllamaStatus, SessionInfo, TimelineEntry, TimelineEntryType } from '@agentdeck/shared';
 import {
   stateRank, sortSessions, assignDisplayNames,
   timelineShouldRenderTaskRow, timelineTaskHeaderDisplay,
@@ -643,6 +643,39 @@ function renderScopedLimitLines(u: NonNullable<DashboardState['usage']>, gaugeW:
   return lines;
 }
 
+/**
+ * Codex windows are labelled by duration, never by primary/secondary slot. A
+ * Pro account can report its only weekly window in `primary`; treating that
+ * slot as 5h would manufacture a limit the account does not have.
+ */
+function codexWindowLabel(window: CodexRateLimitWindow): string {
+  const minutes = window.windowMinutes;
+  if (minutes >= 1440 && minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes >= 60 && minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+function renderCodexLimitLines(
+  u: NonNullable<DashboardState['usage']>, gaugeW: number, inlineReset: boolean,
+): string[] {
+  const lines: string[] = [];
+  const cx = u.codexRateLimits;
+  const windows = [cx?.primary, cx?.secondary].filter((w): w is CodexRateLimitWindow => w != null);
+  for (const window of windows) {
+    const pct = Math.round(window.usedPercent);
+    const label = `Codex ${codexWindowLabel(window)}`;
+    const gauge = blockGauge(pct, gaugeW, window.stale === true);
+    const reset = window.stale === true ? 'stale' : resetTimeStr(window.resetsAt);
+    if (inlineReset) {
+      lines.push(` ${label} [${gauge}] ${pct}%${reset ? ` ${colors.dim}${reset}${RESET}` : ''}`);
+    } else {
+      lines.push(` ${label} [${gauge}] ${pct}%`);
+      if (reset) lines.push(`${colors.dim}    ${reset}${RESET}`);
+    }
+  }
+  return lines;
+}
+
 function renderStatusLimitsLines(state: DashboardState, width: number): string[] {
   const lines: string[] = [];
   const u = state.usage;
@@ -661,6 +694,7 @@ function renderStatusLimitsLines(state: DashboardState, width: number): string[]
     if (reset) lines.push(`${colors.dim}    ${reset}${RESET}`);
   }
   lines.push(...renderScopedLimitLines(u, gaugeW, false));
+  lines.push(...renderCodexLimitLines(u, gaugeW, false));
   if (state.currentTool) {
     lines.push(` ${colors.tool}${truncText(state.currentTool, width - 2)}${RESET}`);
   }
@@ -693,6 +727,7 @@ function renderStatusLines(state: DashboardState, width: number): string[] {
       lines.push(` 7d [${blockGauge(pct, gaugeW)}] ${pct}% ${colors.dim}${resetTimeStr(u.sevenDayResetsAt)}${RESET}`);
     }
     lines.push(...renderScopedLimitLines(u, gaugeW, true));
+    lines.push(...renderCodexLimitLines(u, gaugeW, true));
   }
   if (state.currentTool) lines.push(` ${colors.tool}Tool: ${truncText(state.currentTool, width - 8)}${RESET}`);
   if (state.modelName) lines.push(`${colors.dim} Model: ${state.modelName}${RESET}`);

--- a/docs/esp32-client-contract.md
+++ b/docs/esp32-client-contract.md
@@ -258,14 +258,30 @@ Card Feed implementation.
   md5 against its applied-marker (`/.crosspoint/agentdeck-fw-applied.txt` —
   written *before* flashing so a bad image can't re-download every pull),
   guards battery ≥30% and the OTA slot size, downloads `GET /esp32/fw` with
-  the same tuple in query + Surface headers to the shared SD OTA cache, validates
+  the same tuple in query + Surface headers to the shared SD OTA cache, and
+  resumes with `from=<persistedBytes>`. Foreground clients may add
+  `limit=<bytes>` (32–512 KiB; Pocket Daily uses 128 KiB) to yield between
+  bounded responses without discarding half of a server segment. It validates
   (whole-file MD5 + bootloader-mirror structural check), and flashes +
   restarts on that same wake. Staging persists across daemon restarts
   (`~/.agentdeck/staged-fw.json`); re-staging a rebuilt binary refreshes the
-  md5. Product-aware requests never consult board-only stages; X3/X4 CLI staging
+  md5. For Pocket images, the daemon reads the embedded `CrossPoint version`
+  build identity and clears the stage once a subsequent product-aware Feed
+  identifies that exact client version. The staged file's size, MD5, and
+  embedded identity are refreshed before this acknowledgement, so a
+  rebuilt-in-place image cannot be silently discarded. Product-aware requests
+  never consult board-only stages; X3/X4 CLI staging
   without a full tuple is refused. Existing board-only state is retained only for
   headerless legacy AgentDeck requests. Device: Pocket Daily `src/agentdeck/ota_pull.*`;
   daemon: the versioned full-tuple staging store in `bridge/src/daemon-server.ts`.
+- **Dual-homed Surface routing (2026-08-26)**: Feed, Glance Frame, and pull OTA
+  can answer `307` when a Mac has Ethernet and Wi-Fi addresses on the device
+  subnet. Outbox is served on the accepted interface so older Pocket builds do
+  not stall before Feed; current clients nevertheless support safe replay of
+  its idempotency-keyed POST. Portable clients promote the final redirected GET
+  origin in their persisted endpoint candidates. This prevents a successful
+  request from losing its response on the competing return interface after
+  host wake without breaking the OTA bootstrap path for legacy clients.
 - **Glance Frame (M8, 2026-07-31)**: `GET /glance-frame?board=<id>` returns
   the daemon-**rendered** glance as packed 1bpp framebuffer rows (MSB-first,
   bit 1 = white) with `X-Frame-Width`/`X-Frame-Height`/`X-Frame-Sig` headers —

--- a/docs/surface-protocol.md
+++ b/docs/surface-protocol.md
@@ -111,7 +111,20 @@ Headerless clients and `surface=pocket-reader` retain their previous baseline.
 Resumable OTA clients may offer `ota.resume-206`; negotiated clients receive
 `206 Partial Content` for `?from=` downloads, while older clients receive the
 same remaining bytes with status `200` so an already persisted partial image can
-still converge instead of requiring SD-card recovery.
+still converge instead of requiring SD-card recovery. `GET /esp32/fw` also
+accepts an optional `limit=<bytes>` cooperative response budget, clamped to
+32–512 KiB. Current Pocket Daily requests 128 KiB so it can yield to input
+between bursts; legacy clients omit it and receive 256 KiB to reduce reconnects.
+For firmware carrying a `CrossPoint version` build identity, a later Feed whose
+`AgentDeck-Client-Version` matches that identity acknowledges installation and
+clears the persisted stage. The daemon re-fingerprints the staged file before
+accepting that acknowledgement, preserving a rebuilt-in-place image.
+On a dual-homed daemon host, Surface Feed, Glance Frame, and pull OTA may return
+`307` to the host interface sharing the device's Wi-Fi path. Outbox is handled
+on the accepted interface for compatibility with Pocket builds that predate
+explicit POST replay; current clients can replay its idempotency-keyed body but
+are not required to do so. Successful clients cache the redirected GET origin
+as their next preferred route.
 
 The in-process Swift daemon serves a weather-only Card Feed envelope, validates the
 same eight Pocket identity headers, and negotiates a bounded subset:

--- a/esp32/src/ui/widgets/ttgo_state.cpp
+++ b/esp32/src/ui/widgets/ttgo_state.cpp
@@ -71,6 +71,30 @@ static const char* stateString(AgentState st) {
     }
 }
 
+/** One provider per compact line when both Claude and Codex must share the two
+ * usage rows. Absent windows are omitted instead of rendered as a phantom `--`. */
+static void formatProviderUsage(char* out, size_t outSize, const char* provider,
+                                float fiveHour, float sevenDay) {
+    if (fiveHour >= 0.0f && sevenDay >= 0.0f) {
+        snprintf(out, outSize, "%s 5:%d 7:%d%%", provider, (int)fiveHour, (int)sevenDay);
+    } else if (fiveHour >= 0.0f) {
+        snprintf(out, outSize, "%s 5h:%d%%", provider, (int)fiveHour);
+    } else if (sevenDay >= 0.0f) {
+        snprintf(out, outSize, "%s 7d:%d%%", provider, (int)sevenDay);
+    } else {
+        out[0] = '\0';
+    }
+}
+
+static void setUsageLabel(lv_obj_t* label, const char* text) {
+    if (text && text[0]) {
+        lv_label_set_text(label, text);
+        lv_obj_clear_flag(label, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_flag(label, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
 namespace TTGO {
 namespace StateWidget {
 
@@ -288,35 +312,29 @@ void update() {
         lv_label_set_text(lblModel, "");
     }
 
-    // Update usage gauges. Prefer Claude; fall back to Codex when Claude has no
-    // data so a Codex-only user still sees their real windows.
-    char buf[16];
+    // Update the two compact usage rows. When both providers exist, each gets
+    // one compressed line containing every present window. With one provider,
+    // each window keeps its own more legible row. No absent window prints `--`.
+    char first[24];
+    char second[24];
+    first[0] = '\0';
+    second[0] = '\0';
     bool hasClaude = p5h >= 0.0f || p7d >= 0.0f;
     bool hasCodex = cxP5h >= 0.0f || cxP7d >= 0.0f;
     bool showTankStatus = connected && (hasClaude || hasCodex);
     if (showTankStatus) {
-        lv_obj_clear_flag(lblUsage5h, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(lblUsage7d, LV_OBJ_FLAG_HIDDEN);
-
-        const char* pfx = hasClaude ? "" : "CX ";
-        float u5 = hasClaude ? p5h : cxP5h;
-        float u7 = hasClaude ? p7d : cxP7d;
-
-        if (u5 >= 0.0f) {
-            snprintf(buf, sizeof(buf), "%s5h: %d%%", pfx, (int)u5);
-            lv_label_set_text(lblUsage5h, buf);
+        if (hasClaude && hasCodex) {
+            formatProviderUsage(first, sizeof(first), "CL", p5h, p7d);
+            formatProviderUsage(second, sizeof(second), "CX", cxP5h, cxP7d);
         } else {
-            snprintf(buf, sizeof(buf), "%s5h: --", pfx);
-            lv_label_set_text(lblUsage5h, buf);
+            const char* prefix = hasCodex ? "CX " : "";
+            float u5 = hasCodex ? cxP5h : p5h;
+            float u7 = hasCodex ? cxP7d : p7d;
+            if (u5 >= 0.0f) snprintf(first, sizeof(first), "%s5h: %d%%", prefix, (int)u5);
+            if (u7 >= 0.0f) snprintf(second, sizeof(second), "%s7d: %d%%", prefix, (int)u7);
         }
-
-        if (u7 >= 0.0f) {
-            snprintf(buf, sizeof(buf), "%s7d: %d%%", pfx, (int)u7);
-            lv_label_set_text(lblUsage7d, buf);
-        } else {
-            snprintf(buf, sizeof(buf), "%s7d: --", pfx);
-            lv_label_set_text(lblUsage7d, buf);
-        }
+        setUsageLabel(lblUsage5h, first);
+        setUsageLabel(lblUsage7d, second);
     } else {
         lv_obj_add_flag(lblUsage5h, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(lblUsage7d, LV_OBJ_FLAG_HIDDEN);

--- a/plugin/src/__tests__/usage-encoder.test.ts
+++ b/plugin/src/__tests__/usage-encoder.test.ts
@@ -77,11 +77,9 @@ describe('buildCodexUsageEncoder', () => {
 /**
  * Single-window companion readout.
  *
- * Codex stopped reporting its 5h rolling window upstream on 2026-07-12 and has
- * reported the weekly cap alone since (verified across every rollout from
- * 2026-07-13 on), so the "one live window" shape is the steady state, not an
- * edge case. The freed half carries the SUBSCRIPTION behind the quota; the
- * window's own countdown stays inside the gauge, where E2 also prints it.
+ * Pro can report only its weekly cap, while Plus can report both windows. For a
+ * one-window payload the freed half carries the subscription behind the quota;
+ * the window's own countdown stays inside the gauge, where E2 also prints it.
  */
 describe('buildCodexUsageEncoder — single live window', () => {
   const WEEKLY_ONLY = { secondary: CODEX_LIMITS.secondary, planType: 'plus' };

--- a/plugin/src/renderers/usage-gauge.ts
+++ b/plugin/src/renderers/usage-gauge.ts
@@ -215,9 +215,8 @@ export interface UsageEncoderTank {
 
 /**
  * Companion readout shown beside a lone gauge in the 'both' view. A provider can
- * permanently report a single window (Codex dropped its 5h rolling window
- * upstream on 2026-07-12 and has reported the weekly cap alone ever since), which
- * left the other half of the LCD as a dim "—" ghost. This card fills that half
+ * report a single window (for example Codex Pro's weekly-only quota), which
+ * would leave the other half of the LCD as a dim "—" ghost. This card fills it
  * with the facts the gauge itself cannot carry: how far out the reset is in
  * absolute terms, or the plan tier.
  */
@@ -381,8 +380,7 @@ function encSideCard(x: number, y: number, w: number, h: number, card: UsageEnco
  * 'both' view: 5H and 7D as two side-by-side full-bleed mini level-fills.
  *
  * When the provider reports only ONE live window the second panel would be a
- * permanent dim "—" ghost (Codex dropped its 5h rolling window upstream on
- * 2026-07-12 and has reported the weekly cap alone since). The lone gauge KEEPS
+ * permanent dim "—" ghost (for example Codex Pro has no 5h window). The lone gauge KEEPS
  * its half-width geometry — stretching one level-fill across the full 200px LCD
  * reads as a banner, not a gauge — and the freed half carries the side card
  * instead. Providers still reporting both windows are unaffected.

--- a/plugin/src/utility-modes/usage.ts
+++ b/plugin/src/utility-modes/usage.ts
@@ -189,9 +189,8 @@ export type UsageView = typeof USAGE_VIEWS[number];
 
 /**
  * Views actually reachable for the current payload. A window's zoom stop exists
- * only while that window does: Codex stopped reporting its 5h rolling window
- * upstream on 2026-07-12, so a fixed list left one of four rotation stops
- * showing a full-bleed "—" for a window that no longer exists.
+ * only while that window does. Plus can expose both 5h and 7d, while Pro can
+ * expose only 7d; a fixed list would create a full-bleed "—" zoom stop.
  */
 export function availableUsageViews(enc: Pick<UsageEncoderData, 'fiveHour' | 'sevenDay'>): UsageView[] {
   const views: UsageView[] = ['both'];
@@ -225,12 +224,9 @@ export function buildCodexUsageEncoder(data: UsageModeData, hasReceivedData: boo
       note = 'No Codex usage';
     }
   }
-  // Exactly one live window — Codex has reported the weekly cap alone since
-  // 2026-07-12, when the 5h rolling window disappeared upstream for good (not the
-  // transient post-reset slot flip the daemon normalizer already handles). Fill
-  // the half the missing gauge used to occupy with the SUBSCRIPTION behind the
-  // quota: which plan is paying for it and when it next renews. The window's own
-  // countdown stays inside the gauge, where E2 also prints it.
+  // Exactly one live window (for example Pro's weekly-only shape). Fill the half
+  // the missing gauge would occupy with the subscription behind the quota. The
+  // window's own countdown stays inside the gauge, where E2 also prints it.
   const solo = primary != null && secondary == null ? primary
     : primary == null && secondary != null ? secondary
     : undefined;

--- a/shared/src/__tests__/d200h-layout.test.ts
+++ b/shared/src/__tests__/d200h-layout.test.ts
@@ -3,6 +3,7 @@ import {
   buildSessionDeck,
   parseState,
   renderUsageButton,
+  renderUsagePairGauge,
   renderUsageWideSlot,
 } from '../d200h-layout.js';
 
@@ -38,6 +39,18 @@ describe('usage tiles — usageKnown tri-state', () => {
     const svg = renderUsageWideSlot(12, 34, true);
     expect(svg).toContain('12%');
     expect(svg).toContain('34%');
+  });
+
+  it('compact pair preserves both window labels and values in one key', () => {
+    const svg = renderUsagePairGauge('codex', [
+      { agent: 'codex', window: '5h', label: '5H', usedPercent: 31 },
+      { agent: 'codex', window: '7d', label: '7D', usedPercent: 67 },
+    ]);
+    expect(svg).toContain('5H');
+    expect(svg).toContain('>31<');
+    expect(svg).toContain('7D');
+    expect(svg).toContain('>67<');
+    expect(svg).toContain('#6166E0');
   });
 
   it('parseState infers usageKnown=false when no percent fields are present', () => {
@@ -243,7 +256,7 @@ describe('usage tiles — scoped caps and the three-key strip budget', () => {
   };
 
   /** All usage-strip SVG text for a state, joined. The strip is three keys wide
-   *  (USAGE_PREFERRED_POS) and buildSessionDeck drops tiles past it. */
+   *  (USAGE_PREFERRED_POS), so provider windows are paired before placement. */
   function stripText(extra: Record<string, unknown>): string {
     const deck = buildSessionDeck(
       { state: 'IDLE', allSessions: [], fiveHourPercent: 32, sevenDayPercent: 64, codexRateLimits, ...extra },
@@ -266,14 +279,15 @@ describe('usage tiles — scoped caps and the three-key strip budget', () => {
     expect(text).not.toContain('SONNET');
   });
 
-  it('documents the cost: the scoped tile takes the slot Codex 5H used to hold', () => {
+  it('compacts provider pairs so scoped and Codex limits all remain visible', () => {
     const withScoped = stripText({ scopedLimits: [{ label: 'Fable', percent: 98, active: true }] });
     const withoutScoped = stripText({});
-    // 5H + 7D + scoped fills the three-key strip exactly.
+    // Claude pair + scoped + Codex pair fills the three-key strip exactly.
     expect(withScoped).toContain('FABLE');
-    // Codex's own 5H gauge rides the strip only when no scoped cap is present.
     expect(withoutScoped.match(/>5H</g)?.length).toBe(2);
-    expect(withScoped.match(/>5H</g)?.length).toBe(1);
+    expect(withScoped.match(/>5H</g)?.length).toBe(2);
+    expect(withScoped).toContain('>55<');
+    expect(withScoped).toContain('>20<');
   });
 
   it('sanitizes and truncates the API label before it reaches SVG text', () => {

--- a/shared/src/__tests__/session-deck-usage.test.ts
+++ b/shared/src/__tests__/session-deck-usage.test.ts
@@ -5,9 +5,9 @@ import { buildSessionDeck } from '../d200h-layout.js';
 // Ulanzi): with `showUsage`, the three bottom-row keys LEFT of the wide clock
 // widget (0_2/1_2/2_2) form a horizontal quota strip. The strip fills from its
 // RIGHT end — flush against the clock — so an absent tile frees the LEFTMOST
-// key back to sessions instead of holing the row, and it caps usage at three
-// keys (Claude prioritised). Sessions/paging reflow into the remaining keys,
-// and the tiles refresh usage on press.
+// key back to sessions instead of holing the row. Four or five logical limits
+// compact same-provider 5H+7D pairs rather than dropping a real window.
+// Sessions/paging reflow into the remaining keys, and tiles refresh on press.
 
 const POS = ['0_0', '1_0', '2_0', '3_0', '4_0', '0_1', '1_1', '2_1', '3_1', '4_1', '0_2', '1_2', '2_2', '3_2', '4_2'];
 
@@ -170,9 +170,9 @@ describe('buildSessionDeck list-view usage tiles', () => {
     expect(deck.get(C7D)!.svg).toContain('7D');
   });
 
-  it('caps the strip at 3 keys, dropping the 4th tile (Claude prioritised)', () => {
-    // Claude 5H/7D + Codex 5H/7D = 4 tiles, but the strip is 3 wide: the trailing
-    // Codex window drops rather than pushing usage off the bottom row.
+  it('compacts the Codex pair so Plus 5H and 7D both fit the 3-key strip', () => {
+    // Claude 5H/7D + Codex 5H/7D = 4 logical limits. The two Codex windows
+    // share the third physical key, preserving the clock and every limit.
     const codex = {
       codexRateLimits: {
         primary: { usedPercent: 30, windowMinutes: 300, resetsAt: undefined },
@@ -186,7 +186,7 @@ describe('buildSessionDeck list-view usage tiles', () => {
     // provider LOGO — terracotta-tinted Claude mark, blue Codex mark.
     const claude5 = deck.get(STRIP_L)!.svg;
     const claude7 = deck.get(STRIP_M)!.svg;
-    const codex5 = deck.get(STRIP_R)!.svg;
+    const codexPair = deck.get(STRIP_R)!.svg;
     expect(claude5).toContain('5H');
     expect(claude5).toContain(CLAUDE_MARK);
     expect(claude5).toContain('M20.998 10.949'); // canonical Claude Code robot path
@@ -195,13 +195,12 @@ describe('buildSessionDeck list-view usage tiles', () => {
     expect(claude5).not.toContain('opacity="0.72"');
     expect(claude7).toContain('7D');
     expect(claude7).toContain(CLAUDE_MARK);
-    expect(codex5).toContain('5H');       // Codex 5H, used 30%
-    expect(codex5).toContain('>30<');
-    expect(codex5).toContain(CODEX_MARK);
-    expect(codex5).toContain('M8.086.457'); // Codex provider logo path
-    expect(codex5).toContain('opacity="0.38"');
-    // The Codex weekly window (10% used) is the tile that dropped.
-    expect(usageCells(deck).map((c) => c.svg).join('')).not.toContain('>10<');
+    expect(codexPair).toContain('5H');
+    expect(codexPair).toContain('>30<');
+    expect(codexPair).toContain('7D');
+    expect(codexPair).toContain('>10<');
+    expect(codexPair).toContain(CODEX_MARK);
+    expect(codexPair).toContain('M8.086.457'); // Codex provider logo path
   });
 
   it('renders only the Codex window whose datum exists', () => {
@@ -286,11 +285,10 @@ describe('buildSessionDeck list-view usage tiles', () => {
   });
 });
 
-// The scoped per-model cap (e.g. the weekly "Fable" limit) and the third strip
-// key it competes with Codex for. `scopedLimitClaimsUsageKey` is the shared
-// arbiter — the Stream Deck keypad strip runs the same rule, so the two decks
-// can never disagree about which limit the user is looking at.
-describe('buildSessionDeck scoped cap vs the third usage key', () => {
+// The scoped per-model cap (e.g. the weekly "Fable" limit) shares the fixed
+// usage strip with Codex. The Stream Deck keypad applies the shared inclusion
+// and ordering rules, then compacts provider windows rather than dropping them.
+describe('buildSessionDeck scoped cap within the fixed usage strip', () => {
   const FABLE = { label: 'Fable', percent: 98, active: true };
   const FABLE_IDLE = { label: 'Fable', percent: 61, active: false };
   const codexWeekly = {
@@ -315,17 +313,19 @@ describe('buildSessionDeck scoped cap vs the third usage key', () => {
     expect(tiles[2]).toContain('>61<');
   });
 
-  it('lets an ACTIVE cap TAKE the Codex key — it is the limit that binds', () => {
-    // Replacement, not addition: the strip is a fixed budget carved out of
-    // session keys, so a cap the user cannot act on must not cost them a tile.
+  it('keeps an ACTIVE cap and the live Codex window by compacting Claude', () => {
     const tiles = svgs({ ...codexWeekly, scopedLimits: [FABLE] });
     expect(tiles).toHaveLength(3);
-    expect(tiles[2]).toContain('FABLE');
-    expect(tiles[2]).toContain('>98<');
-    expect(tiles.join('')).not.toContain(CODEX_MARK);
+    expect(tiles[0]).toContain(CLAUDE_MARK);
+    expect(tiles[0]).toContain('>42<');
+    expect(tiles[0]).toContain('>17<');
+    expect(tiles[1]).toContain('FABLE');
+    expect(tiles[1]).toContain('>98<');
+    expect(tiles[2]).toContain(CODEX_MARK);
+    expect(tiles[2]).toContain('>10<');
   });
 
-  it('leaves the first Codex window standing when Codex reports two', () => {
+  it('compacts both providers when an active scoped cap would otherwise overflow', () => {
     const bothWindows = {
       codexRateLimits: {
         primary: { usedPercent: 30, windowMinutes: 300 },
@@ -334,16 +334,22 @@ describe('buildSessionDeck scoped cap vs the third usage key', () => {
       },
     };
     const tiles = svgs({ ...bothWindows, scopedLimits: [FABLE] });
-    // 5H, 7D, FABLE, CX-5H → the 3-key strip keeps the first three.
+    // Claude pair, FABLE, Codex pair: five logical readings in three keys.
     expect(tiles).toHaveLength(3);
-    expect(tiles[2]).toContain('FABLE');
+    expect(tiles[0]).toContain(CLAUDE_MARK);
+    expect(tiles[0]).toContain('>42<');
+    expect(tiles[0]).toContain('>17<');
+    expect(tiles[1]).toContain('FABLE');
+    expect(tiles[2]).toContain(CODEX_MARK);
+    expect(tiles[2]).toContain('>30<');
+    expect(tiles[2]).toContain('>10<');
   });
 
-  it('never lets an INACTIVE cap displace a live Codex window', () => {
+  it('keeps an INACTIVE cap without displacing a live Codex window', () => {
     const tiles = svgs({ ...codexWeekly, scopedLimits: [FABLE_IDLE] });
     expect(tiles).toHaveLength(3);
-    expect(tiles[2]).toContain(CODEX_MARK);
-    expect(tiles.join('')).not.toContain('FABLE');
+    expect(tiles[1]).toContain(CODEX_MARK);
+    expect(tiles[2]).toContain('FABLE');
   });
 
   it('shows nothing but Claude when neither Codex nor a scoped cap exists', () => {

--- a/shared/src/d200h-layout.ts
+++ b/shared/src/d200h-layout.ts
@@ -25,7 +25,7 @@ import {
 import { State, type PromptOption } from './states.js';
 import { sortSessions, foldCodexSessionsForDisplay } from './session-utils.js';
 import type { SessionInfo, SubscriptionInfo, CodexRateLimits, CodexRateLimitWindow, ScopedUsageLimit } from './protocol.js';
-import { Brand, UI } from './design-tokens.js';
+import { Brand, Tide, UI } from './design-tokens.js';
 import { PASSIVE_OFFLINE_LABEL, OPEN_AGENTDECK_LABEL } from './connection-status.js';
 import { CLAUDE_LOGO_PATH, CODEX_LOGO_PATH } from './svg-renderers/agent-logos.js';
 import { formatScopedLabel, codexUsageFootnote, scopedLimitClaimsUsageKey, codexWindowsBeside } from './format-utils.js';
@@ -57,9 +57,10 @@ export const GRID_COLS = 5;
  * key falls out of the strip and flows back to sessions instead of leaving a
  * hole in the middle of the row.
  *
- * Its length also caps usage at three keys: a fourth tile (Codex 5H *and* 7D)
- * drops, Claude prioritised by `buildUsageTiles` order. That cap is why the
- * scoped per-model caps contribute at most ONE tile — see `buildUsageTiles`.
+ * Its length caps usage at three physical keys. When four or five windows are
+ * present, `buildUsageTiles` compacts same-provider 5H+7D windows into a dual
+ * readout so no real limit is dropped. Scoped per-model caps still contribute
+ * at most one tile.
  */
 const USAGE_PREFERRED_POS = ['0_2', '1_2', '2_2'];
 
@@ -377,6 +378,35 @@ export function renderUsageGauge(data: UsageTankData): string {
 }
 
 /**
+ * Two rolling windows compacted into one physical key. The D200H reserves only
+ * the three keys left of its wide clock, so Claude 5H/7D + Codex 5H/7D cannot
+ * be represented as four independent tiles. Compacting a provider pair keeps
+ * every real window visible without stealing the clock or dropping a limit.
+ */
+export function renderUsagePairGauge(agent: 'claude' | 'codex', windows: [UsageTankData, UsageTankData]): string {
+  const W = 144, H = 144, RX = 12;
+  const bg = `<rect width="${W}" height="${H}" rx="${RX}" fill="${UI.popupBgMid}"/>`;
+  const logo = usageBrandLogo(agent, 128, 16, 16, false);
+  const rows = windows.map((window, index) => {
+    const used = Math.max(0, Math.min(100, window.usedPercent));
+    const dim = window.stale === true || Boolean(window.footnote);
+    const ramp = usageRampColor(used, dim, window.inactive === true);
+    const y = index === 0 ? 0 : 72;
+    const reset = window.footnote || (window.stale ? 'stale' : formatResetCountdown(window.resetsAt));
+    const textColor = dim ? UI.ttyDim : Tide.s50;
+    const barW = Math.round(120 * used / 100);
+    return `<text x="12" y="${y + 29}" font-family="JetBrains Mono, monospace" font-size="18" font-weight="bold" fill="${textColor}">${escXml(window.label)}</text>`
+      + `<text x="100" y="${y + 29}" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="20" font-weight="bold" fill="${textColor}">${Math.round(used)}</text>`
+      + `<text x="102" y="${y + 29}" font-family="IBM Plex Sans, sans-serif" font-size="12" font-weight="bold" fill="${textColor}">%</text>`
+      + (reset ? `<text x="12" y="${y + 51}" font-family="JetBrains Mono, monospace" font-size="11" font-weight="bold" fill="${textColor}">${escXml(reset)}</text>` : '')
+      + `<rect x="12" y="${y + 62}" width="120" height="3" rx="1.5" fill="${UI.ttyFaint}"/>`
+      + (barW > 0 ? `<rect x="12" y="${y + 62}" width="${barW}" height="3" rx="1.5" fill="${ramp.fill}" opacity="${dim ? 0.55 : 1}"/>` : '');
+  }).join('');
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">`
+    + bg + `<rect x="8" y="71" width="128" height="1" fill="${UI.ttyFaint}"/>` + rows + logo + `</svg>`;
+}
+
+/**
  * Codex credit-based plans (e.g. `limit_id: "premium"`) report null 5h/7d
  * windows and convey usage via a credits balance instead. Render a flat readout
  * tile — limit label + balance (or ∞ when unlimited) — matching the gauge frame
@@ -412,50 +442,72 @@ export function renderCreditsTile(data: { limitId?: string; balance?: string; un
 function buildUsageTiles(state: DashState): SessionDeckCell[] {
   const action: DeckAction = { kind: 'command', command: { type: 'query_usage' } };
   const known = state.usageKnown !== false;
-  const tiles: SessionDeckCell[] = [];
+  const claudeWindows: UsageTankData[] = [];
   if (known && state.fiveHourPercent != null) {
-    tiles.push({ svg: renderUsageGauge({ agent: 'claude', window: '5h', label: '5H', usedPercent: state.fiveHourPercent, resetsAt: state.fiveHourResetsAt, known: true }), action });
+    claudeWindows.push({ agent: 'claude', window: '5h', label: '5H', usedPercent: state.fiveHourPercent, resetsAt: state.fiveHourResetsAt, known: true });
   }
   if (known && state.sevenDayPercent != null) {
-    tiles.push({ svg: renderUsageGauge({ agent: 'claude', window: '7d', label: '7D', usedPercent: state.sevenDayPercent, resetsAt: state.sevenDayResetsAt, known: true }), action });
+    claudeWindows.push({ agent: 'claude', window: '7d', label: '7D', usedPercent: state.sevenDayPercent, resetsAt: state.sevenDayResetsAt, known: true });
   }
   // At most ONE scoped tile — the worst-sorted cap (active desc, then percent
   // desc), rendered muted when it isn't the binding one.
   //
-  // The usage strip is three keys wide (USAGE_PREFERRED_POS) and `buildSessionDeck`
-  // drops every tile past it, so scoped tiles never stack: only [0] could ever
-  // reach a key, and building the rest is dead work. Paging through them lives on
-  // the SD+ encoder, which has room for it.
+  // The usage strip is three keys wide (USAGE_PREFERRED_POS), so scoped tiles
+  // never stack: only [0] can reach a key, and building the rest is dead work.
+  // Same-provider rolling windows compact below when the total would overflow;
+  // paging through the remaining scoped caps lives on the SD+ encoder.
   //
-  // Whether it takes a key at all is `scopedLimitClaimsUsageKey`, and what Codex
-  // keeps once it has is `codexWindowsBeside` — both shared with the Stream Deck
-  // keypad strip so the two decks can't disagree about which limit the user is
-  // looking at. An ACTIVE cap is placed ahead of Codex and TAKES one of its keys
-  // (it replaces, never stacks); an inactive one only lands when Codex reports
-  // nothing at all.
+  // Inclusion comes from `scopedLimitClaimsUsageKey`, and the Codex windows to
+  // retain from `codexWindowsBeside` — both shared with the Stream Deck keypad.
+  // Active caps sort ahead of Codex; inactive caps follow it. Capacity pressure
+  // is solved by compacting provider pairs below, never by deleting a window.
   const cx = state.codexRateLimits;
   const allCodexWindows = [cx?.primary, cx?.secondary].filter((w): w is CodexRateLimitWindow => w != null);
   const worstScoped = known ? state.scopedLimits?.[0] : undefined;
   const scopedClaims = scopedLimitClaimsUsageKey(worstScoped, allCodexWindows.length);
   const codexWindows = codexWindowsBeside(allCodexWindows, scopedClaims);
-  const scopedTile = scopedClaims && worstScoped
+  const scopedTile: SessionDeckCell | undefined = scopedClaims && worstScoped
     ? { svg: renderUsageGauge({ agent: 'claude' as const, window: '7d' as const, label: formatScopedLabel(worstScoped.label, 6), usedPercent: worstScoped.percent, resetsAt: worstScoped.resetsAt, known: true, inactive: worstScoped.active !== true }), action }
     : undefined;
-  if (scopedTile && worstScoped?.active === true) tiles.push(scopedTile);
   // Codex windows carry the same short "5H"/"7D" labels — the brand dot conveys
   // the agent, not a "CX " prefix. Label each present window by its own length
   // (windowMinutes), never by slot: Codex now sometimes reports the weekly
   // (10080-min) window as `primary` with `secondary` null, so a slot-based "7D
   // = secondary" would drop the gauge entirely.
-  for (const w of codexWindows) {
-    tiles.push({ svg: renderUsageGauge({ agent: 'codex', window: usageWindowKind(w.windowMinutes), label: usageWindowLabel(w.windowMinutes) || '5H', usedPercent: w.usedPercent, resetsAt: w.resetsAt, known: true, stale: w.stale === true, footnote: codexUsageFootnote(w, cx?.capturedAt)?.text }), action });
-  }
+  const codexWindowData: UsageTankData[] = codexWindows.map((w) => ({
+    agent: 'codex',
+    window: usageWindowKind(w.windowMinutes),
+    label: usageWindowLabel(w.windowMinutes) || '5H',
+    usedPercent: w.usedPercent,
+    resetsAt: w.resetsAt,
+    known: true,
+    stale: w.stale === true,
+    footnote: codexUsageFootnote(w, cx?.capturedAt)?.text,
+  }));
+
+  // Compact only as much as the fixed three-key strip requires. In the common
+  // Plus shape, Claude keeps its two familiar tiles and Codex 5H+7D share one.
+  // If a binding scoped cap also exists, Claude compacts too, preserving all
+  // five readings in three physical keys.
+  const creditsTile: SessionDeckCell | undefined = !cx?.primary && !cx?.secondary && (cx?.credits || cx?.limitId)
+    ? { svg: renderCreditsTile({ limitId: cx.limitId, balance: cx.credits?.balance, unlimited: cx.credits?.unlimited }), action }
+    : undefined;
+  const logicalCount = claudeWindows.length + codexWindowData.length + (scopedTile ? 1 : 0) + (creditsTile ? 1 : 0);
+  const compactCodex = logicalCount > USAGE_PREFERRED_POS.length && codexWindowData.length === 2;
+  const afterCodex = logicalCount - (compactCodex ? 1 : 0);
+  const compactClaude = afterCodex > USAGE_PREFERRED_POS.length && claudeWindows.length === 2;
+  const cellsFor = (agent: 'claude' | 'codex', windows: UsageTankData[], compact: boolean): SessionDeckCell[] => {
+    if (compact && windows.length === 2) {
+      return [{ svg: renderUsagePairGauge(agent, [windows[0], windows[1]]), action }];
+    }
+    return windows.map((window) => ({ svg: renderUsageGauge(window), action }));
+  };
+
+  const tiles: SessionDeckCell[] = cellsFor('claude', claudeWindows, compactClaude);
+  if (scopedTile && worstScoped?.active === true) tiles.push(scopedTile);
+  tiles.push(...cellsFor('codex', codexWindowData, compactCodex));
+  if (creditsTile) tiles.push(creditsTile);
   if (scopedTile && worstScoped?.active !== true) tiles.push(scopedTile);
-  // Credit-based Codex plan: no windows, show the credits balance instead so the
-  // Codex usage doesn't silently vanish.
-  if (!cx?.primary && !cx?.secondary && (cx?.credits || cx?.limitId)) {
-    tiles.push({ svg: renderCreditsTile({ limitId: cx.limitId, balance: cx.credits?.balance, unlimited: cx.credits?.unlimited }), action });
-  }
   return tiles;
 }
 
@@ -816,8 +868,8 @@ function buildList(
   // Pin the bottom-row usage strip to the global quota gauges (opt-in,
   // water-tank style). On the D200H the strip sits just left of the native clock
   // widget; on classic Stream Deck it replaces the encoder LCD this surface
-  // lacks. We reserve as many keys as we have usage tiles (Claude 5H/7D + any
-  // Codex window), but never more than the strip is wide, and never more than
+  // lacks. We reserve as many keys as we have usage tiles (same-provider pairs
+  // compact when necessary), but never more than the strip is wide or more than
   // `slots.length - 1` so at least one key stays for sessions — the latter is
   // the fix for the old `slots.length >= 6` gate that silently dropped ALL usage
   // when the user placed only a few AgentDeck keys. Reserved keys are pinned on

--- a/shared/src/format-utils.ts
+++ b/shared/src/format-utils.ts
@@ -275,22 +275,13 @@ export function codexUsageFootnote(
  * decides what happens to the remainder. Shared so the two decks cannot disagree
  * about which limit a user is looking at.
  *
- * Two ways in, and only two:
- *   - the cap is ACTIVE, i.e. it is the limit currently binding. Then it outranks
- *     Codex and is placed ahead of it: the whole point of surfacing scoped caps
- *     is that a per-model weekly cap can sit at 98% while 5H/7D still read low
- *     (issue #99). A strip that shows only the windows that aren't binding is
- *     worse than one gauge short.
- *   - Codex contributes no window at all — no Codex account, or a free ChatGPT
- *     tier with nothing to meter. The key is going spare, so an inactive cap is
- *     better context than an empty tile.
+ * Any surfaced cap claims one logical usage tile. An ACTIVE cap outranks Codex
+ * and is placed ahead of it because a per-model weekly cap can be binding while
+ * the aggregate 5H/7D windows still read low (issue #99). An inactive cap is
+ * informational and is placed after live Codex windows.
  *
- * An inactive cap never displaces a live Codex window: "not currently binding" is
- * weaker information than a real quota the user is spending right now.
- *
- * The cap TAKES Codex's key rather than adding one beside it (see
- * `codexWindowsBeside`) — the strip is a fixed budget carved out of session keys,
- * and a limit the user cannot act on should not cost them a session tile.
+ * Physical surfaces enforce their own budgets by pairing or paging readings;
+ * this shared arbiter never authorizes silently dropping a known quota.
  */
 export function scopedLimitClaimsUsageKey(
   scoped: { active?: boolean } | undefined | null,
@@ -303,8 +294,8 @@ export function scopedLimitClaimsUsageKey(
 /**
  * The Codex windows that sit beside the scoped limit tile.
  *
- * Retains all present Codex windows so devices with 15+ keys can show
- * Claude 5H, 7D, Scoped (Fable), and Codex windows together across up to 4 usage keys.
+ * Retains every present Codex window. Fixed-size surfaces compact or page the
+ * resulting logical tiles instead of discarding a known window.
  */
 export function codexWindowsBeside<T>(
   codexWindows: T[],


### PR DESCRIPTION
## Summary

### Codex dashboard limits

- render Codex Plus 5H and 7D windows in wide, standard, and narrow TUI dashboards
- render Codex Pro weekly-only data as 7D without a phantom 5H row
- compact same-provider windows on the D200H three-key usage strip so no known limit is dropped
- mirror the D200H pair layout in Apple Device Preview and compact TTGO/C6 provider rows without heap allocation

### Pocket pull OTA

- send a cache-preserving OTA-first Feed envelope whenever staged firmware is advertised
- support bounded cooperative download segments and increase the legacy default segment to 256 KiB
- redirect Surface Feed, Glance Frame, and pull OTA onto the device-side interface on dual-homed hosts while preserving legacy Outbox behavior
- acknowledge installed Pocket images by embedded build identity, after re-fingerprinting rebuilt-in-place stage files
- document the resume, redirect, and stage lifecycle contracts

## Review fixes

- verify the actual Feed mutation instead of testing a tautological boolean helper
- refresh stage metadata before accepting a client-version acknowledgement
- do not advertise standard HTTP byte ranges because resume uses the explicit from/limit contract

## Validation

- pnpm test: 3,598 passed
- pnpm build
- pnpm docs:check: 109 Markdown files passed
- pnpm check-preview-sync: 10 pins across 6 mirrors passed
- Apple XCTest: 684 executed, 2 skipped, 0 failures
- PlatformIO: ttgo and esp32_c6_147 builds succeeded
- git diff --check