### PR TITLE
ui(collab): BETA is a badge, not half the switch label

### DIFF
--- a/apple/AgentDeck/UI/Monitor/CollaborationPanel.swift
+++ b/apple/AgentDeck/UI/Monitor/CollaborationPanel.swift
@@ -95,7 +95,18 @@ struct CollaborationPanel: View {
                 Label("Collaboration", systemImage: "point.3.connected.trianglepath.dotted")
                     .font(.system(size: 17, weight: .semibold))
                 Spacer()
-                Text("BETA").font(.caption.weight(.semibold)).foregroundStyle(DesignTokens.UI.cyan)
+                // Badge, not a word: the existing capsule idiom (caption-size
+                // text, 6/2 padding, 20% tinted Capsule) used by the
+                // connection overlay's `local` / agent chips.
+                Text("BETA")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .kerning(0.8)
+                    .foregroundStyle(DesignTokens.UI.cyan)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(DesignTokens.UI.cyan.opacity(0.18), in: Capsule())
+                    .overlay(Capsule().stroke(DesignTokens.UI.cyan.opacity(0.35), lineWidth: 0.5))
+                    .accessibilityLabel("Beta feature")
                 Button { showsSystem.toggle() } label: {
                     Image(systemName: "network")
                 }.help("Show system status").popover(isPresented: $showsSystem) {

--- a/apple/AgentDeck/UI/Monitor/MonitorScreen.swift
+++ b/apple/AgentDeck/UI/Monitor/MonitorScreen.swift
@@ -96,10 +96,12 @@ struct MonitorScreen: View {
                 ToolbarItem(placement: .primaryAction) {
                     Picker("Dashboard view", selection: $collaborationEnabled) {
                         Text("Habitat").tag(false)
-                        Text("Collaboration · Beta").tag(true)
+                        // The segment names the view; its Beta status is a
+                        // badge in the panel header, not half of the label.
+                        Text("Collaboration").tag(true)
                     }
                     .pickerStyle(.segmented)
-                    .frame(width: 250)
+                    .frame(width: 220)
                     .accessibilityIdentifier("dashboard-collaboration-switch")
                 }
             }


### PR DESCRIPTION
The segmented control read `Collaboration · Beta`, giving the beta status the same size and weight as the feature name, and the panel header's `BETA` was bare tinted text rather than a badge.

- Segment now reads `Collaboration` — it names the view.
- Header carries a real badge in the existing capsule idiom (caption-size text, 6/2 padding, tinted `Capsule`) that `ConnectionOverlay`'s `local` / agent chips already use, plus an accessibility label.

Habitat remains the default view.

Verified by installing the Release build and capturing the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)