### PR TITLE
docs(windows): run the checkout CLI without a global link

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -29,7 +29,7 @@ pnpm test               # optional: run the Vitest suite
 node hooks/dist/install.js
 
 # Link the CLI + Stream Deck plugin
-cd bridge; pnpm link --global; cd ..
+node bridge/dist/cli.js daemon install
 cd plugin; streamdeck link bound.serendipity.agentdeck.sdPlugin; cd ..   # then restart the Stream Deck app
 ```
 


### PR DESCRIPTION
The Windows checkout guide used `pnpm link --global`, which the contributor's pnpm rejects. It now runs `node bridge/dist/cli.js daemon install` directly and consistently uses the built CLI for checkout commands, so setup no longer depends on a global link.

The guide distinguishes daemon autostart from putting `agentdeck` on PATH, explains that the Scheduled Task references the checkout, and retains `npx @agentdeck/setup` for normal package installations. This does not claim to fix the separate Stream Deck connectivity report #303.

The contributor's original commit is preserved; a maintainer follow-up updates the guide against current master and completes the direct-invocation instructions.

Validation: `pnpm docs:check` and `pnpm design-system:check` pass. Clean-source design lint is 89, matching the base. All CI checks passed before merge, including Windows Node 22/24/26. Merged with the original contributor commit preserved.
