### PR TITLE
Fix macOS managed PTY launch from fresh npm installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ designed and validated in Discussion #278 and issue #273. A 1.1 managed worker's
 register/state frames remain accepted by the 1.2 daemon and continue to surface
 as managed sessions.
 
+Fresh macOS installs also repair the missing executable bit in the stable
+`node-pty@1.1.0` `spawn-helper` before the first managed PTY launch. The upstream
+tarball imports successfully but otherwise fails only at the first real spawn,
+so import-only installation checks could report a broken compatibility path as
+healthy.
+
 ### Portable readers receive complete, bounded content
 
 The daemon now distributes the licensed Pocket Daily Japanese N3 learning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,16 @@ Full command list: `agentdeck --help`, or [docs/cli.md](docs/cli.md) for the ann
 
 **Env-var default args** (`bridge/src/cli.ts` — `applyGlobalEnvArgs`/`weaveAgentCommand`/`resolveAgentCommand`): `AGENTDECK_COMMANDER_ARGS` injects flags into the `agentdeck` (commander) layer — spliced into argv right after the session subcommand, **keyed on `argv[2]`** (`claude`/`codex`/`opencode`/`monitor`; any other command ignores it, even with a session word as a positional value). Env tokens land before typed flags: scalar options are overridden by retyping (last-write); boolean flags have no inverse spelling, so the per-invocation override is **`--no-env-args`**, which disables BOTH layers (the splice pre-parse, the per-agent weave in the action). `AGENTDECK_CLAUDE_ARGS` / `AGENTDECK_CODEX_ARGS` / `AGENTDECK_OPENCODE_ARGS` append to the spawned agent command, weaving onto an existing `-c` (e.g. `AGENTDECK_CLAUDE_ARGS="--remote-control"` + `-c "claude --resume X"` → `claude --resume X --remote-control`). The per-agent append rides the same platform shell path as `-c` (`pty-manager.ts`); the global var is tokenized in pure JS and never touches a shell.
 
+**node-pty macOS helper mode** (`bridge/src/pty-manager.ts`): stable
+`node-pty@1.1.0` is published with both Darwin `spawn-helper` prebuilds at mode
+0644 (upstream microsoft/node-pty#850/#919), so the native addon imports but its
+first spawn fails with the misleading generic `posix_spawnp failed`. Before the
+dynamic import, `PtyManager` resolves the actual installed package and adds only
+the missing execute bits to a regular helper file (prebuild first, source-build
+fallback). This runtime repair intentionally covers direct bridge installs as
+well as `@agentdeck/setup` and does not depend on npm/pnpm install scripts. Never
+replace it with an import-only probe; the measured failure occurs only at spawn.
+
 ESP32 provisioning, WiFi OTA scope, the external-client wire contract, and Autonomous Pocket are documented in [esp32/CLAUDE.md](esp32/CLAUDE.md) (loads when working under `esp32/`) and [docs/esp32.md](docs/esp32.md).
 
 ## Key Conventions

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -2,6 +2,29 @@
 
 ---
 
+## 2026-08-31 — npm 실설치 soak가 node-pty 1.1.0의 0644 spawn-helper를 잡는다 (#279)
+
+#277을 합친 정확한 prospective tag commit `70d455cb`에서 네 tarball을 다시
+pack해 `/opt/homebrew/bin/agentdeck`에 설치했다. package version, native addon
+import, tarball↔installed `dist/cli.js` hash는 모두 정상이었지만 실제
+`agentdeck claude --weight 7 -c ...`가 첫 PTY spawn에서 `posix_spawnp failed`로
+종료했다. import-only smoke가 실제 기능을 증명하지 못하는 정확한 사례다.
+
+실측 원인은 기존 오류 문구가 주장한 Node ABI 불일치가 아니었다.
+`node-pty@1.1.0`의 npm tarball 자체가 macOS arm64/x64 `spawn-helper`를 0644로
+싣고 있고(상류 microsoft/node-pty#850/#919), 설치본도 correct-arch Mach-O지만
+execute bit가 없었다. `@agentdeck/setup`도 `npm install` exit code만 보므로 이
+runtime failure를 감지하지 못했다. source checkout 전용 `scripts/install.sh`의
+chmod는 전역 npm 설치 경로를 고치지 않는다.
+
+`PtyManager`는 이제 dynamic import 전에 실제 resolve된 node-pty package root의
+prebuilt/source helper를 찾고, regular file에 execute bit가 하나도 없을 때만
+기존 read bit 범위에 대응하는 execute bit만 더한다. symlink는 건드리지 않고
+macOS 외 플랫폼은 no-op이다.
+수정할 권한이 없으면 정확한 package path와 chmod 조치를 말하며, 그래도 남는
+`posix_spawnp`에만 setup/source-rebuild 안내를 준다. 0644→0755, 기존 0750 보존,
+source-build fallback, non-mac no-op, symlink 거부를 독립 테스트로 고정했다.
+
 ## 2026-08-31 — managed PTY 정리는 capability 제거가 아니라 replacement-gated migration이다
 
 npm 1.2.0 준비에서 `agentdeck claude|codex|opencode|monitor`를 곧 제거할

--- a/bridge/src/__tests__/pty-manager-spawn-helper.test.ts
+++ b/bridge/src/__tests__/pty-manager-spawn-helper.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureNodePtySpawnHelperExecutable } from '../pty-manager.js';
+
+const roots: string[] = [];
+
+function fixture(mode: number, location: 'prebuild' | 'source' = 'prebuild'): {
+  root: string;
+  helper: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'agentdeck-node-pty-'));
+  roots.push(root);
+  const helper = location === 'prebuild'
+    ? join(root, 'prebuilds', 'darwin-arm64', 'spawn-helper')
+    : join(root, 'build', 'Release', 'spawn-helper');
+  mkdirSync(join(helper, '..'), { recursive: true });
+  writeFileSync(helper, 'helper');
+  chmodSync(helper, mode);
+  return { root, helper };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('ensureNodePtySpawnHelperExecutable', () => {
+  it('repairs the 0644 mode shipped by node-pty 1.1.0 on macOS', () => {
+    const { root, helper } = fixture(0o644);
+
+    expect(ensureNodePtySpawnHelperExecutable(root, 'darwin', 'arm64')).toBe(helper);
+    expect(lstatSync(helper).mode & 0o777).toBe(0o755);
+  });
+
+  it('leaves an already executable helper unchanged', () => {
+    const { root, helper } = fixture(0o750);
+
+    expect(ensureNodePtySpawnHelperExecutable(root, 'darwin', 'arm64')).toBeNull();
+    expect(lstatSync(helper).mode & 0o777).toBe(0o750);
+  });
+
+  it('repairs a source-built helper when no prebuild is present', () => {
+    const { root, helper } = fixture(0o600, 'source');
+
+    expect(ensureNodePtySpawnHelperExecutable(root, 'darwin', 'arm64')).toBe(helper);
+    expect(lstatSync(helper).mode & 0o777).toBe(0o700);
+  });
+
+  it('is a no-op outside macOS', () => {
+    const { root, helper } = fixture(0o644);
+
+    expect(ensureNodePtySpawnHelperExecutable(root, 'linux', 'arm64')).toBeNull();
+    expect(lstatSync(helper).mode & 0o777).toBe(0o644);
+  });
+
+  it('does not chmod a symlink in place of the package helper', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentdeck-node-pty-'));
+    roots.push(root);
+    const target = join(root, 'target');
+    const helper = join(root, 'prebuilds', 'darwin-arm64', 'spawn-helper');
+    mkdirSync(join(helper, '..'), { recursive: true });
+    writeFileSync(target, 'target');
+    chmodSync(target, 0o644);
+    symlinkSync(target, helper);
+
+    expect(ensureNodePtySpawnHelperExecutable(root, 'darwin', 'arm64')).toBeNull();
+    expect(lstatSync(target).mode & 0o777).toBe(0o644);
+  });
+});

