### PR TITLE
fix(ci): pin PlatformIO — 6.2.0 and the ESP32 platform disagree about SCons

### DIFF
--- a/.github/workflows/esp32-release.yml
+++ b/.github/workflows/esp32-release.yml
@@ -74,8 +74,25 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Pinned for the same reason esptool is, and it broke the same way: a
+      # routine upstream release breaks a firmware cut AT TAG TIME, when the
+      # tag is already pushed. PlatformIO 6.2.0 (PyPI, 2026-09-05) requires
+      # `platformio/tool-scons @ ~4.41101.0` (SCons 4.11.1) while the
+      # pioarduino ESP32 platform pins its own `tool-scons` 4.8.1 — the build
+      # installs BOTH and links against the mixture, which no longer carries
+      # `SCons.Tool.FortranCommon`. Every board fails at the firmware.elf link
+      # step; `esp32-v1.2.2` died there two days after `esp32-v1.2.1` (PlatformIO
+      # 6.1.19 + SCons 4.8.1) had passed on the same source.
+      #
+      # TAKE THIS NUMBER FROM PyPI AND FROM A GREEN RUN, never from a local
+      # `pio --version`: a dev machine's ~/.platformio/penv is whatever it
+      # first installed and keeps working long after CI has moved on — which
+      # is exactly why this cut built locally and failed in CI.
+      #
+      # 6.1.19 is measured: it is what run 33819354649 (`esp32-v1.2.1`,
+      # 2026-09-03) installed alongside SCons 4.8.1 for all ten boards.
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install "platformio==6.1.19"
 
       # Pinned deliberately. esptool renamed its subcommands between v4 and v5
       # (`merge_bin`/`--flash_size` -> `merge-bin`/`--flash-size`); un-pinned, a


### PR DESCRIPTION
`esp32-v1.2.2` failed at tag time. Every board dies at the `firmware.elf` link step with:

```
ModuleNotFoundError : No module named 'SCons.Tool.FortranCommon'
```

`pip install platformio` was unpinned, so the cut installed **PlatformIO 6.2.0** (PyPI, 2026-09-05 — two days after the green `esp32-v1.2.1`). 6.2.0 requires `platformio/tool-scons @ ~4.41101.0` (SCons 4.11.1) while the pioarduino ESP32 platform pins its own `tool-scons` 4.8.1. The job installs **both** and links against the mixture, which no longer carries the Fortran tool modules.

The same source builds fine locally, because a dev machine's `~/.platformio/penv` keeps whatever it first installed — the same trap the esptool pin comment in this file already warns about, one package over.

Pinned to `6.1.19`: measured, not remembered — it is what run [33819354649](https://github.com/puritysb/AgentDeck/actions/runs/33819354649) (`esp32-v1.2.1`, 2026-09-03) installed alongside SCons 4.8.1 for all ten boards.

`esp32-v1.2.2` published no assets, so the tag will be recut on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)