### PR TITLE
Fix inactive Codex App sessions accumulating on dashboards

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-08-26 — Codex App의 보존된 채팅과 AgentDeck의 활성 세션을 분리한다
+
+Codex App의 단일 `app-server`는 사용자가 열어 본 여러 채팅의 rollout FD를 며칠씩
+유지한다. Node passive observer는 이 FD 하나를 세션 하나로 만들고 모두 `alive: true`로
+내보내서, 실제 hook/OTel 활동은 한 스레드뿐이어도 과거 idle 채팅이 기기마다 계속
+쌓였다. 같은 raw roster를 Swift daemon은 project별로 접었지만 Node daemon은 그대로
+보내고 일부 consumer만 다시 접어, 화면별 세션 수도 서로 달랐다.
+
+- Codex App의 idle rollout은 마지막 write 후 90초까지만 active roster에 남긴다. CLI는
+  프로세스 자체가 열린 대화이므로 기존처럼 유지하고, processing rollout도 보존한다.
+- Node `BridgeCore`가 enrich 뒤 Codex project folding + 안정 정렬을 수행하고 initial
+  connect도 같은 snapshot builder를 사용한다. raw registry는 routing/diagnostics용으로
+  그대로 유지한다.
+- USB/WiFi 중복 전송은 현재 daemon lifetime에 live `device_info`를 받고 최근 inbound가
+  있는 serial만 우선한다. cache-seeded CDC에 write만 성공했다는 이유로 정상 WiFi
+  display stream을 막지 않으며, `/devices`에 `deviceInfoFresh`를 노출한다.
+
+검증: 전체 Vitest 3,603개, monorepo build, Markdown 문서 검사와 `git diff --check`
+통과.
+
+---
+
 ## 2026-08-26 — Pocket pull-OTA는 먼저 발견하고, 끊겨도 이어 받고, 설치 뒤 스스로 stage를 닫는다
 
 Pocket/XTeink의 약한 링크에서 full Feed를 받은 뒤 OTA를 발견하면 첫 요청 자체가 실패할

--- a/bridge/src/__tests__/bridge-core-sessions.test.ts
+++ b/bridge/src/__tests__/bridge-core-sessions.test.ts
@@ -73,6 +73,42 @@ describe('BridgeCore sessions_list', () => {
     });
   });
 