--- a/bridge/src/pty-manager.ts
+++ b/bridge/src/pty-manager.ts
@@ -1,5 +1,67 @@
 import { EventEmitter } from 'events';
+import { chmodSync, existsSync, lstatSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { debug } from './logger.js';
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * node-pty 1.1.0's npm tarball ships the macOS spawn-helper as 0644 even
+ * though posix_spawn requires an executable file (upstream #850/#919). Repair
+ * the selected helper at the point of use so direct bridge installs and setup
+ * installs behave the same and do not depend on package-manager script policy.
+ *
+ * Returns the repaired path, or null when no repair was needed/applicable.
+ */
+export function ensureNodePtySpawnHelperExecutable(
+  packageRoot: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | null {
+  if (platform !== 'darwin') return null;
+
+  const candidates = [
+    join(packageRoot, 'prebuilds', `${platform}-${arch}`, 'spawn-helper'),
+    join(packageRoot, 'build', 'Release', 'spawn-helper'),
+  ];
+
+  for (const helperPath of candidates) {
+    if (!existsSync(helperPath)) continue;
+    const stat = lstatSync(helperPath);
+    if (!stat.isFile()) continue;
+    if ((stat.mode & 0o111) !== 0) return null;
+    // Mirror each read bit to its execute bit. The published 0644 becomes
+    // 0755 without granting execution to a class that could not read the file.
+    const permissions = stat.mode & 0o777;
+    chmodSync(helperPath, permissions | ((permissions & 0o444) >> 2));
+    return helperPath;
+  }
+  return null;
+}
+
+function repairInstalledNodePtySpawnHelper(): void {
+  if (process.platform !== 'darwin') return;
+
+  let packageRoot: string;
+  try {
+    packageRoot = dirname(dirname(requireFromHere.resolve('node-pty')));
+  } catch {
+    // The dynamic import below owns the public "not installed" error.
+    return;
+  }
+
+  try {
+    const repaired = ensureNodePtySpawnHelperExecutable(packageRoot);
+    if (repaired) debug('PTY', `restored executable permission on ${repaired}`);
+  } catch (error) {
+    throw new Error(
+      `node-pty spawn-helper is not executable and AgentDeck could not repair it under ${packageRoot}.\n` +
+      `Fix its permissions with: chmod +x "${join(packageRoot, 'prebuilds', `darwin-${process.arch}`, 'spawn-helper')}"\n` +
+      `Cause: ${String(error)}`,
+    );
+  }
+}
 
 /** Minimal interface matching node-pty's IPty */
 interface IPty {
@@ -19,7 +81,9 @@ export class PtyManager extends EventEmitter {
       throw new Error('PTY process already running');
     }
 
-    // Dynamic import — node-pty is optionalDependency
+    // Dynamic import — node-pty is optionalDependency. Repair the stable
+    // macOS tarball's missing helper execute bit before node-pty resolves it.
+    repairInstalledNodePtySpawnHelper();
     let pty: typeof import('node-pty');
     try {
       pty = await import('node-pty');
@@ -57,10 +121,10 @@ export class PtyManager extends EventEmitter {
     } catch (err: any) {
       if (err?.message?.includes('posix_spawnp')) {
         throw new Error(
-          'posix_spawnp failed — the prebuilt node-pty binary is incompatible with your Node.js version.\n' +
-          'Fix: rebuild node-pty from source:\n' +
+          'posix_spawnp failed while launching node-pty. AgentDeck already checked the macOS spawn-helper execute bit.\n' +
+          'Reinstall with `npx @agentdeck/setup`, or rebuild a genuinely incompatible native prebuild:\n' +
           '  cd $(npm root -g)/@agentdeck/bridge/node_modules/node-pty && npx node-gyp rebuild\n' +
-          'Or reinstall: npx @agentdeck/setup',
+          `Original error: ${String(err)}`,
         );
       }
       throw err;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@
 | Android app can't find bridge | mDNS blocked on network | Use QR pairing (`agentdeck qr`) or enter IP manually in Settings |
 | Android shows "Not Connected" | Bridge not reachable | Verify same LAN; for USB: `adb reverse tcp:9120 tcp:9120` then connect to 127.0.0.1:9120 |
 | E-ink ghosting on Crema | Missing full GC16 refresh | State transitions trigger full refresh automatically; force refresh by toggling bridge connection |
-| `posix_spawnp failed` | Prebuilt node-pty binary incompatible with Node version | `cd $(npm root -g)/@agentdeck/bridge/node_modules/node-pty && npx node-gyp rebuild` |
+| `posix_spawnp failed` | On macOS, old installs may have a non-executable node-pty `spawn-helper`; otherwise the native prebuild may be incompatible | Current AgentDeck repairs the helper mode on first use. Reinstall with `npx @agentdeck/setup`; only if it still fails, run `cd $(npm root -g)/@agentdeck/bridge/node_modules/node-pty && npx node-gyp rebuild` |
 
 ## tmux -CC Compatibility
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -34,7 +34,7 @@ No Stream Deck required — the daemon is the product; decks and other devices a
 
 ## Platform notes
 
-**Node.js 22 or later** is required everywhere. Native modules (`node-pty`, `sharp`, `better-sqlite3`) install from prebuilt binaries first; a compiler is only needed if a prebuild is missing for your platform.
+**Node.js 22 or later** is required everywhere. Native modules (`node-pty`, `sharp`, `better-sqlite3`) install from prebuilt binaries first; a compiler is only needed if a prebuild is missing for your platform. On macOS, AgentDeck repairs the known missing execute bit in the stable node-pty `spawn-helper` at first PTY use, including for direct bridge installs.
 
 ### macOS
 


### PR DESCRIPTION
## Summary

- repair the missing execute bit in the resolved macOS node-pty `spawn-helper` before the first dynamic import/spawn
- cover both prebuilt and source-build layouts without relying on npm/pnpm install scripts
- refuse symlinks and preserve the existing permission scope by mirroring read bits to execute bits
- replace the incorrect unconditional ABI diagnosis with measured permission guidance plus a true rebuild fallback
- document the upstream `node-pty@1.1.0` packaging defect and the runtime contract

Closes #279. Blocks npm 1.2.0 delivery in #274.

## Measured failure

The final 1.2.0 candidate imported `node-pty` successfully but failed its first real managed launch with `posix_spawnp failed`. The stable upstream tarball ships both Darwin helpers as 0644. This is upstream microsoft/node-pty#850/#919, not an architecture mismatch.

## Verification

- [x] focused PTY/CLI tests — 61 passed
- [x] full `pnpm test` — 240 files, 3,732 passed, 1 skipped
- [x] `pnpm build`
- [x] bridge `tsc --noEmit`
- [x] `pnpm docs:check`
- [x] `pnpm verify-version`
- [x] `pnpm verify-release-version npm 1.2.0`
- [x] source-checkout real managed launch repaired helper 0644 → 0755
- [x] `AGENTDECK_CLAUDE_ARGS=managed-args-ok` reached the child process
- [x] typed `--weight 7` overrode env default 6 and registered `weight: 7`
- [x] merge, repack exact master, reinstall globally, and repeat the real managed launch

## Test cases

- published 0644 prebuild → 0755
- existing 0750 remains unchanged
- source-built 0600 helper → 0700
- non-macOS no-op
- symlink is not chmodded

