### PR TITLE
fix(timeline): a rotating row draws the running glyph, and an error stops the spinner on Android

### DIFF
--- a/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/TimelineStrip.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/monitor/TimelineStrip.kt
@@ -67,6 +67,7 @@ import dev.agentdeck.ui.component.BrandIcon
 import dev.agentdeck.ui.component.agentDisplayLabel
 import dev.agentdeck.ui.timeline.TimelineIconKey
 import dev.agentdeck.ui.timeline.TimelineMarkdownView
+import dev.agentdeck.ui.timeline.ROTATING_ICON_KEY
 import dev.agentdeck.ui.timeline.isRotatingEntry
 import dev.agentdeck.ui.timeline.rowSummary
 import dev.agentdeck.ui.timeline.stripMarkdownForSummary
@@ -544,11 +545,19 @@ private fun TurnRow(
         // key, or an open task_start whose task_end hasn't arrived). Non-
         // rotating rows get angle=0 from the helper and skip the infinite
         // transition entirely. Mirrors `isRotatingEntry` in shared.
-        val rowAngle = rememberRunningRotation(
-            active = !isFolded && !isCompletedTurn && isRotatingEntry(entry, siblings),
-        )
+        // A rotating row draws the Running circular arrow whatever its own key
+        // is, and returns to its semantic glyph when it stops — same rule as
+        // the TASK marker below. For a `running` row this is already its own
+        // glyph; it matters when a task hierarchy row reaches this path.
+        // contentDescription stays semantic: the rotation is decorative.
+        val rowRotating = !isFolded && !isCompletedTurn && isRotatingEntry(entry, siblings)
+        val rowAngle = rememberRunningRotation(active = rowRotating)
         Icon(
-            imageVector = if (isFolded) Icons.Filled.SubdirectoryArrowRight else iconKey.materialIcon,
+            imageVector = when {
+                isFolded -> Icons.Filled.SubdirectoryArrowRight
+                rowRotating -> ROTATING_ICON_KEY.materialIcon
+                else -> iconKey.materialIcon
+            },
             contentDescription = if (isFolded) "answered with next turn" else iconKey.name,
             tint = iconColor.copy(alpha = if (isChatEnd) 0.6f else 1f),
             modifier = Modifier
@@ -748,12 +757,16 @@ private fun TaskHeaderRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // Spin the TASK marker while task_start has no matching task_end yet
-        // — at-a-glance "this task is still running" signal.
-        val taskAngle = rememberRunningRotation(
-            active = isRotatingEntry(entry, siblings),
-        )
+        // — at-a-glance "this task is still running" signal. While it spins the
+        // glyph swaps to the Running circular arrow and returns to the static
+        // Task checklist when it stops: a square checklist rotating on its
+        // centre reads as a glitch, not a spinner. `timelineDisplayIconKey`
+        // owns that rule (shared/src/timeline-icons.ts); Apple does the same
+        // through RotatingTimelineIcon(rotatingSymbolName:).
+        val rotating = isRotatingEntry(entry, siblings)
+        val taskAngle = rememberRunningRotation(active = rotating)
         Icon(
-            imageVector = TimelineIconKey.Task.materialIcon,
+            imageVector = (if (rotating) ROTATING_ICON_KEY else TimelineIconKey.Task).materialIcon,
             contentDescription = "Task",
             tint = accent,
             modifier = Modifier.width(14.dp).height(14.dp).rotate(taskAngle),

--- a/android/app/src/main/kotlin/dev/agentdeck/ui/timeline/TimelineIcons.kt
+++ b/android/app/src/main/kotlin/dev/agentdeck/ui/timeline/TimelineIcons.kt
@@ -174,6 +174,34 @@ fun turnHasLaterCompletion(entry: TimelineEntry, siblings: List<TimelineEntry>):
     return false
 }
 
+/**
+ * The icon key a row draws WHILE its leading icon rotates.
+ *
+ * A rotating row shows the [TimelineIconKey.Running] circular arrow, not its
+ * own semantic glyph, and returns to its own key the instant rotation stops.
+ * Only [TimelineIconKey.Task] is visibly affected — every other rotating row
+ * already resolves to Running — but that one case is the whole point: a square
+ * glyph spinning on its centre reads as a glitch rather than a spinner.
+ *
+ * Mirrors `TIMELINE_ROTATING_ICON_KEY` in shared/src/timeline-icons.ts and
+ * Apple's `RotatingTimelineIcon(rotatingSymbolName:)`.
+ */
+val ROTATING_ICON_KEY: TimelineIconKey = TimelineIconKey.Running
+
+/**
+ * The icon key to draw for [entry] right now: Running while the row rotates,
+ * otherwise the row's own semantic key. Use this instead of [timelineIconKey]
+ * anywhere the leading icon is animated. Mirrors `timelineDisplayIconKey` in
+ * shared/src/timeline-icons.ts.
+ */
+fun timelineDisplayIconKey(
+    entry: TimelineEntry,
+    siblings: List<TimelineEntry>,
+    nowMs: Long = System.currentTimeMillis(),
+): TimelineIconKey =
+    if (isRotatingEntry(entry, siblings, nowMs)) ROTATING_ICON_KEY
+    else timelineIconKey(entry.type, entry.status)
+
 fun isRotatingEntry(
     entry: TimelineEntry,
     siblings: List<TimelineEntry>,
@@ -186,7 +214,13 @@ fun isRotatingEntry(
         for (s in siblings) {
             if (s.timestamp < ts) continue
             if (!sameRotatingSession(entry.sessionId, s.sessionId)) continue
-            if (s.type == "chat_response" || s.type == "chat_end" || s.type == "model_response") return false
+            // `error` closes a turn as surely as a response does — a failed
+            // request emits one instead of a reply, and leaving it off this
+            // list kept the spinner turning next to its own explanation.
+            // Mirrors shared/src/timeline-icons.ts and Swift
+            // `timelineIsRotatingEntry`, both of which already had it.
+            if (s.type == "chat_response" || s.type == "chat_end" ||
+                s.type == "model_response" || s.type == "error") return false
             if (s.type == "chat_start" && s.timestamp > ts) return false
         }
         return true

--- a/android/app/src/test/kotlin/dev/agentdeck/state/TimelineTaskHierarchyTest.kt
+++ b/android/app/src/test/kotlin/dev/agentdeck/state/TimelineTaskHierarchyTest.kt
@@ -4,12 +4,14 @@ import dev.agentdeck.ui.timeline.IN_FLIGHT_TASK_MAX_AGE_MS
 import dev.agentdeck.ui.timeline.ROTATING_ENTRY_MAX_AGE_MS
 import dev.agentdeck.ui.timeline.TimelineIconKey
 import dev.agentdeck.ui.timeline.isInFlightTask
+import dev.agentdeck.ui.timeline.ROTATING_ICON_KEY
 import dev.agentdeck.ui.timeline.isRotatingEntry
 import dev.agentdeck.ui.timeline.parseTimelineMarkdown
 import dev.agentdeck.ui.timeline.stripMarkdownInline
 import dev.agentdeck.ui.timeline.timelineDetailIsRedundant
 import dev.agentdeck.ui.timeline.timelinePromoteInformativeLead
 import dev.agentdeck.ui.timeline.timelineSummaryIsRedundantWithDetail
+import dev.agentdeck.ui.timeline.timelineDisplayIconKey
 import dev.agentdeck.ui.timeline.timelineIconKey
 import dev.agentdeck.ui.timeline.TimelineMarkdownLine
 import org.junit.Assert.assertEquals
@@ -325,6 +327,46 @@ class TimelineTaskHierarchyTest {
         )
         // Non-response types (e.g. the prompt on a merged turn) pass through.
         assertEquals(raw, timelinePromoteInformativeLead(raw, "chat_start"))
+    }
+
+    @Test
+    fun `a rotating row draws the running glyph, not its own`() {
+        // An open task_start spins. Before this rule Android rotated the
+        // static Checklist glyph, which reads as a glitch rather than a
+        // spinner; Apple already swapped in the circular arrow.
+        val open = entry("task_start", timestamp = 1_000L, taskId = "task-A")
+        assertTrue(isRotatingEntry(open, emptyList(), nowMs = 1_000L))
+        assertEquals(TimelineIconKey.Task, timelineIconKey(open.type, open.status))
+        assertEquals(ROTATING_ICON_KEY, timelineDisplayIconKey(open, emptyList(), nowMs = 1_000L))
+        assertEquals(TimelineIconKey.Running, ROTATING_ICON_KEY)
+    }
+
+    @Test
+    fun `a closed task returns to its own task glyph`() {
+        val open = entry("task_start", timestamp = 1_000L, taskId = "task-A")
+        val siblings = listOf(entry("task_end", timestamp = 1_010L, taskId = "task-A"))
+        assertFalse(isRotatingEntry(open, siblings, nowMs = 1_000L))
+        assertEquals(TimelineIconKey.Task, timelineDisplayIconKey(open, siblings, nowMs = 1_000L))
+    }
+
+    @Test
+    fun `an error closes a turn so the spinner stops beside its explanation`() {
+        // The TS and Swift mirrors both counted `error` as a completion; the
+        // Kotlin mirror had dropped it, so a failed request kept spinning
+        // right next to the error row that explained it.
+        val chat = entry("chat_start", timestamp = 1_000L, sessionId = "sess-1")
+        val err = entry("error", timestamp = 1_005L, sessionId = "sess-1")
+        assertFalse(
+            "a later same-session error must stop the spinner",
+            isRotatingEntry(chat, listOf(err), nowMs = 1_000L),
+        )
+    }
+
+    @Test
+    fun `an error in a different session leaves the turn spinning`() {
+        val chat = entry("chat_start", timestamp = 1_000L, sessionId = "sess-1")
+        val other = entry("error", timestamp = 1_005L, sessionId = "sess-2")
+        assertTrue(isRotatingEntry(chat, listOf(other), nowMs = 1_000L))
     }
 
     private fun entry(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,10 @@ this table live in CLAUDE.md § Key Conventions ("Cross-platform rules are SSOT-
 
 Known hand-mirror debt: `shared/src/creature-layout.ts` band layout (3-way comment-discipline mirror, test parity only) — fold it into a generator when next touched. The idle-gap
 constant in `ApmeCollector` stays grep-pinned by `apme-display-rules-sync.test.ts`.
+`shared/src/timeline-icons.ts` is a 3-way hand mirror too (Apple `TimelineStripView.swift`, Android `TimelineIcons.kt`), with per-surface tests rather than a drift gate — and it has
+demonstrably diverged: on 2026-09-12 the Android mirror was found missing `error` from the `isRotatingEntry` completion list (so a failed turn kept spinning next to the error row that
+explained it) and missing the rotating-glyph swap entirely (so `task_start` rotated the static checklist). Both had been correct in TS and Swift for some time. Parallel tests do not
+catch an omission that exists in every surface's test alike; fold this into a generator when next touched.
 
 ## Terrarium rules SSOT (cross-platform behavior invariants)
 

--- a/shared/src/__tests__/timeline-rotating-glyph.test.ts
+++ b/shared/src/__tests__/timeline-rotating-glyph.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TIMELINE_ROTATING_ICON_KEY,
+  timelineDisplayIconKey,
+  timelineIconKey,
+  isRotatingEntry,
+} from '../timeline-icons.js';
+
+const now = 1_700_000_000_000;
+const entry = (over: Record<string, unknown> = {}) =>
+  ({ type: 'task_start', taskId: 't1', sessionId: 's1', ts: now, ...over }) as never;
+
+describe('rotating rows draw the running glyph, not their own', () => {
+  it('an open task_start rotates and renders `running`, not `task`', () => {
+    const e = entry();
+    expect(isRotatingEntry(e, [], now)).toBe(true);
+    // Its semantic key stays `task` — only what is DRAWN changes.
+    expect(timelineIconKey(e)).toBe('task');
+    expect(timelineDisplayIconKey(e, [], now)).toBe('running');
+    expect(TIMELINE_ROTATING_ICON_KEY).toBe('running');
+  });
+
+  it('a closed task returns to its own `task` glyph', () => {
+    const e = entry();
+    const siblings = [{ type: 'task_end', taskId: 't1', sessionId: 's1', ts: now + 10 }] as never[];
+    expect(isRotatingEntry(e, siblings, now)).toBe(false);
+    expect(timelineDisplayIconKey(e, siblings, now)).toBe('task');
+  });
+
+  it('a non-rotating row is unchanged by the display key', () => {
+    const e = entry({ type: 'tool_exec', taskId: undefined });
+    expect(timelineIconKey(e)).toBe('tool');
+    expect(timelineDisplayIconKey(e, [], now)).toBe('tool');
+  });
+
+  it('a stale orphaned task_start stops rotating and shows `task`', () => {
+    const e = entry({ ts: now - 11 * 60 * 1000 });
+    expect(timelineDisplayIconKey(e, [], now)).toBe('task');
+  });
+});
+
+describe('an `error` closes a turn for rotation purposes', () => {
+  const chat = { type: 'chat_start', taskId: undefined, sessionId: 's1', ts: now } as never;
+
+  it('a later same-session error stops the spinner', () => {
+    const siblings = [{ type: 'error', taskId: undefined, sessionId: 's1', ts: now + 5 }] as never[];
+    expect(isRotatingEntry(chat, siblings, now)).toBe(false);
+    // A chat_start's own key IS `running`, so the arrow stays — it just stops
+    // spinning. The bug this guards is the spinner, not the glyph.
+    expect(timelineDisplayIconKey(chat, siblings, now)).toBe('running');
+  });
+
+  it('an error in a DIFFERENT session leaves it spinning', () => {
+    const siblings = [{ type: 'error', taskId: undefined, sessionId: 's2', ts: now + 5 }] as never[];
+    expect(isRotatingEntry(chat, siblings, now)).toBe(true);
+  });
+});

--- a/shared/src/timeline-icons.ts
+++ b/shared/src/timeline-icons.ts
@@ -184,6 +184,38 @@ export function isRotatingEntry(
 }
 
 /**
+ * The icon key a row draws WHILE its leading icon rotates.
+ *
+ * A rotating row shows the `running` circular arrow, not its own semantic
+ * glyph, and returns to its own key the instant rotation stops. Only `task` is
+ * visibly affected — every other rotating row already resolves to `running`
+ * (see {@link isRotatingEntry}) — but that one case is the whole point: a
+ * square glyph spinning on its centre reads as a glitch rather than a spinner.
+ *
+ * Apple spells this as `RotatingTimelineIcon(rotatingSymbolName:)` in
+ * TimelineStripView.swift. E-ink surfaces never rotate, so they always take
+ * {@link timelineIconKey} directly.
+ */
+export const TIMELINE_ROTATING_ICON_KEY: TimelineIconKey = 'running';
+
+/**
+ * The icon key to draw for `entry` right now: `running` while the row rotates,
+ * otherwise the row's own semantic key. Use this instead of
+ * {@link timelineIconKey} on any surface that animates the leading icon.
+ * Mirrored in Android TimelineIcons.kt — update both in the same commit.
+ */
+export function timelineDisplayIconKey(
+  entry: Pick<TimelineEntry, 'type' | 'status' | 'taskId'> &
+    Partial<Pick<TimelineEntry, 'sessionId' | 'ts'>>,
+  siblings: ReadonlyArray<RotatingSibling>,
+  nowMs?: number,
+): TimelineIconKey {
+  return isRotatingEntry(entry, siblings, nowMs)
+    ? TIMELINE_ROTATING_ICON_KEY
+    : timelineIconKey(entry);
+}
+
+/**
  * E-ink ASCII glyphs — bracket-padded so total width is constant (4 chars)
  * for column alignment on monospace bitmap fonts.
  */


### PR DESCRIPTION
Found while answering "왜 Task 앞 아이콘이 체크리스트인데 돌아가지?" — the spinning is intentional, the spinning *checklist* is not. Two Android mirror bugs, **both already fixed in TS and Swift**.

## 1. The spinning checklist

`task_start` rotates while its matching `task_end` is missing — an at-a-glance "still running" signal, and that part is deliberate. But Android rotated `TimelineIconKey.Task` itself, so a square checklist spun on its centre.

Apple had already solved exactly this, and said why in `TimelineStripView.swift:746`:

> Static state shows `list.bullet.rectangle.fill` (task identity); rotation swaps in `arrow.triangle.2.circlepath` so the spinner **reads as a spinner rather than a flickering square**.

The rule now lives in the shared SSOT — `TIMELINE_ROTATING_ICON_KEY` and `timelineDisplayIconKey()`: **whatever rotates draws the `running` arrow, and returns to its own key when it stops.** Only `task` is visibly affected, because every other rotating row already resolves to `running`.

Both Android render sites take the rule, each gated on *that row's real rotation condition*. The general row keeps its `!isFolded && !isCompletedTurn` gates, so it can never draw the arrow statically — swapping on a recomputed predicate there would have been a new bug. `contentDescription` stays semantic; the rotation is decorative.

## 2. The missing `error`

Kotlin's `isRotatingEntry` completion list read:

```kotlin
if (s.type == "chat_response" || s.type == "chat_end" || s.type == "model_response") return false
```

No `error`. TS and Swift both have it, carrying the same comment — *"a failed request emits one instead of a reply, and leaving it off this list kept the spinner turning next to its own explanation."* So on Android tablet a failed turn kept spinning beside the error row that explained it. The same Kotlin file's `turnHasLaterCompletion` **already included** `error`, so the omission was in one function only.

## Both tests were verified to fail without their fix

Not asserted — measured. Disabling the swap fails *"a rotating row draws the running glyph, not its own"*; dropping `error` fails *"an error closes a turn so the spinner stops beside its explanation"*. Restored, all 44 pass.

## Why this kept happening

`shared/src/timeline-icons.ts` is a **3-way hand mirror** with per-surface tests and no drift gate, and it was not listed anywhere as debt. Parallel tests cannot catch an omission that is absent from every surface's tests alike — which is precisely how Android lost `error` and never received the glyph swap while TS and Swift carried both. `docs/architecture.md` now records it under Known hand-mirror debt with this divergence as the evidence, and marks it for folding into a generator when next touched.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm test` (**286 files, 4457 passed / 1 skipped** — up 6), `pnpm generate-protocol` no drift, `python3 design/verify-tokens-sync.py` all mirrors in sync, `pnpm docs:check`, and `./gradlew testDebugUnitTest` (44 in `TimelineTaskHierarchyTest`).

`design/lint.sh` reads 91 in this built worktree — 89 baseline plus the two gitignored Ulanzi build-artifact violations documented in `.claude/rules/design-system.md` today, which the Design System workflow never builds. No HTML/CSS/JS changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)