### PR TITLE
Gate npm 1.2.0 on managed-session compatibility and three-mode soak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,24 +42,27 @@ bumped, superseded by 1.0.17, and never published, so it exists only in git.
 
 This is a backward-compatible minor release. It keeps protocol compatibility
 major 1 and delivers the daemon, Surface, and Work-board changes accumulated
-since npm 1.1.0. Managed agent launchers still work in this release; their
-deprecation is an announced migration, not a removal.
+since npm 1.1.0. Managed agent launchers still work in this release. They are a
+legacy compatibility path with no removal date, not a capability-removal notice.
 
-### Normal agent commands are now the only recommended launch path
+### Normal agent commands are now the default launch path
 
 `agentdeck claude`, `agentdeck codex`, `agentdeck opencode`, and
-`agentdeck monitor` now identify themselves as deprecated in help and print an
-actionable warning before starting their existing per-session bridge. The
-replacement is `agentdeck daemon install` followed by the agent's normal
-command. `agentdeck diag agents [--json]` checks the installed Claude Code,
+`agentdeck monitor` now identify themselves as legacy compatibility commands in
+help and print an actionable notice before starting their existing per-session
+bridge. The recommended default for ordinary local sessions is `agentdeck daemon
+install` followed by the agent's normal command. `agentdeck diag agents [--json]`
+checks the installed Claude Code,
 Codex, and OpenCode versions against AgentDeck's lifecycle compatibility
 baselines without opening a PTY or requiring a running daemon.
 
-The old commands are not tombstones: remote attach, `--weight`, terminal UI
-steering, and terminal telemetry still have no direct-launch equivalent, so
-the managed implementation and `node-pty` remain available through the 1.x
-compatibility window. A 1.1 managed worker's register/state frames remain
-accepted by the 1.2 daemon and continue to surface as managed sessions.
+The old commands are not tombstones: remote attach, `--weight`,
+`AGENTDECK_COMMANDER_ARGS`, agent-specific `AGENTDECK_*_ARGS`, terminal UI
+steering, and terminal telemetry still have no daemon-first equivalent. The
+managed implementation and `node-pty` remain available while replacements are
+designed and validated in Discussion #278 and issue #273. A 1.1 managed worker's
+register/state frames remain accepted by the 1.2 daemon and continue to surface
+as managed sessions.
 
 ### Portable readers receive complete, bounded content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,17 @@ Stream Deck+ controller for AI coding agents — a bidirectional local control s
 
 See [docs/architecture.md](docs/architecture.md) for full architecture details (BridgeCore, PtyAdapter hierarchy, device modules, AgentAdapter abstraction, Gateway protocol, plugin connection model).
 