+  it('folds same-project Codex App chats in the canonical snapshot', async () => {
+    mockBuildEnrichedSessionsList.mockResolvedValue([
+      {
+        id: 'observed:codex-app:old',
+        port: 0,
+        projectName: 'AgentDeck',
+        alive: true,
+        state: 'idle',
+        agentType: 'codex-app',
+        startedAt: '2026-08-25T00:00:00.000Z',
+      },
+      {
+        id: 'observed:codex-app:working',
+        port: 0,
+        projectName: 'AgentDeck',
+        alive: true,
+        state: 'processing',
+        agentType: 'codex-app',
+        startedAt: '2026-08-26T00:00:00.000Z',
+      },
+    ]);
+
+    const sessions = await core.buildSessionsSnapshot();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'observed:codex-app:working',
+      state: 'processing',
+      groupSize: 2,
+      foldedSessionIds: [
+        'observed:codex-app:old',
+        'observed:codex-app:working',
+      ],
+    });
+  });
+
   it('sendInitialState sends enriched sessions_list to the connecting client', async () => {
     mockBuildEnrichedSessionsList.mockResolvedValue([
       {
@@ -115,16 +151,16 @@ describe('BridgeCore sessions_list', () => {
       expect(sessionsEvent).toBeDefined();
       expect((sessionsEvent as any).sessions).toEqual([
         expect.objectContaining({
-          id: 'sibling-2',
-          projectName: 'Frontend',
-          state: 'processing',
-          modelName: 'opus-4',
-        }),
-        expect.objectContaining({
           id: 'openclaw-gateway',
           projectName: 'OpenClaw',
           agentType: 'openclaw',
           state: 'idle',
+        }),
+        expect.objectContaining({
+          id: 'sibling-2',
+          projectName: 'Frontend',
+          state: 'processing',
+          modelName: 'opus-4',
         }),
       ]);
     });

--- a/bridge/src/__tests__/esp32-serial-node.test.ts
+++ b/bridge/src/__tests__/esp32-serial-node.test.ts
@@ -32,6 +32,7 @@ import {
   shouldSendWifiProvision,
   shouldSendAuthProvision,
   shouldRetryDeviceInfoIdentify,
+  isSerialReachableForDedup,
   recordForeignProbeFailure,
   isForeignPortDenylisted,
   __resetForeignPortState,
@@ -889,6 +890,34 @@ describe('device-info re-identify gating', () => {
 
   it('does not retry a disconnected connection', () => {
     expect(shouldRetryDeviceInfoIdentify(identifyConn({ connected: false }))).toBe(false);
+  });
+});
+
+describe('serial/WiFi display-path dedup', () => {
+  const now = 1_000_000;
+
+  it('does not suppress WiFi for a cache-seeded CDC port with no inbound traffic', () => {
+    const c = identifyConn({
+      port: '/dev/cu.usbmodem832401',
+      connectedAt: now - 10_000,
+      lastReadAt: 0,
+      lastWriteAt: now,
+      deviceInfo: { board: 't_display_pro', ip: '192.168.1.20', wifiConnected: true },
+    });
+    expect(isSerialReachableForDedup(c, now)).toBe(false);
+  });
+
+  it('suppresses WiFi only while a live device_info connection has recent inbound traffic', () => {
+    const c = identifyConn({
+      port: '/dev/cu.usbmodem832401',
+      connectedAt: now - 10_000,
+      lastReadAt: now - 1_000,
+      lastWriteAt: now,
+      deviceInfoFresh: true,
+      deviceInfo: { board: 't_display_pro', ip: '192.168.1.20', wifiConnected: true },
+    });
+    expect(isSerialReachableForDedup(c, now)).toBe(true);
+    expect(isSerialReachableForDedup({ ...c, lastReadAt: now - 61_000 }, now)).toBe(false);
   });
 });
 

--- a/bridge/src/__tests__/passive-observer.test.ts
+++ b/bridge/src/__tests__/passive-observer.test.ts
@@ -683,6 +683,7 @@ describe('passive-observer parsers', () => {
       [process],
       new Map([[999, ['/rollout-parent.jsonl', '/rollout-child.jsonl']]]),
       cache,
+      100,
     );
 
     expect(sessions).toHaveLength(1);
@@ -691,6 +692,82 @@ describe('passive-observer parsers', () => {
       agentType: 'codex-app',
       pid: 999,
       cwd: '/repo/parent',
+    });
+  });
+
+  it('drops stale idle Desktop rollouts while retaining recent and processing chats', async () => {
+    const process = {
+      pid: 999,
+      ppid: 1,
+      rssKb: 100,
+      command: '/Applications/ChatGPT.app/Contents/Resources/codex app-server',
+    };
+    const now = 1_000_000;
+    const cache = new CodexRolloutCache({
+      stat: async (path) => ({
+        mtimeMs: path.includes('recent') ? now - 1_000 : now - 91_000,
+        size: 10,
+      }),
+      read: async (path) => jsonl([
+        {
+          type: 'session_meta',
+          payload: {
+            id: path.replace('/rollout-', '').replace('.jsonl', ''),
+            cwd: '/repo/app',
+            originator: 'Codex Desktop',
+          },
+        },
+        ...(path.includes('processing')
+          ? [{ type: 'event_msg', payload: { type: 'task_started' } }]
+          : []),
+      ]),
+    });
+
+    const sessions = await collectCodexSessionsFromRollouts(
+      [process],
+      new Map([[999, [
+        '/rollout-stale.jsonl',
+        '/rollout-recent.jsonl',
+        '/rollout-processing.jsonl',
+      ]]]),
+      cache,
+      now,
+    );
+
+    expect(sessions.map((session) => session.id)).toEqual([
+      'observed:codex-app:recent',
+      'observed:codex-app:processing',
+    ]);
+  });
+
+  it('keeps an idle Codex CLI rollout because its owning process is the live session', async () => {
+    const process = {
+      pid: 1000,
+      ppid: 1,
+      rssKb: 100,
+      command: '/opt/homebrew/bin/codex',
+    };
+    const now = 1_000_000;
+    const cache = new CodexRolloutCache({
+      stat: async () => ({ mtimeMs: now - 600_000, size: 10 }),
+      read: async () => jsonl([{
+        type: 'session_meta',
+        payload: { id: 'cli-idle', cwd: '/repo/cli', originator: 'codex-tui' },
+      }]),
+    });
+
+    const sessions = await collectCodexSessionsFromRollouts(
+      [process],
+      new Map([[1000, ['/rollout-cli-idle.jsonl']]]),
+      cache,
+      now,
+    );
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'observed:codex:cli-idle',
+      agentType: 'codex-cli',
+      state: 'idle',
     });
   });
 

--- a/bridge/src/bridge-core.ts
+++ b/bridge/src/bridge-core.ts
@@ -15,7 +15,7 @@ import { readCodexRateLimits } from './codex-rate-limits.js';
 import { codexRateLimitsWithLiveRefresh } from './codex-rate-limits-live.js';
 import { fetchMlxModels } from './mlx-probe.js';
 import { buildDisplayStateEvent } from './display-dim.js';
-import { loadMlxSettings } from '@agentdeck/shared';
+import { foldCodexSessionsForDisplay, loadMlxSettings, sortSessions } from '@agentdeck/shared';
 import { probeGateway, checkGatewayHealth } from './gateway-probe.js';
 import { fetchUsageFromApi, hasOAuthToken, getTokenStatus, type ApiUsageData, type UsageFetchResult } from './usage-api.js';
 import { buildEnrichedSessionsList } from './session-aggregator.js';
@@ -705,6 +705,11 @@ export class BridgeCore {
       snapshot.effortLevel ?? undefined,
     );
     if (this.sessionsEnricher) sessions = this.sessionsEnricher(sessions);
+    // Canonical user-facing projection. The Swift daemon already folds here;
+    // doing the same in Node keeps ESP32/native dashboards aligned with the
+    // Stream Deck and Pixoo consumers that otherwise had to fold locally.
+    // The raw registry remains untouched for routing and diagnostics.
+    sessions = sortSessions(foldCodexSessionsForDisplay(sessions));
     // Attach the shared per-session activity one-liner to the FINAL list (covers
     // managed + observed sessions). Heuristic is immediate; a Foundation Models
     // summary, when available, lands on a later periodic broadcast via the cache.
@@ -857,14 +862,8 @@ export class BridgeCore {
     }
 
     // Sessions list
-    buildEnrichedSessionsList(
-      this.sessionId,
-      snapshot.state,
-      snapshot.modelName ?? undefined,
-      snapshot.effortLevel ?? undefined,
-    ).then((sessions) => {
-      const enriched = this.sessionsEnricher ? this.sessionsEnricher(sessions) : sessions;
-      this.wsServer.sendTo(ws, { type: 'sessions_list', sessions: enriched } as BridgeEvent);
+    this.buildSessionsSnapshot().then((sessions) => {
+      this.wsServer.sendTo(ws, { type: 'sessions_list', sessions } as BridgeEvent);
     }).catch(() => {});
 
     // Extra events from caller

--- a/bridge/src/daemon-server.ts
+++ b/bridge/src/daemon-server.ts
@@ -1281,6 +1281,7 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
       port: status.port,
       connected: status.connected,
       transportOpen: status.transportOpen,
+      deviceInfoFresh: status.deviceInfoFresh,
       deviceInfo: status.board ? {
         board: status.board,
         version: status.version,
@@ -1299,6 +1300,7 @@ function buildNodeModuleHealth(startedModules: DeviceModule[]): Record<string, u
         sessionCount: status.sessionCount,
         usageFiveH: status.usageFiveH,
         processingCount: status.processingCount,
+        deviceInfoFresh: status.deviceInfoFresh,
       } : null,
       lastReadAt: status.lastReadAt,
       lastWriteAt: status.lastWriteAt,

--- a/bridge/src/esp32-serial.ts
+++ b/bridge/src/esp32-serial.ts
@@ -1674,6 +1674,9 @@ export function shouldSendWifiProvision(conn: Pick<SerialConnection, 'connected'
  */
 export function getESP32DeviceInfo(): Array<{
   port: string;
+  /** True only after device_info arrived on this live serial connection. */
+  deviceInfoFresh: boolean;
+  lastReadSecondsAgo: number | null;
   board?: string;
   version?: string;
   buildHash?: string;
@@ -1694,7 +1697,28 @@ export function getESP32DeviceInfo(): Array<{
     .map(c => ({
       port: c.port,
       ...c.deviceInfo,
+      deviceInfoFresh: c.deviceInfoFresh,
+      lastReadSecondsAgo: c.lastReadAt > 0 ? Math.floor((now - c.lastReadAt) / 1000) : null,
     }));
+}
+
+/**
+ * A serial path may suppress the same board's WiFi display stream only when
+ * it has proved two-way liveness in this daemon lifetime. A cache-seeded CDC
+ * descriptor with successful writes but zero reads is not proof that the
+ * board received or applied the roster; treating it as live stranded boards
+ * on stale session counts while their healthy WiFi socket was muted.
+ *
+ * @internal Exported for regression tests.
+ */
+export function isSerialReachableForDedup(
+  conn: Pick<SerialConnection, 'connected' | 'deviceInfo' | 'deviceInfoFresh' | 'lastReadAt' | 'lastWriteAt' | 'port' | 'connectedAt'>,
+  now = Date.now(),
+): boolean {
+  return conn.deviceInfoFresh
+    && conn.lastReadAt > 0
+    && now - conn.lastReadAt <= STALE_THRESHOLD_MS
+    && isResponsive(conn, now);
 }
 
 /**
@@ -1713,7 +1737,7 @@ export function getSerialReachableBoards(): Array<{ board: string; ip?: string }
   const now = Date.now();
   const out: Array<{ board: string; ip?: string }> = [];
   for (const c of connections) {
-    if (!isResponsive(c, now)) continue;
+    if (!isSerialReachableForDedup(c, now)) continue;
     const board = c.deviceInfo?.board;
     if (!board) continue;
     out.push({ board, ip: c.deviceInfo?.wifiConnected ? c.deviceInfo?.ip : undefined });
@@ -1852,6 +1876,7 @@ export function getSerialConnectionStatus(): Array<{
   sessionCount?: number;
   usageFiveH?: number;
   processingCount?: number;
+  deviceInfoFresh: boolean;
   transportOpen: boolean;
   lastReadAt: number;
   lastWriteAt: number;
@@ -1883,6 +1908,7 @@ export function getSerialConnectionStatus(): Array<{
     sessionCount: c.deviceInfo?.sessionCount,
     usageFiveH: c.deviceInfo?.usageFiveH,
     processingCount: c.deviceInfo?.processingCount,
+    deviceInfoFresh: c.deviceInfoFresh,
     lastReadAt: c.lastReadAt,
     lastWriteAt: c.lastWriteAt,
     lastReadSecondsAgo: c.lastReadAt > 0 ? Math.floor((now - c.lastReadAt) / 1000) : null,

--- a/bridge/src/passive-observer.ts
+++ b/bridge/src/passive-observer.ts
@@ -138,6 +138,15 @@ const MAX_TAIL_BYTES = 512 * 1024;
 const MAX_SAMPLE_BYTES = 1024 * 1024;
 /** Transcript/rollout silence after which an end-event-less turn is presumed dead. */
 const STALE_TURN_MS = 10 * 60 * 1000;
+/**
+ * A desktop app-server keeps rollout descriptors open for chats retained by
+ * the Codex App, including conversations that have not done work for days.
+ * An idle descriptor is therefore only a recent observation, not process
+ * liveness. Mirror the Swift daemon's `codexIdleObservationStaleTTL`: after
+ * this window the chat remains resumable in Codex, but leaves AgentDeck's
+ * active-session roster until its rollout changes again.
+ */
+export const CODEX_APP_IDLE_ROLLOUT_TTL_MS = 90_000;
 
 export function observedStateAfterSilence(
   state: ObservedState,
@@ -715,6 +724,7 @@ export async function collectCodexSessionsFromRollouts(
   processes: ProcInfo[],
   rolloutsByPid: Map<number, string[]>,
   rolloutCache: CodexRolloutCache,
+  now = Date.now(),
 ): Promise<ObservedSession[]> {
   const byPid = new Map(processes.map((p) => [p.pid, p]));
   const codex = processes.filter((p) => isCodexSessionProcessCommand(p.command));
@@ -733,14 +743,17 @@ export async function collectCodexSessionsFromRollouts(
       if (!snapshot || snapshot.summary.isSubagent) continue;
       const parsed = snapshot.summary;
       let state = parsed.state;
-      if (state === 'processing' && !parsed.hasPendingCalls && Date.now() - snapshot.mtimeMs > STALE_TURN_MS) {
+      if (state === 'processing' && !parsed.hasPendingCalls && now - snapshot.mtimeMs > STALE_TURN_MS) {
         state = 'idle';
+      }
+      const desktop = proc.command.includes('app-server');
+      if (desktop && state === 'idle' && now - snapshot.mtimeMs > CODEX_APP_IDLE_ROLLOUT_TTL_MS) {
+        continue;
       }
       const sessionId = parsed.sessionId ?? codexRolloutId(rollout);
       if (seen.has(sessionId)) continue;
       seen.add(sessionId);
       const cwd = parsed.cwd;
-      const desktop = proc.command.includes('app-server');
       sessions.push({
         id: desktop ? `observed:codex-app:${sessionId}` : `observed:codex:${sessionId}`,
         port: 0,


### PR DESCRIPTION
## Summary
- expire idle Codex App rollout observations after 90 seconds while preserving live Codex CLI and processing sessions
- fold and sort Codex project sessions in the Node daemon canonical snapshot, matching the Swift daemon across initial and periodic broadcasts
- require current two-way serial liveness before suppressing a board WiFi display path, and expose whether device info came from the current connection

## Verification
- `pnpm test` — 231 files, 3,603 tests
- `pnpm build`
- `pnpm docs:check`
- targeted ESLint — 0 errors (9 pre-existing warnings)
- `git diff --check`