-**Managed-session deprecation:** `agentdeck claude`, `agentdeck codex`,
-`agentdeck opencode`, and `agentdeck monitor` remain functional during the
-current compatibility-major but are deprecated under
-[#273](https://github.com/puritysb/AgentDeck/issues/273). New work targets
-`agentdeck daemon install` plus normal agent commands. Do not add new PTY parser,
-per-session bridge, `--weight`, or remote-attach dependencies unless #273 first
-records why the daemon-first path cannot own the capability.
+**Managed-session compatibility:** `agentdeck claude`, `agentdeck codex`,
+`agentdeck opencode`, and `agentdeck monitor` remain functional with no removal
+date. New ordinary-session work targets `agentdeck daemon install` plus normal
+agent commands, but managed-only remote attach, `--weight`,
+`AGENTDECK_<AGENT>_ARGS`, and terminal controls are product contracts until
+validated replacements exist. [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278)
+collects workflows; [#273](https://github.com/puritysb/AgentDeck/issues/273)
+owns implementation gates. Do not add new PTY parser or per-session bridge
+dependencies unless #273 first records why daemon-first cannot own the
+capability; likewise, do not delete a managed dependency while a tracked
+workflow still relies on it.
 
 ## Build
 
@@ -122,7 +126,7 @@ The Node.js bridge, hook installer, and Stream Deck plugin run on Windows 11 (Ap
 
 ## Linux dev setup
 
-The Node.js bridge + daemon run on Linux; the **Stream Deck desktop app is unavailable**, so the plugin host and its setup/CLI steps are skipped (device control is via the daemon + Apple/Android companions). Normal `claude`/`codex`/`opencode` observation, mDNS (pure-JS `bonjour-service`), and hook HTTP all work; the deprecated `agentdeck <agent>` managed path remains functional only during the compatibility window. Autostart is a per-user **systemd `--user` unit** `agentdeck-daemon.service` (`bridge/src/linux-service.ts`, analog of the LaunchAgent/Scheduled Task; degrades to a manual-start hint without systemd; `loginctl enable-linger` for headless boot). `npx @agentdeck/setup` checks for a C toolchain (`node-pty` still builds from source for the deprecated PTY path) instead of Xcode CLT and skips Stream Deck checks. Full prereqs/differences: **[docs/linux.md](docs/linux.md)** (README links it the same way as docs/windows.md). Code refs: `bridge/src/linux-service.ts`, `bridge/src/cli.ts`, `bridge/src/pty-manager.ts`, `setup/src/setup.ts`.
+The Node.js bridge + daemon run on Linux; the **Stream Deck desktop app is unavailable**, so the plugin host and its setup/CLI steps are skipped (device control is via the daemon + Apple/Android companions). Normal `claude`/`codex`/`opencode` observation, mDNS (pure-JS `bonjour-service`), and hook HTTP all work; the legacy `agentdeck <agent>` managed path remains functional for compatibility while replacements are validated. Autostart is a per-user **systemd `--user` unit** `agentdeck-daemon.service` (`bridge/src/linux-service.ts`, analog of the LaunchAgent/Scheduled Task; degrades to a manual-start hint without systemd; `loginctl enable-linger` for headless boot). `npx @agentdeck/setup` checks for a C toolchain (`node-pty` still builds from source for the managed PTY path) instead of Xcode CLT and skips Stream Deck checks. Full prereqs/differences: **[docs/linux.md](docs/linux.md)** (README links it the same way as docs/windows.md). Code refs: `bridge/src/linux-service.ts`, `bridge/src/cli.ts`, `bridge/src/pty-manager.ts`, `setup/src/setup.ts`.
 
 Dev-only note: when debugging Windows issues, run commands directly in PowerShell so output appears in the conversation — the Apple/Xcode diagnostic bundle is macOS-only.
 

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,32 @@
 
 ---
 
+## 2026-08-31 — managed PTY 정리는 capability 제거가 아니라 replacement-gated migration이다
+
+npm 1.2.0 준비에서 `agentdeck claude|codex|opencode|monitor`를 곧 제거할
+명령처럼 공지했지만, remote attach와 `--weight`의 원 구현자이자 실사용자인
+@doug-w가 두 기능과 `AGENTDECK_CLAUDE_ARGS`를 모두 일상 워크플로에 사용하며,
+세 가지가 사라지면 private fork를 유지해야 한다고 피드백했다. 구현 이력을 다시
+대조한 결과 우려가 타당했다. remote attach는 #24의 SSH/NAT worker→main-node
+same-socket 제어 제품 시나리오이고, weight는 #62의 terminal-tab→physical-deck-slot
+매핑이며, agent별 args는 #93의 resume/custom-command 합성 계약이다. 셋 모두
+daemon-first equivalent가 없고, 특히 args 계약은 #273의 최초 영향 표에서 누락됐다.
+
+제품 방향은 daemon-first를 기본으로 유지한다. lifecycle의 권위도 계속 hook/event에
+있고 PTY parser로 돌아가지 않는다. 대신 **workflow를 보존한 뒤 implementation을
+교체**한다. remote attach는 outbound daemon worker/relay, weight는 observed session에도
+적용되는 daemon-persisted pin/order, args는 lightweight non-PTY exec/profile 같은 후보를
+실제 사용자 시나리오로 검증하기 전에는 managed compatibility path를 제거하지 않는다.
+제거 날짜도 두지 않는다.
+
+[Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278)을 Ideas에
+열어 topology/order/argument/terminal-control 요구사항을 모으고, #273은 예정된
+retirement 티켓에서 replacement gate와 release checklist를 관리하는 구현 티켓으로
+재작성했다. 1.2.0의 runtime/help/README/CLI/CHANGELOG/architecture/platform 문구도
+`deprecated; will be removed`에서 `legacy compatibility; no removal date`로 바꾸고,
+`AGENTDECK_COMMANDER_ARGS`와 agent별 `AGENTDECK_*_ARGS`를 명시적 공개 계약으로
+추가했다.
+
 ## 2026-08-30 — Design token self-test가 생성 대시보드의 실제 primitive를 다시 변조한다
 
 `verify-tokens-sync.py --self-test`의 두 CSS-root 케이스가 예전에 제거된

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ terminal dashboard. Install both on the same Mac and the app automatically
 attaches to the CLI daemon, adding the CLI-tier capabilities on top — Claude
 subscription quota gauges and ADB-driven Android/e-ink surfaces. The legacy
 managed-terminal tier also retains PTY session launching and cross-machine
-remote attach during its deprecation window. The exact split is documented in
+remote attach while daemon-first replacements are designed and validated. The
+exact split is documented in
 [docs/appstore-feature-matrix.md](docs/appstore-feature-matrix.md).
 
 **The CLI path needs:** macOS 15+, Windows 11 ([guide](docs/windows.md)), or Linux
@@ -111,17 +112,20 @@ agentdeck diag agents
 
 > [!IMPORTANT]
 > `agentdeck claude`, `agentdeck codex`, `agentdeck opencode`, and
-> `agentdeck monitor` are deprecated. They remain functional during the current
-> compatibility-major, but will be removed in a future coordinated major.
-> Migrate now with `agentdeck daemon install`, then run the agent normally.
-> PTY-only features such as remote attach, `--weight`, terminal UI steering,
-> and terminal telemetry do not yet have direct-launch equivalents; follow
-> [#273](https://github.com/puritysb/AgentDeck/issues/273) or report your use case there.
+> `agentdeck monitor` are legacy compatibility commands. They remain functional,
+> and no removal date is set. For ordinary local sessions, prefer
+> `agentdeck daemon install`, then run the agent normally. Managed-only features
+> such as remote attach, `--weight`, `AGENTDECK_<AGENT>_ARGS`, terminal UI
+> steering, and terminal telemetry do not yet have daemon-first equivalents.
+> Share workflows and help design replacements in
+> [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278);
+> implementation and release work remain tracked in
+> [#273](https://github.com/puritysb/AgentDeck/issues/273).
 
 Kiro has no managed form at all — see [Agents](#agents) for why, and for what its
 sessions do and do not report.
 
-The deprecated managed path can still attach agents on **several machines** to
+The legacy managed compatibility path can attach agents on **several machines** to
 one deck on a main node. `--remote-daemon` is the opt-in switch — without it
 nothing leaves the machine and the default stays local-only:
 
@@ -292,7 +296,8 @@ managed session supplies real options, or when an observed session advertises a
 real answer-delivery path (`liveAnswerable`) through an ask-gate or terminal
 injection. Otherwise the prompt is display-only. On macOS the SwiftUI app ships a
 **standalone in-process Swift dashboard daemon** with no Node.js. The PTY Session
-Bridge remains available only as a deprecated CLI compatibility feature.
+Bridge remains available as a CLI compatibility feature until its managed-only
+workflows have validated daemon-first replacements.
 
 Details: **[docs/architecture.md](docs/architecture.md)**.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -196,13 +196,17 @@ when editing a published body.
 #### Pre-tag three-mode daemon soak
 
 Run this from a clean checkout of the commit that will receive the tag. Record the
-previous installed CLI version and a rollback command before replacing it, and put
-the measured results in the release issue. All three rows are required:
+previous installed CLI version and a rollback command before replacing it. Also
+record the macOS app's exact version and build: an npm-only release must test
+against the currently delivered app, while a coordinated Apple+npm round uses the
+Apple release candidate. Put the measured results in the release issue. All three
+rows are required:
 
-1. **Swift daemon only** — stop the CLI daemon, launch the built macOS app, and
+1. **Swift daemon only** — stop the CLI daemon, launch the recorded macOS app, and
    confirm port 9120 is owned by `AgentDeck` with `/health` reporting `isSwift:
    true`. Use at least one real directly launched agent turn and confirm that its
-   state reaches the app plus at least one connected downstream surface.
+   state reaches the app plus at least one connected downstream surface. Do not
+   run two copies with the same bundle identifier to stand in for this row.
 2. **CLI daemon only** — quit the macOS app, start the installed release-candidate
    `agentdeck` daemon, and confirm the installed binary reports the target version
    and `/health` reports `isSwift: false`. Repeat a real agent turn and downstream

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -185,8 +185,39 @@ when editing a published body.
 
 1. Verify all four public npm manifests match each other and that the target version is unused on npm.
 2. Run `pnpm build` and tests.
-3. Tag the exact release commit as `npm-v<TARGET_VERSION>` and push it. CI runs `node scripts/publish-npm.mjs`, which enforces the dependency order (`shared`+`hooks` → `bridge` → `setup`) and rewrites `workspace:*` around each publish. Do **not** substitute `pnpm publish`: pnpm (verified 11.5.2) uploads README.md inside the tarball but never attaches the readme to the registry packument, and npmjs.com renders the package page from the packument — that is why every @agentdeck page was blank through 1.0.14.
-4. Confirm the workflow read all four exact versions back from npm, each package's `latest` dist-tag matches the target, and `npm view @agentdeck/setup readme` is non-empty.
+3. Pack all four packages from the exact release commit, install that candidate through
+   the maintainer's real `agentdeck` command path, and complete the **three-mode
+   daemon soak** below. A temporary-prefix smoke is useful but does not replace this
+   gate: it does not exercise upgrades, the installed hook configuration, port 9120
+   ownership, or the macOS app's hand-off behavior.
+4. Tag the exact release commit as `npm-v<TARGET_VERSION>` and push it. CI runs `node scripts/publish-npm.mjs`, which enforces the dependency order (`shared`+`hooks` → `bridge` → `setup`) and rewrites `workspace:*` around each publish. Do **not** substitute `pnpm publish`: pnpm (verified 11.5.2) uploads README.md inside the tarball but never attaches the readme to the registry packument, and npmjs.com renders the package page from the packument — that is why every @agentdeck page was blank through 1.0.14.
+5. Confirm the workflow read all four exact versions back from npm, each package's `latest` dist-tag matches the target, and `npm view @agentdeck/setup readme` is non-empty.
+
+#### Pre-tag three-mode daemon soak
+
+Run this from a clean checkout of the commit that will receive the tag. Record the
+previous installed CLI version and a rollback command before replacing it, and put
+the measured results in the release issue. All three rows are required:
+
+1. **Swift daemon only** — stop the CLI daemon, launch the built macOS app, and
+   confirm port 9120 is owned by `AgentDeck` with `/health` reporting `isSwift:
+   true`. Use at least one real directly launched agent turn and confirm that its
+   state reaches the app plus at least one connected downstream surface.
+2. **CLI daemon only** — quit the macOS app, start the installed release-candidate
+   `agentdeck` daemon, and confirm the installed binary reports the target version
+   and `/health` reports `isSwift: false`. Repeat a real agent turn and downstream
+   surface update; also exercise one release-relevant CLI diagnostic or action.
+3. **Both processes running** — launch the macOS app and the CLI daemon together.
+   Confirm there is exactly one listener on 9120, the app defers to or attaches to
+   the CLI daemon without a duplicate roster, and connected surfaces stay live.
+   Stop the CLI daemon while leaving the app open and confirm the Swift daemon
+   reclaims 9120 and the roster/surfaces recover without reinstalling hooks.
+
+Do not tag on a launch-only observation. Each single-daemon row needs a real agent
+turn and visible downstream delivery, and the coexistence row needs both takeover
+and recovery. Any crash, duplicate session/device, stale state, lost hook, failed
+port hand-off, or required manual repair blocks the tag until it is explained and
+either fixed or explicitly waived in the release issue.
 
 `npm-release.yml` runs on the tag: it re-verifies the version, builds, tests, publishes in dependency order, reads all four exact versions back from the npm registry, and only then creates the GitHub Release. npmjs.com must configure a GitHub Actions **Trusted Publisher** for each public package with owner `puritysb`, repository `AgentDeck`, and workflow `npm-release.yml` (`npm publish` allowed). The workflow uses OIDC (`id-token: write`) and intentionally has no long-lived `NPM_TOKEN` or opt-in variable. Missing or drifted trust fails the release instead of producing a green no-op.
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -31,9 +31,11 @@ report through lifecycle hooks or native event channels and can be steered where
 the observed session exposes a real delivery path.
 
 The legacy `agentdeck claude|codex|opencode|monitor` per-session bridges remain
-functional during the current compatibility-major but are deprecated under
-[#273](https://github.com/puritysb/AgentDeck/issues/273). Do not build new
-workflows around their PTY-only options.
+functional compatibility paths with no removal date. Prefer daemon-first for
+ordinary local sessions, but keep managed-only workflows working while
+[Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278) and
+[#273](https://github.com/puritysb/AgentDeck/issues/273) define and validate
+replacements.
 
 Full CLI reference: https://github.com/puritysb/AgentDeck/blob/master/docs/cli.md
 

--- a/bridge/src/__tests__/cli.test.ts
+++ b/bridge/src/__tests__/cli.test.ts
@@ -12,7 +12,7 @@ import {
   daemonPostureArgs,
   buildPlist,
   waitForDaemonPid,
-  managedPtyDeprecationNotice,
+  managedPtyCompatibilityNotice,
 } from '../cli.js';
 import { allModulesOff } from '../modules/types.js';
 
@@ -57,28 +57,32 @@ describe('agentdeck CLI parser', () => {
     expect(stderr).not.toContain('too many arguments');
   });
 
-  it('marks every legacy per-session command as deprecated in --help metadata', () => {
+  it('marks every managed per-session command as legacy compatibility in --help metadata', () => {
     for (const name of ['claude', 'codex', 'opencode', 'monitor']) {
       const command = program.commands.find((candidate) => candidate.name() === name);
-      expect(command?.description()).toContain('[deprecated]');
+      expect(command?.description()).toContain('[legacy compatibility]');
     }
   });
 });
 
-describe('managed PTY deprecation contract', () => {
+describe('managed PTY compatibility contract', () => {
   it.each(['claude', 'codex', 'opencode'] as const)(
     'points agentdeck %s users to daemon-first direct launch',
     (command) => {
-      const notice = managedPtyDeprecationNotice(command).join('\n');
+      const notice = managedPtyCompatibilityNotice(command).join('\n');
       expect(notice).toContain(`agentdeck ${command}`);
       expect(notice).toContain('agentdeck daemon install');
       expect(notice).toContain(`run \`${command}\` directly`);
+      expect(notice).toContain('AGENTDECK_<AGENT>_ARGS');
+      expect(notice).toContain('No removal date is set');
+      expect(notice).toContain('discussions/278');
       expect(notice).toContain('issues/273');
+      expect(notice).not.toContain('will be removed');
     },
   );
 
   it('points monitor users to all normal agent entry points', () => {
-    const notice = managedPtyDeprecationNotice('monitor').join('\n');
+    const notice = managedPtyCompatibilityNotice('monitor').join('\n');
     expect(notice).toContain('agentdeck monitor');
     expect(notice).toContain('run `claude`, `codex`, or `opencode` normally');
   });
@@ -396,12 +400,12 @@ describe('claude action wiring (parseAsync end-to-end)', () => {
     vi.restoreAllMocks();
   });
 
-  it('prints the migration warning before starting the still-functional bridge', async () => {
+  it('prints the compatibility notice before starting the still-functional bridge', async () => {
     const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
     await program.parseAsync([...base, 'claude', '--no-env-args']);
 
     expect(startSessionMock).toHaveBeenCalledTimes(1);
-    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('DEPRECATED'));
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('LEGACY COMPATIBILITY MODE'));
     expect(stderr).toHaveBeenCalledWith(expect.stringContaining('agentdeck daemon install'));
   });
 

--- a/bridge/src/agent-cli-diagnostics.ts
+++ b/bridge/src/agent-cli-diagnostics.ts
@@ -129,6 +129,6 @@ export function formatAgentCliDiagnosticReport(report: AgentCliDiagnosticReport)
       lines.push(`- ${agent.label}: ${version} — could not evaluate ${agent.compatibleRange}`);
     }
   }
-  lines.push('', `Managed-session deprecation: ${report.trackingIssue}`);
+  lines.push('', `Managed-session compatibility: ${report.trackingIssue}`);
   return lines.join('\n');
 }

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -53,26 +53,26 @@ function warnIfDaemonHostIgnored(opts: { remoteDaemon?: boolean; daemonHost?: st
   }
 }
 
-export type DeprecatedSessionCommand = 'claude' | 'codex' | 'opencode' | 'monitor';
+export type LegacySessionCommand = 'claude' | 'codex' | 'opencode' | 'monitor';
 
 /**
- * User-visible migration notice for the legacy per-session bridge. Keep this
- * pure so CLI tests can pin the public deprecation contract without starting
+ * User-visible compatibility notice for the legacy per-session bridge. Keep
+ * this pure so CLI tests can pin the public migration contract without starting
  * a PTY or importing its native dependencies.
  */
-export function managedPtyDeprecationNotice(command: DeprecatedSessionCommand): string[] {
+export function managedPtyCompatibilityNotice(command: LegacySessionCommand): string[] {
   const directLaunch = command === 'monitor'
     ? 'run `claude`, `codex`, or `opencode` normally'
     : `run \`${command}\` directly`;
   return [
-    `[agentdeck] DEPRECATED: \`agentdeck ${command}\` uses the legacy per-session bridge and will be removed in the next AgentDeck compatibility-major release.`,
-    `[agentdeck] Migrate now: run \`agentdeck daemon install\`, then ${directLaunch}.`,
-    '[agentdeck] PTY-only features such as --remote-daemon, --weight, terminal UI steering, and terminal telemetry have no direct-launch equivalent. Tracking: https://github.com/puritysb/AgentDeck/issues/273',
+    `[agentdeck] LEGACY COMPATIBILITY MODE: \`agentdeck ${command}\` uses the managed per-session bridge; daemon-first launch is the recommended default.`,
+    `[agentdeck] For ordinary local sessions, run \`agentdeck daemon install\`, then ${directLaunch}.`,
+    '[agentdeck] --remote-daemon, --weight, AGENTDECK_<AGENT>_ARGS, and terminal-only controls do not yet have daemon-first equivalents. No removal date is set. Design: https://github.com/puritysb/AgentDeck/discussions/278 Tracking: https://github.com/puritysb/AgentDeck/issues/273',
   ];
 }
 
-function warnManagedPtyDeprecation(command: DeprecatedSessionCommand): void {
-  for (const line of managedPtyDeprecationNotice(command)) console.error(line);
+function warnManagedPtyCompatibility(command: LegacySessionCommand): void {
+  for (const line of managedPtyCompatibilityNotice(command)) console.error(line);
 }
 
 function log(msg: string): void {
@@ -664,7 +664,7 @@ weatherCommand
 
 program
   .command('claude')
-  .description('[deprecated] Start Claude Code in the legacy PTY session bridge')
+  .description('[legacy compatibility] Start Claude Code in the managed PTY session bridge')
   .option('-p, --port <port>', 'Bridge server port', String(BRIDGE_WS_PORT))
   .option('-c, --command <cmd>', 'Command to spawn', 'claude')
   .option('-d, --debug', 'Enable debug logging')
@@ -680,7 +680,7 @@ program
   .option('--no-env-args', 'Ignore AGENTDECK_COMMANDER_ARGS and AGENTDECK_<AGENT>_ARGS for this invocation')
   .option('--weight <n>', 'Deck/tab sort order override (integer, lower first; default 0)', parseWeight)
   .action(async (opts) => {
-    warnManagedPtyDeprecation('claude');
+    warnManagedPtyCompatibility('claude');
     warnIfDaemonHostIgnored(opts);
     const { startSession } = await import('./index.js');
     await startSession({
@@ -710,7 +710,7 @@ program
 
 program
   .command('codex')
-  .description('[deprecated] Start Codex in the legacy PTY session bridge')
+  .description('[legacy compatibility] Start Codex in the managed PTY session bridge')
   .option('-p, --port <port>', 'Bridge server port', String(BRIDGE_WS_PORT))
   .option('-c, --command <cmd>', 'Command to spawn', 'codex')
   .option('-d, --debug', 'Enable debug logging')
@@ -724,7 +724,7 @@ program
   .option('--no-env-args', 'Ignore AGENTDECK_COMMANDER_ARGS and AGENTDECK_<AGENT>_ARGS for this invocation')
   .option('--weight <n>', 'Deck/tab sort order override (integer, lower first; default 0)', parseWeight)
   .action(async (opts) => {
-    warnManagedPtyDeprecation('codex');
+    warnManagedPtyCompatibility('codex');
     warnIfDaemonHostIgnored(opts);
     // Install Codex lifecycle hooks before starting the session so the
     // first prompt's UserPromptSubmit / Stop events reach the daemon.
@@ -769,7 +769,7 @@ program
 
 program
   .command('opencode')
-  .description('[deprecated] Start OpenCode in the legacy PTY/SSE session bridge')
+  .description('[legacy compatibility] Start OpenCode in the managed PTY/SSE session bridge')
   .option('-p, --port <port>', 'Bridge server port', String(BRIDGE_WS_PORT))
   .option('-c, --command <cmd>', 'Command to spawn', 'opencode')
   .option('-d, --debug', 'Enable debug logging')
@@ -783,7 +783,7 @@ program
   .option('--no-env-args', 'Ignore AGENTDECK_COMMANDER_ARGS and AGENTDECK_<AGENT>_ARGS for this invocation')
   .option('--weight <n>', 'Deck/tab sort order override (integer, lower first; default 0)', parseWeight)
   .action(async (opts) => {
-    warnManagedPtyDeprecation('opencode');
+    warnManagedPtyCompatibility('opencode');
     warnIfDaemonHostIgnored(opts);
     // Install the OpenCode observer plugin so standalone `opencode` runs
     // (outside this managed session) also reach the daemon timeline. The
@@ -826,7 +826,7 @@ program
 
 program
   .command('monitor')
-  .description('[deprecated] Start the legacy hook-only per-session bridge')
+  .description('[legacy compatibility] Start the managed hook-only per-session bridge')
   .option('-p, --port <port>', 'Bridge server port', String(BRIDGE_WS_PORT))
   .option('-d, --debug', 'Enable debug logging')
   .option('--local', 'Disable all device modules')
@@ -837,7 +837,7 @@ program
   .option('--no-env-args', 'Ignore AGENTDECK_COMMANDER_ARGS for this invocation')
   .option('--weight <n>', 'Deck/tab sort order override (integer, lower first; default 0)', parseWeight)
   .action(async (opts) => {
-    warnManagedPtyDeprecation('monitor');
+    warnManagedPtyCompatibility('monitor');
     warnIfDaemonHostIgnored(opts);
     const { startSession } = await import('./index.js');
     const port = parseInt(opts.port, 10);

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -28,14 +28,14 @@ This repo is built by switching between **Claude Code, Codex, OpenCode, and occa
 
 | Agent | Enters repo via | Instruction files it reads | Skill/workflow auto-discovery | Known limits in the harness |
 |---|---|---|---|---|
-| **Claude Code** | native `claude` (`agentdeck claude` deprecated) | `CLAUDE.md`; `.claude/skills/` | `.claude/skills/*.md` (pointers → `.agents/skills/`) | `.claude/skills/` files must stay **pointers**, not procedure copies |
-| **Codex** | native `codex` (`agentdeck codex` deprecated) | `AGENTS.md` → `CLAUDE.md` | `.agents/skills/` (repo-scoped) + `.agents/workflows/` | — |
-| **OpenCode** | native `opencode` (`agentdeck opencode` deprecated) | `AGENTS.md` → `CLAUDE.md` | No repo hook/skill auto-discovery | Fully supported as a product session type through the observer plugin; when authoring this repo, point it explicitly at `.agents/workflows/<name>.md` |
+| **Claude Code** | native `claude` (`agentdeck claude` is legacy compatibility) | `CLAUDE.md`; `.claude/skills/` | `.claude/skills/*.md` (pointers → `.agents/skills/`) | `.claude/skills/` files must stay **pointers**, not procedure copies |
+| **Codex** | native `codex` (`agentdeck codex` is legacy compatibility) | `AGENTS.md` → `CLAUDE.md` | `.agents/skills/` (repo-scoped) + `.agents/workflows/` | — |
+| **OpenCode** | native `opencode` (`agentdeck opencode` is legacy compatibility) | `AGENTS.md` → `CLAUDE.md` | No repo hook/skill auto-discovery | Fully supported as a product session type through the observer plugin; when authoring this repo, point it explicitly at `.agents/workflows/<name>.md` |
 | **Antigravity** | manual editing, or native Antigravity CLI/app | `AGENTS.md` → `CLAUDE.md` | Instruction files only; no repo hook/skill auto-discovery | Current product session visibility is CLI-daemon passive discovery only; the App Store app shows usage/credit status, not coding-session observation |
 
 Notes:
 - **Claude Code & Codex** are the two first-class authoring agents: both get lifecycle hooks (Claude: `~/.claude/settings.json` — written by the CLI installer, or by the App Store opt-in installer against the user-selected file; Codex: `~/.codex/config.toml`) and discover skills.
-- **OpenCode** is a fully supported *product session type* through its observer plugin. The deprecated `agentdeck opencode` PTY + SSE overlay remains available only during the current compatibility-major. OpenCode still does not auto-discover this repo's skills or hooks as an authoring tool; explicit workflow paths are the supported handoff.
+- **OpenCode** is a fully supported *product session type* through its observer plugin. The legacy `agentdeck opencode` PTY + SSE overlay remains available as a replacement-gated compatibility path. OpenCode still does not auto-discover this repo's skills or hooks as an authoring tool; explicit workflow paths are the supported handoff.
 - **Antigravity** reads the repo instruction chain only. AgentDeck does not install or auto-discover Antigravity hooks/skills; the App Store app reads only the user-approved usage/credit database, while coding-session creatures require optional CLI-daemon passive discovery.
 
 ## SSOT rules (where each kind of knowledge lives)

--- a/docs/apme.md
+++ b/docs/apme.md
@@ -251,7 +251,7 @@ v_category_scorecard    -- (task_category, model_id) 그룹: runs, avg_overall,
 2. **Claude Code**: `adapter.on('event', 'hook')` → `claudeHookToSpans` → `apme.collector.ingestSpan(sessionId, span)`
 3. **Non-Claude 에이전트** (OpenClaw/OpenCode/Codex): `wireAgentApme(adapter, agentType, apme, core)` — timeline 이벤트(OpenClaw/OpenCode)와 Codex lifecycle hook + notify를 collector로 변환
 4. **Claude Code 응답 캡처**: Stop hook의 `transcript_path` JSONL tail 을 읽어 `setTurnResponse()` (`readClaudeTranscriptLastTurn`). Stop 자체가 유실되면 hook 침묵 + transcript `end_turn` 레코드를 근거로 synthetic Stop 을 주입해 **같은 경로로** 닫는다 — 화면(PTY) 파싱은 어느 단계에도 없다. 복구는 세션 종류별로 두 벌:
-   - **deprecated managed PTY** (`agentdeck claude`) — `claude-turn-watchdog.ts`, 브리지 프로세스당 1개, 어댑터 이벤트 파이프로 직접 주입
+   - **legacy managed PTY** (`agentdeck claude`) — `claude-turn-watchdog.ts`, 브리지 프로세스당 1개, 어댑터 이벤트 파이프로 직접 주입
    - **hook-observed** (터미널에서 직접 `claude`) — `observed-turn-watchdogs.ts`, 데몬 1프로세스가 session_id 로 다중화하므로 **세션당 1개**. 복구는 데몬이 자기 loopback `/hooks/Stop` 으로 self-POST 한다: Stop 분기는 상태머신·타임라인·APME·모델복구·스티어링 6가지를 하는데 그 두 번째 사본은 반드시 드리프트하므로, 복구 경로는 원래 경로와 **같은 경로여야** 한다. 1.0.20 은 앞의 한 벌만 있었고 실측상 기록된 Claude 턴은 전부 후자여서 복구가 한 턴도 걸리지 않았다
 
    synthetic Stop 에서 지켜야 할 계약 두 가지: **디렉티브 큐를 소비하면 안 된다**(`takeDirectiveForStop`) — 전달은 Claude 가 기다리는 hook 을 block 해서 이뤄지는데 self-POST 응답은 아무도 안 듣기 때문에, 큐에서 꺼내면 사용자 후속 지시가 조용히 증발한다. 그리고 **세션이 식으면 워치독을 수거해야 한다** — 관측 세션은 죽을 때 SessionEnd 를 안 보내므로(터미널 닫힘, 슬립) 수거 없이는 5초 폴링이 데몬 수명 내내 남는다

--- a/docs/appstore-feature-matrix.md
+++ b/docs/appstore-feature-matrix.md
@@ -24,14 +24,14 @@ This matrix defines which capabilities belong to the standalone App Store produc
 | Tier | Contract |
 |---|---|
 | Tier 1 — App Store | Complete sandboxed dashboard. No PTY, subprocess, bundled interpreter, helper executable, or install prompt. |
-| Tier 2 — CLI | Optional Node daemon that owns integrations requiring external tools or unrestricted process discovery. Its legacy managed-PTY launcher remains functional during the 1.x deprecation window but is not the default session path. |
+| Tier 2 — CLI | Optional Node daemon that owns integrations requiring external tools or unrestricted process discovery. Its legacy managed-PTY launcher remains functional as a replacement-gated compatibility path but is not the default session path. |
 
-> **Managed-session deprecation:** `agentdeck claude`, `agentdeck codex`,
-> `agentdeck opencode`, and `agentdeck monitor` are deprecated under
-> [#273](https://github.com/puritysb/AgentDeck/issues/273). Install the daemon,
-> then run the agent normally. The commands remain functional throughout the
-> current compatibility-major; their PTY-only capabilities are tracked here
-> until each has a replacement or an explicit retirement decision.
+> **Managed-session compatibility:** `agentdeck claude`, `agentdeck codex`,
+> `agentdeck opencode`, and `agentdeck monitor` remain functional with no
+> removal date. Install the daemon, then run the agent normally for the default
+> path. [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278)
+> collects workflows for managed-only capabilities; implementation and release
+> gates live in [#273](https://github.com/puritysb/AgentDeck/issues/273).
 
 The submitted macOS app must not contain `Process()`, `/bin/sh`, AppleScript, generated `.command` files, or bundled Node/Python/sqlite binaries. Native serial, BLE, local-network, and user-selected-file access remain valid when implemented with Apple frameworks and declared entitlements.
 
@@ -82,7 +82,7 @@ All surfaces follow the same rule:
 | Codex rate limits (passive rollout read) | Yes | Yes | User grants a security-scoped bookmark to `~/.codex`. Both tiers reconcile the snapshot against the live account tier in `auth.json` and **void** one minted under a plan the account no longer holds — neither freshness axis can retire it, since a lapsed plan's weekly window stays future-dated (`codexSnapshotMatchesAccountPlan`, mirrored to Swift as the generated `CodexPlanRules`). Voiding rides the wire as a windowless block, so Tier 1's own daemon retracts the gauge rather than leaving a client to guess |
 | Codex rate limits (live `app-server` query) | No | Yes | The rollout `rate_limits` block is a byproduct of a **successful turn**, so the reading freezes exactly when the quota is exhausted (no turn can complete) and never sees usage spent on Codex Cloud or another machine. Tier 2 backs it with a throttled `codex app-server` → `account/rateLimits/read` JSON-RPC query against the user's own CLI (`bridge/src/codex-rate-limits-live.ts`); the fresher of the two snapshots wins by `capturedAt`. Tier 1 cannot follow — the App Store daemon spawns no subprocess — so it keeps the passive read and its age footnote. This is also why plan reconciliation matters most on Tier 1: with no live query to overwrite it, a retired plan's snapshot is the *only* thing Tier 1 would ever read, and Codex is its only quota gauge (Claude's needs the relay). |
 | Anthropic Admin API usage | Yes | Yes | User supplies the API key |
-| Terminal status-line token and cost telemetry | Hook-only | Yes (deprecated) | Legacy CLI-managed UI telemetry; no direct-launch replacement. Lifecycle correctness comes from hooks/events, never terminal scraping. Tracked in #273 |
+| Terminal status-line token and cost telemetry | Hook-only | Yes (compatibility) | Legacy CLI-managed UI telemetry; no daemon-first replacement. Lifecycle correctness comes from hooks/events, never terminal scraping. Tracked in #273 |
 
 ## Hardware
 
@@ -109,18 +109,19 @@ All surfaces follow the same rule:
 | Codex lifecycle/notify/OTel monitoring | Yes | Yes | Opt-in managed config |
 | Existing terminal-session discovery | Limited | Yes | General `ps` / `lsof` / transcript discovery is CLI-only |
 | Display-only permission attention | Yes | Yes | Real permission notification; no fabricated options |
-| Session order pinning (`--weight` sort override) | Limited | Yes (deprecated) | Weight is CLI-set only by the deprecated managed launcher and reaches the Swift daemon via `session_push_register`; observed-hook sessions never carry it. Replacement-or-retirement decision is tracked in #273 |
+| Session order pinning (`--weight` sort override) | Limited | Yes (compatibility) | Weight is CLI-set only by the managed launcher and reaches the Swift daemon via `session_push_register`; observed-hook sessions never carry it. A daemon-persisted replacement must be validated before this path can be removed; tracked in Discussion #278 and issue #273 |
 | Adaptive high-volume menu bar overview | Yes | Yes | The popup keeps a bounded height at every session/device count: actionable sessions stay visible, idle sessions and repeated surface families collapse into counted summaries, and Activity shows completed work from a named recent window instead of unbounded duration totals. The Dashboard retains the complete roster, topology, and report. This is presentation-only and uses the same daemon state in both tiers |
 | Adaptive high-volume Dashboard session panel | Yes | Yes | The left HUD reserves the Timeline region, widens within a fixed landscape cap, switches to compact rows for larger rosters, and scrolls the complete session collection inside its own bounded card instead of painting over Timeline. Adjacent setup guidance shifts beside the roster rather than covering it. Presentation-only; focus and session data remain identical in both tiers |
 | Form-factor-readable Dashboard HUD | Yes | Yes | iPhone/compact-phone portrait presents one full-width readable HUD rail at a time with an explicit Sessions/System switch; phone landscape, iPad/tablet, and macOS retain the dual-rail terrarium composition with bounded Timeline-safe heights. Android e-ink keeps its static high-contrast, no-scroll projection while typography and spacing scale by reader size. Presentation-only; all tiers consume the same session, topology, and timeline state |
-| Managed terminal UI steering | No | Yes (deprecated) | The legacy compatibility observer reads only real mode/diff/option UI and injects keys; lifecycle state, timeline, and APME remain hook/event-owned. Direct-launch steering uses ask-gates/injection and is not fully equivalent. Tracked in #273 |
+| Managed terminal UI steering | No | Yes (compatibility) | The legacy compatibility observer reads only real mode/diff/option UI and injects keys; lifecycle state, timeline, and APME remain hook/event-owned. Direct-launch steering uses ask-gates/injection and is not fully equivalent. Tracked in #273 |
 | Observed AskUserQuestion — device answer (ask-gate) | Yes | Yes | The daemon holds the question's PreToolUse hook open and resolves it with the option the user picked, stated as the decision reason. Pure HTTP hold, no subprocess, so it works sandboxed. Engaged only when injection is unavailable (always so in Tier 1); an unanswered hold releases empty, and Claude's own picker appears in the terminal as usual. Multi-question calls are answered one question at a time |
 | Observed-session answer injection (device tap → host UI) | No | Yes | tmux / iTerm2 / Terminal.app by tty, GUI apps by AX button or key events. Needs `ps` tty discovery + tmux/osascript subprocesses — both CLI-only; sandbox has neither. Preferred over the ask-gate when available: it answers the live picker with no added latency for whoever is at that terminal |
 | OpenCode monitoring | Opt-in read-only | Yes | Tier 1 connects only to a configured/fixed local server; no port scan |
 | Antigravity session monitoring | No | Yes | Tier 1 may display user-approved usage data only |
 | Kiro CLI / IDE session monitoring | Yes, after granting `~/.kiro` | Yes | Both tiers read Kiro's own store, because Kiro reports nothing on its own: its standalone lifecycle hooks load but CLI chat fires none of them (measured 2026-08-17, kiro-cli 2.18.1 — each hook instrumented with a marker, a live turn produced zero markers while a hand-POSTed hook produced a row normally). The App Store build reaches `~/.kiro` only through a **user-granted security-scoped bookmark** (Settings → Integrations → Kiro CLI), the same shape as `~/.codex`; with no grant it observes nothing rather than guessing. Sessions and their chat rows come from the transcript, so an observed Kiro session is always reported `idle` — passive reading cannot see a turn in flight. Process discovery stays CLI-only; the App Store path keys on the transcript instead |
 | Subagent activity summaries + parent-linked orbit visuals | Yes | Yes | Read-only lifecycle hooks collapse each child to concise start/completion rows using existing Timeline types. Terrarium surfaces may derive non-interactive wire/ring/satellite accents around the owning parent; they never become selectable sessions. No subagent commands, approvals, team configuration, or process discovery |
-| Launch Claude / Codex / OpenCode session | No | Yes (deprecated) | `agentdeck <agent>` remains functional during the 1.x deprecation window. The supported default is `agentdeck daemon install`, then a normal agent command. Tracked in #273 |
+| Managed launch argument profiles (`AGENTDECK_COMMANDER_ARGS`, `AGENTDECK_*_ARGS`, `-c`) | No | Yes (compatibility) | The managed launcher composes persistent and one-off arguments, including resume commands, with platform-specific quoting and override rules. No daemon-first equivalent exists; Discussion #278 and issue #273 gate replacement/removal |
+| Launch Claude / Codex / OpenCode session | No | Yes (compatibility) | `agentdeck <agent>` remains functional with no removal date. The supported default for ordinary local sessions is `agentdeck daemon install`, then a normal agent command. Tracked in #273 |
 | OpenClaw Gateway WebSocket pairing | Yes | Yes | Local WS, Keychain identity, optional user-selected token file |
 | OpenClaw CLI pairing | No | Yes | Requires external `openclaw` process |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Core bridge architecture, adapter hierarchy, and module system. See [daemon.md](
 
 ## Monorepo layout
 
-- **bridge/** — Node.js server: Daemon (sole hub for all clients, mDNS, device modules) + deprecated managed Session Bridge (PTY transport, hook HTTP, state machine; removal tracked in [#273](https://github.com/puritysb/AgentDeck/issues/273)). BridgeCore (shared infra), lifecycle/event adapters, terminal UI observers, WebSocket server, voice (Apple on-device Speech via the bundled helper), usage API client, auth token, SSE broadcast, TUI dashboard (`tui/`)
+- **bridge/** — Node.js server: Daemon (sole hub for all clients, mDNS, device modules) + legacy managed Session Bridge (PTY transport, hook HTTP, state machine; replacement gates tracked in [#273](https://github.com/puritysb/AgentDeck/issues/273)). BridgeCore (shared infra), lifecycle/event adapters, terminal UI observers, WebSocket server, voice (Apple on-device Speech via the bundled helper), usage API client, auth token, SSE broadcast, TUI dashboard (`tui/`)
 - **plugin/** — Stream Deck SDK v2 plugin: actions for buttons/encoders, bridge WebSocket client
 - **shared/** — TypeScript types and utilities shared between bridge and plugin (protocol, states, timeline, adapter interfaces, `format-utils` time/count/bytes formatters, `timeline-summarizer` extractTopicHint/cleanLLMOutput, `deduplicateEntry` pipeline, `session-utils` stateRank/sortSessions/assignDisplayNames — 세션 정렬/번호 공통 유틸리티, 6곳에서 import)
 - **hooks/** — Claude Code CLI hook installer for `~/.claude/settings.json` (the App Store opt-in UI writes the same user-global file, user-selected), Codex lifecycle hook installer for `~/.codex/config.toml`, and OpenCode observer plugin installer for `~/.config/opencode/plugins/agentdeck.js`
@@ -40,11 +40,11 @@ Core bridge architecture, adapter hierarchy, and module system. See [daemon.md](
 
 ## PtyAdapter hierarchy
 
-`bridge/src/adapters/pty-adapter.ts` — Transport base for deprecated managed
+`bridge/src/adapters/pty-adapter.ts` — Transport base for legacy managed
 agent terminals. Subclasses implement `getDefaultCommand()`, terminal UI
 observation, and agent-specific input handling. PTY output is not a lifecycle
-authority. This hierarchy remains only for the compatibility-major deprecation
-window; new features target daemon-first observed sessions.
+authority. This hierarchy remains as a replacement-gated compatibility path;
+new ordinary-session features target daemon-first observed sessions.
 
 - `ClaudeCodeAdapter` uses hooks for lifecycle/transcript response capture and a terminal UI observer only for real mode/diff/options/cursor affordances, plus Shift+Tab mode switching
 - `CodexCliAdapter` uses lifecycle hooks + notify completion, with rollout-tail response capture; its terminal UI observer is limited to real approval/options detail
@@ -108,7 +108,7 @@ Not every agent enters through an adapter. Three tiers exist, and which one an
 agent lands in is decided by what that agent will actually tell us — not by
 preference.
 
-1. **Managed PTY (deprecated)** — `agentdeck <agent>`. AgentDeck owns the terminal; removal is tracked in #273.
+1. **Managed PTY (legacy compatibility)** — `agentdeck <agent>`. AgentDeck owns the terminal; Discussion #278 captures workflows and removal gates are tracked in #273.
 2. **Hook-observed** — the user runs `claude` / `codex` / `opencode` normally and
    AgentDeck-installed lifecycle hooks POST to the daemon. This is the default
    and covers the great majority of real traffic.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,12 +16,15 @@ The daemon installs or refreshes the lifecycle integrations and observes agents
 started through their normal commands. The **daemon** (port 9120, `0.0.0.0` by
 default) aggregates all sessions for external clients.
 
-> **Deprecation notice:** `agentdeck claude`, `agentdeck codex`,
-> `agentdeck opencode`, and `agentdeck monitor` still work in the current
-> compatibility-major, but their per-session PTY/bridge path is deprecated.
-> They will be removed in a future coordinated major. PTY-only remote attach,
-> `--weight`, terminal steering, and terminal telemetry have no direct-launch
-> equivalent yet; see [#273](https://github.com/puritysb/AgentDeck/issues/273).
+> **Legacy compatibility notice:** `agentdeck claude`, `agentdeck codex`,
+> `agentdeck opencode`, and `agentdeck monitor` still work, and no removal date
+> is set. The daemon-first default is `agentdeck daemon install` followed by a
+> normal agent launch. Remote attach, `--weight`, `AGENTDECK_<AGENT>_ARGS`,
+> terminal steering, and terminal telemetry do not have daemon-first
+> equivalents yet. Replacement design is discussed in
+> [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278) and
+> implementation remains tracked in
+> [#273](https://github.com/puritysb/AgentDeck/issues/273).
 
 Lifecycle compatibility: Claude Code `>=2.1.50` and Codex CLI `>=0.141.0` are
 the supported hook baselines. All same-major AgentDeck clients remain wire-compatible;
@@ -38,13 +41,14 @@ The CLI command is `agentdeck`.
 
 | Command | Description |
 |---------|-------------|
-| `agentdeck claude` | **Deprecated:** start Claude Code in the legacy PTY session bridge |
-| `agentdeck codex` | **Deprecated:** start Codex in the legacy PTY session bridge |
-| `agentdeck opencode` | **Deprecated:** start OpenCode in the legacy PTY/SSE session bridge |
-| `agentdeck monitor` | **Deprecated:** start the legacy hook-only per-session bridge |
+| `agentdeck claude` | **Legacy compatibility:** start Claude Code in the managed PTY session bridge |
+| `agentdeck codex` | **Legacy compatibility:** start Codex in the managed PTY session bridge |
+| `agentdeck opencode` | **Legacy compatibility:** start OpenCode in the managed PTY/SSE session bridge |
+| `agentdeck monitor` | **Legacy compatibility:** start the managed hook-only per-session bridge |
 
-The following flags document the still-functional deprecation window; new
-workflows should not adopt them.
+The following flags document the managed compatibility path. New ordinary local
+sessions should use the normal agent commands; keep this path when one of these
+capabilities is required.
 
 **Flags:** `-p <port>`, `-c <command>`, `-d` (debug), `--no-update-check`, `--weight <n>`
 **Remote attach flags:** `--remote-daemon`, `--daemon-host <host[:port]>`, `--daemon-token <token>` (pairing token of the remote hub — from `~/.agentdeck/auth-token` there, or `agentdeck token show`; env `AGENTDECK_DAEMON_TOKEN`). Required for a current hub: since issue #145 daemons no longer hand their token to unauthenticated LAN peers.
@@ -60,7 +64,7 @@ workflows should not adopt them.
 
 **Preferred daemon port (`agentdeck daemon port`).** The daemon resolves the port it *intends* to serve from `-p/--port` › `AGENTDECK_DAEMON_PORT` › `settings.json` `daemonPort` › 9120, and records where it actually landed in `daemon.json`. Only the user writes the persisted value (`agentdeck daemon port 9200`, `--clear` to forget it); nothing in the startup path does, because persisting the *outcome* would turn a 14-second kernel hold on 9120 into a permanent move to 9121. When the preferred port is held but nothing answers `/health` there, the daemon waits up to 20s for it rather than conceding — see [docs/daemon.md § Preferred port vs actual port](daemon.md#preferred-port-vs-actual-port).
 
-On the deprecated managed path, the `-c` flag sets the full command AgentDeck
+On the managed compatibility path, the `-c` flag sets the full command AgentDeck
 spawns inside the session PTY, so any arguments you add are forwarded straight
 to the underlying agent. For example, to resume an earlier Claude Code session
 (the interactive picker appears when no id is given):

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -33,10 +33,12 @@ AgentDeck runs two daemon implementations that are **not competitors but collabo
 | mDNS 광고 | 먼저 바인드한 쪽 | 동일 |
 | 세션 집계 + 상태 브로드캐스트 | **CLI 있을 때**, 없으면 Swift | singleton guard |
 
-> **Managed PTY deprecation:** the CLI PTY-spawn row is a compatibility
+> **Managed PTY compatibility:** the CLI PTY-spawn row is a compatibility
 > capability, not the default architecture. `agentdeck claude|codex|opencode`
-> and `agentdeck monitor` remain functional during the current major and are
-> scheduled for retirement under
+> and `agentdeck monitor` remain functional with no removal date. Replacement
+> design is discussed in
+> [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278) and
+> implementation gates live in
 > [#273](https://github.com/puritysb/AgentDeck/issues/273). Daemon-first hook and
 > event observation is the supported path for new workflows.
 
@@ -356,11 +358,11 @@ peer regardless of UID. See [ENTERPRISE-ROADMAP.md](ENTERPRISE-ROADMAP.md) §1.
 
 A session bridge (`agentdeck claude` etc.) normally attaches only to a daemon on its own machine. With **opt-in** remote attach it can instead push to a daemon on another machine and be controlled from that machine's Stream Deck — the use case being "I run Claude Code on several boxes (often over SSH) but have one Stream Deck on a main node."
 
-This feature belongs to the deprecated managed-session path and currently has no
-daemon-first replacement. It remains functional during the current
-compatibility-major while #273 collects affected topologies and decides whether
-to replace or explicitly retire it. Do not adopt it for a new deployment without
-following that issue.
+This feature belongs to the legacy managed-session compatibility path and
+currently has no daemon-first replacement. It remains functional with no removal
+date. Discussion #278 collects affected topologies; #273 requires a validated
+outbound worker/relay replacement before the managed implementation can be
+removed.
 
 - **Enable**: `--remote-daemon` is THE opt-in switch. `--daemon-host <host[:port]>` only names the explicit endpoint (cross-subnet / SSH where multicast doesn't reach) and **requires the switch** — the recommended explicit form is `--remote-daemon --daemon-host mainnode.lan`. Env equivalents: `AGENTDECK_REMOTE_DAEMON=1`, `AGENTDECK_DAEMON_HOST` (alias `AGENTDECK_REMOTE_DAEMON_HOST`). Default is unchanged (local-only).
 - **Opt-in gate (security boundary)**: remote attach never happens on ambient/inherited state — `--remote-daemon` / `AGENTDECK_REMOTE_DAEMON=1` gates **both** remote paths. A host hint given without the switch is inert (the CLI prints a pre-PTY warning via the shared `deriveRemoteAttachOpts` helper, so the derivations can't drift). Within the switch: an unreachable or capability-less named host returns null rather than falling through to mDNS, and mDNS is never consulted on any other signal. With no opt-in and no local daemon, `resolveDaemonTarget` returns null and the session stays local-only (byte-for-byte unchanged). Regression-tested in `bridge/src/__tests__/daemon-target.test.ts` (`resolveDaemonTarget precedence + opt-in gate`).

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,7 +1,7 @@
 # Linux (Bridge + Daemon)
 
 Canonical Linux setup reference. The Node.js **bridge** and **daemon** run on
-Linux — the daemon hub, mDNS advertisement, hook HTTP, and the deprecated
+Linux — the daemon hub, mDNS advertisement, hook HTTP, and the legacy
 managed session bridge (`agentdeck claude` / `codex` / `opencode`). The
 **Stream Deck desktop app is
 not available on Linux**, so the plugin host and its setup steps are skipped;
@@ -28,7 +28,7 @@ cd bridge && pnpm link --global && cd ..
 
 agentdeck daemon install            # hooks + systemd user daemon
 claude                              # supported default: normal observed launch
-agentdeck claude                    # deprecated managed PTY compatibility path
+agentdeck claude                    # legacy managed PTY compatibility path
 ```
 
 `npx @agentdeck/setup` also works on Linux — it checks for the build toolchain
@@ -39,9 +39,9 @@ instead of Xcode CLT and skips the Stream Deck app/CLI steps.
 - **`agentdeck daemon install` / `uninstall`** — registers a per-user **systemd `--user` unit** `agentdeck-daemon.service` (`~/.config/systemd/user/`), the Linux analog of the macOS LaunchAgent. `install` writes + enables + starts it and installs Codex/OpenCode hooks; `uninstall` gracefully shuts down the daemon then `disable --now` + removes the unit. Without systemd it degrades to a "run `agentdeck daemon start` manually" hint. For boot-without-login on a headless host, run `loginctl enable-linger $USER` once. See [docs/daemon.md → Autostart](daemon.md#autostart-loginlogon).
 - **PTY** — `$SHELL -l -c` (fallback `/bin/bash`); `node-pty` is built from source (needs the toolchain above).
 
-The PTY path remains functional only during the current compatibility-major and
-is scheduled for retirement under
-[#273](https://github.com/puritysb/AgentDeck/issues/273). New Linux workflows
-should install the daemon and run agents normally.
+The PTY path remains functional with no removal date. Replacement design and
+gates live in [Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278)
+and [#273](https://github.com/puritysb/AgentDeck/issues/273). New ordinary Linux
+workflows should install the daemon and run agents normally.
 - **Device modules** — `adb` and Pixoo (LAN) work as-is; USB-serial scans `/dev/ttyUSB*` / `/dev/ttyACM*` (add your user to the `dialout` group for access). BLE (Timebox/iDotMatrix) needs a `bleak` venv + BlueZ and is not wired up by default.
 - **Graceful no-ops** — voice/TTS, wifi/usage/Foundation-Models helpers, the APME hardware sampler, and the macOS `osascript` plugin actions are darwin-only and simply do nothing on Linux (no errors).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -83,7 +83,7 @@ Same-socket is the **only** reverse path (no inbound reachability required — w
 
 ## State Machine
 
-Lifecycle hooks own the 6 states; the deprecated managed terminal contributes only
+Lifecycle hooks own the 6 states; the legacy managed terminal contributes only
 prompt-affordance observations (`terminal_ui` events) that hooks cannot see
 yet. The transition table is the SSOT in `shared/src/states.ts`.
 
@@ -125,9 +125,9 @@ yet. The transition table is the SSOT in `shared/src/states.ts`.
 | `DISCONNECTED` | No session | `SessionEnd` hook, PTY exit |
 | `IDLE` | Waiting for prompt | `Stop` hook; missed-Stop transcript watchdog (Claude); notify `codex_turn_complete` (Codex) |
 | `PROCESSING` | Agent working | `UserPromptSubmit` hook; tool-activity hooks recover a dropped prompt-submit |
-| `AWAITING_PERMISSION` | Yes/No response needed | `terminal_ui` permission-prompt observation (deprecated managed sessions) |
-| `AWAITING_OPTION` | Selection needed | `terminal_ui` option-prompt observation (deprecated managed session; numbered list / navigable cursor) |
-| `AWAITING_DIFF` | Diff review | `terminal_ui` diff-prompt observation (deprecated managed session) |
+| `AWAITING_PERMISSION` | Yes/No response needed | `terminal_ui` permission-prompt observation (legacy managed sessions) |
+| `AWAITING_OPTION` | Selection needed | `terminal_ui` option-prompt observation (legacy managed session; numbered list / navigable cursor) |
+| `AWAITING_DIFF` | Diff review | `terminal_ui` diff-prompt observation (legacy managed session) |
 
 `AWAITING_*` exits are hook-driven for Claude/Codex (tool activity after a
 short grace, `Stop`, or the next `UserPromptSubmit` — a prompt answered at the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@
 ## tmux -CC Compatibility
 
 Normal hook-observed sessions need no special handling under iTerm2 `tmux -CC`.
-During the compatibility window, users who deliberately retain the deprecated
+Users who deliberately retain the legacy
 managed-terminal path must run `agentdeck claude` inside a tmux window; the
 bridge owns only its child PTY. This is a legacy compatibility note, not the
 migration path. New and migrated sessions run `claude` directly after

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -39,7 +39,7 @@ cd plugin; streamdeck link bound.serendipity.agentdeck.sdPlugin; cd ..   # then 
 agentdeck daemon install # hooks + per-user Scheduled Task
 # In another terminal:
 claude                  # supported default: normal observed launch
-agentdeck claude        # deprecated managed ConPTY compatibility path
+agentdeck claude        # legacy managed ConPTY compatibility path
 ```
 
 ## Windows differences (intentional)
@@ -48,10 +48,11 @@ agentdeck claude        # deprecated managed ConPTY compatibility path
 - **Env-var default args** — `AGENTDECK_COMMANDER_ARGS` works identically (tokenized in pure JS, no shell). For `AGENTDECK_CLAUDE_ARGS`/`AGENTDECK_CODEX_ARGS`/`AGENTDECK_OPENCODE_ARGS` the appended string is re-parsed by `cmd.exe`, which does not treat single quotes as quoting — use double quotes for values containing spaces. See [cli.md → Environment-variable defaults](cli.md).
 - **PTY** — ConPTY through `cmd.exe` with `/d /s /c` (POSIX uses `/bin/zsh -l -c`). `node-pty`'s Windows prebuild is used as-is, so no Visual Studio Build Tools are required.
 
-The managed ConPTY path remains functional only during the current
-compatibility-major and is scheduled for retirement under
-[#273](https://github.com/puritysb/AgentDeck/issues/273). New Windows workflows
-should install the daemon and run agents normally.
+The managed ConPTY path remains functional with no removal date. Replacement
+design and gates live in
+[Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278) and
+[#273](https://github.com/puritysb/AgentDeck/issues/273). New ordinary Windows
+workflows should install the daemon and run agents normally.
 - **Hooks** — Claude Code hook entries run a `powershell -NoProfile -ExecutionPolicy Bypass -Command "…"` one-liner that reads `daemon.json`, probes `/health`, and POSTs the payload via `Invoke-RestMethod`.
 - **`agentdeck daemon install` / `uninstall`** — registers a per-user **Scheduled Task** `AgentDeckDaemon` with a logon trigger (built-in `schtasks.exe`, no admin elevation), the Windows analog of the macOS LaunchAgent. `install` registers + starts it now and installs Codex hooks; `uninstall` stops the daemon and removes the task. A real Windows Service is intentionally **not** used — it runs in session 0 with no desktop/device access, breaking USB-HID (D200H), audio (wake-word), and the Stream Deck app. See [daemon.md → Autostart](daemon.md#autostart-loginlogon).
 - **Device modules** — `adb` is probed cross-platform; the `/dev/tty.*` USB-serial scan is skipped on Windows (COM-port enumeration not implemented). mDNS and `better-sqlite3` (APME) support Windows; D200H is driven by the Ulanzi Studio plugin over daemon WebSocket.

--- a/setup/README.md
+++ b/setup/README.md
@@ -24,9 +24,11 @@ agentdeck dashboard  # optional terminal dashboard
 ```
 
 The legacy `agentdeck claude`, `agentdeck codex`, `agentdeck opencode`, and
-`agentdeck monitor` session bridges are deprecated and tracked in
-[#273](https://github.com/puritysb/AgentDeck/issues/273). They remain functional
-during the current compatibility-major for migration.
+`agentdeck monitor` session bridges remain functional compatibility paths with
+no removal date. Workflow design is discussed in
+[Discussion #278](https://github.com/puritysb/AgentDeck/discussions/278) and
+implementation is tracked in
+[#273](https://github.com/puritysb/AgentDeck/issues/273).
 
 No Stream Deck required — the daemon is the product; decks and other devices are optional ways to look at it.
 


### PR DESCRIPTION
## Summary

- require the installed release candidate, not only a temporary-prefix smoke, before any npm tag
- exercise Swift-only, CLI-only, and concurrent Node-takeover/Swift-recovery modes
- require a real agent turn and downstream surface delivery in both single-daemon modes
- revise the managed-session notice after active-user feedback: legacy compatibility, no removal date, and replacement-gated cleanup
- add `AGENTDECK_COMMANDER_ARGS` and agent-specific `AGENTDECK_*_ARGS` to the affected public-contract inventory
- connect runtime/help/README/CHANGELOG/architecture/platform guidance to Discussion #278 and implementation tracker #273

## Product decision

Daemon-first observation remains the recommended default and hooks/events remain lifecycle authority. Managed PTY internals may be replaced, but remote attach, deterministic session ordering, custom launch arguments, and proven terminal-only controls cannot be removed until equivalent workflows are validated.

This keeps all managed commands and capabilities functional in npm 1.2.0.

## Verification

- [x] `pnpm build`
- [x] `pnpm test` — 239 files, 3,727 passed, 1 skipped
- [x] focused CLI/diagnostics tests — 57 passed
- [x] bridge `tsc --noEmit`
- [x] `pnpm docs:check`
- [x] `pnpm verify-version`
- [x] `pnpm verify-release-version npm 1.2.0`
- [x] dry-run pack for shared, hooks, bridge, and setup
- [ ] complete the installed Swift-only / CLI-only / concurrent hands-on soak

Tracks the tag blocker in #274 and the replacement gates in #273. Workflow research is in Discussion #278.