### PR TITLE
Review round on the 1.3.0 delta: supervisor probes and approval survivors

### DIFF
--- a/apple/AgentDeck/Daemon/Gateway/OpenClawAdapter.swift
+++ b/apple/AgentDeck/Daemon/Gateway/OpenClawAdapter.swift
@@ -262,6 +262,24 @@ actor OpenClawAdapter {
         case plugin(OpenClawPluginApprovalPrompt)
     }
 
+    /// The prompt still waiting after the one being closed, in the shape the
+    /// daemon already renders (`gateway_approval`'s `prompt`).
+    ///
+    /// The two approval queues are independent and the deck shows one question
+    /// at a time, so closing the shown one can leave a live, answerable prompt
+    /// behind. Without this, `gateway_approval_resolved` / `_abandoned` set the
+    /// row to processing/idle AND cleared `gatewayPendingApproval`, so the
+    /// survivor lost both its state and its row — the user saw an idle deck
+    /// while the Gateway stayed blocked. Mirrors Node's
+    /// `settleApprovalActivity`.
+    private func survivingApprovalPrompt() -> [String: Any]? {
+        switch activeApproval() {
+        case .exec(let prompt): return Self.promptDict(prompt)
+        case .plugin(let prompt): return Self.pluginPromptDict(prompt)
+        case nil: return nil
+        }
+    }
+
     private func activeApproval() -> ActiveApproval? {
         if let exec = pendingApproval, let plugin = pendingPluginApproval {
             return exec.requestedAtMs <= plugin.requestedAtMs ? .exec(exec) : .plugin(plugin)
@@ -628,7 +646,9 @@ actor OpenClawAdapter {
             } else {
                 setPendingApproval(nil)
             }
-            self._onEvent?(["type": "gateway_approval_resolved", "payload": payload])
+            var resolved: [String: Any] = ["type": "gateway_approval_resolved", "payload": payload]
+            if let survivor = survivingApprovalPrompt() { resolved["survivor"] = survivor }
+            self._onEvent?(resolved)
         case ADGatewayEventName.pluginApprovalRequested.rawValue:
             // Same three-event surface as exec, mirrored field-for-field — the
             // Gateway nests everything under `request` here too
@@ -652,7 +672,9 @@ actor OpenClawAdapter {
             } else {
                 setPendingPluginApproval(nil)
             }
-            self._onEvent?(["type": "gateway_approval_resolved", "payload": payload])
+            var resolved: [String: Any] = ["type": "gateway_approval_resolved", "payload": payload]
+            if let survivor = survivingApprovalPrompt() { resolved["survivor"] = survivor }
+            self._onEvent?(resolved)
         case ADGatewayEventName.pluginApprovalRemoved.rawValue:
             // NOT declared in any `.d.ts` the installed package ships — real
             // wire protocol confirmed only at the embedded/TUI-local approval
@@ -1186,11 +1208,13 @@ actor OpenClawAdapter {
         setPendingApproval(nil)
         DaemonLogger.shared.info(
             "OpenClaw: pending approval \(prompt.id) abandoned — \(reason)")
-        _onEvent?([
+        var abandoned: [String: Any] = [
             "type": "gateway_approval_abandoned",
             "id": prompt.id,
             "reason": reason,
-        ])
+        ]
+        if let survivor = survivingApprovalPrompt() { abandoned["survivor"] = survivor }
+        _onEvent?(abandoned)
     }
 
     /// Ask the Gateway whether the displayed approval still exists.
@@ -1264,11 +1288,13 @@ actor OpenClawAdapter {
         setPendingPluginApproval(nil)
         DaemonLogger.shared.info(
             "OpenClaw: pending plugin approval \(prompt.id) abandoned — \(reason)")
-        _onEvent?([
+        var abandoned: [String: Any] = [
             "type": "gateway_approval_abandoned",
             "id": prompt.id,
             "reason": reason,
-        ])
+        ]
+        if let survivor = survivingApprovalPrompt() { abandoned["survivor"] = survivor }
+        _onEvent?(abandoned)
     }
 
     /// Ask the Gateway whether the displayed plugin approval still exists.

--- a/apple/AgentDeck/Daemon/Server/DaemonServer.swift
+++ b/apple/AgentDeck/Daemon/Server/DaemonServer.swift
@@ -8230,9 +8230,16 @@ final class DaemonServer {
             // `exec.approval.resolved` for those, and this daemon caches the
             // prompt (the Node one reads it live off the adapter), so without
             // this case the row keeps offering a PERM nobody can answer.
-            // `idle`, never `processing`: nothing was allowed to run.
-            gatewaySessionState = "idle"
-            gatewayPendingApproval = nil
+            // `idle`, never `processing`: nothing was allowed to run — unless
+            // the other queue still holds one, in which case the row must stay
+            // in attention and show it (`survivor`).
+            if let survivor = event["survivor"] as? [String: Any] {
+                gatewaySessionState = "awaiting_permission"
+                gatewayPendingApproval = survivor
+            } else {
+                gatewaySessionState = "idle"
+                gatewayPendingApproval = nil
+            }
             gatewayCurrentTool = nil
             broadcastStateUpdate()
             broadcastSessionsList()
@@ -8243,8 +8250,17 @@ final class DaemonServer {
             // allow-always / deny — testing for the string "deny" was right by
             // accident, but testing for allow (as the Node side did) was not.
             let allowed = ExecApprovalDecision(rawValue: decision ?? "")?.allowsExecution ?? false
-            gatewaySessionState = allowed ? "processing" : "idle"
-            gatewayPendingApproval = nil
+            // A resolution closes ONE queue. If the other still holds an
+            // approval the adapter passes it as `survivor`, and the row has to
+            // stay in attention showing it rather than reporting the turn
+            // resumed — see `survivingApprovalPrompt`.
+            if let survivor = event["survivor"] as? [String: Any] {
+                gatewaySessionState = "awaiting_permission"
+                gatewayPendingApproval = survivor
+            } else {
+                gatewaySessionState = allowed ? "processing" : "idle"
+                gatewayPendingApproval = nil
+            }
             gatewayCurrentTool = nil
             broadcastStateUpdate()
             broadcastSessionsList()

--- a/bridge/src/__tests__/daemon-supervisor.test.ts
+++ b/bridge/src/__tests__/daemon-supervisor.test.ts
@@ -16,6 +16,10 @@ import {
   routeDaemonLifecycle,
   runSupervisorPlan,
   supervisorJobRunning,
+  supervisorPosture,
+  parseSystemdActive,
+  parseSchtasksRunning,
+  execFailureAnswered,
   supervisorLivenessProbe,
   classifySupervision,
   describeSupervisor,
@@ -231,6 +235,66 @@ describe('supervisorJobRunning / supervisorLivenessProbe', () => {
     // an answer is not an answer.
     const probe = supervisorLivenessProbe({ kind: 'schtasks', label: 'AgentDeckDaemon' });
     expect(probe()).toBe(true);
+  });
+
+  // Review round (2026-09-12): all three probes had a way to answer "dead"
+  // when they had not actually read anything, which is the failure mode
+  // `supervisorJobRunning`'s own doc comment forbids.
+  it('systemd transitional states are not an outcome', () => {
+    expect(parseSystemdActive('active\n')).toBe(true);
+    expect(parseSystemdActive('inactive\n')).toBe(false);
+    expect(parseSystemdActive('failed\n')).toBe(false);
+    // Restart=on-failure backoff. Reading this as dead ends the wait seconds
+    // before systemd brings the daemon back.
+    expect(parseSystemdActive('activating\n')).toBeUndefined();
+    expect(parseSystemdActive('deactivating\n')).toBeUndefined();
+    expect(parseSystemdActive('reloading\n')).toBeUndefined();
+  });
+
+  it('a localized schtasks answer is unreadable, not "not running"', () => {
+    expect(parseSchtasksRunning('TaskName: \\AgentDeckDaemon\nStatus:  Running\n')).toBe(true);
+    expect(parseSchtasksRunning('TaskName: \\AgentDeckDaemon\nStatus:  Ready\n')).toBe(false);
+    expect(parseSchtasksRunning('TaskName: \\AgentDeckDaemon\nStatus:  Disabled\n')).toBe(false);
+    // Korean Windows prints the header and the value localized. The old
+    // `/^Status:\s+Running/` read a RUNNING job as dead here, which made
+    // convergeInstalledSupervision stop a healthy supervised daemon.
+    expect(parseSchtasksRunning('폴더: \\\n작업 이름: \\AgentDeckDaemon\n상태:  실행 중\n')).toBeUndefined();
+    // English header, value we do not model (Queued / Could not start).
+    expect(parseSchtasksRunning('Status:  Queued\n')).toBeUndefined();
+  });
+
+  it('only a command that ran and exited non-zero has answered', () => {
+    expect(execFailureAnswered(Object.assign(new Error('exit 3'), { status: 3 }))).toBe(true);
+    expect(execFailureAnswered(Object.assign(new Error('exit 0'), { status: 0 }))).toBe(true);
+    // Timed out under load during a restart — no reading was taken.
+    expect(execFailureAnswered(
+      Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT', signal: 'SIGTERM' }),
+    )).toBe(false);
+    // The supervisor CLI is not installed / not on PATH.
+    expect(execFailureAnswered(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).toBe(false);
+    expect(execFailureAnswered(new Error('plain'))).toBe(false);
+    expect(execFailureAnswered(null)).toBe(false);
+  });
+
+  it('a supervisor with no unit file has no posture to compare, not a default one', () => {
+    // A Windows scheduled task: schtasks owns the argv, and the XML that
+    // created it was deleted. Answering [] made every restart on a --local
+    // machine read as a posture mismatch and fork an unsupervised daemon.
+    expect(supervisorPosture({ kind: 'schtasks', label: 'AgentDeckDaemon' })).toBeUndefined();
+    expect(supervisorPosture({ kind: 'systemd', label: 'x.service', unitPath: '/no/such/unit' }))
+      .toBeUndefined();
+  });
+
+  it('an unreadable unit posture leaves the restart with the supervisor', () => {
+    // routeDaemonLifecycle already models the third answer: no comparison to
+    // make means no posture-mismatch takeover.
+    const route = routeDaemonLifecycle({
+      supervisor: { kind: 'schtasks', label: 'AgentDeckDaemon' },
+      oneOffFlags: [],
+      unitPosture: undefined,
+      wantedPosture: ['--local'],
+    });
+    expect(route.via).toBe('supervisor');
   });
 
   it('caches within the throttle window', () => {

--- a/bridge/src/__tests__/openclaw-plugin-approval-flow.test.ts
+++ b/bridge/src/__tests__/openclaw-plugin-approval-flow.test.ts
@@ -249,6 +249,86 @@ describe('exec and plugin approvals coexist without dropping either', () => {
     expect(adapter.getPendingApproval()?.id).toBe(EXEC_REQUESTED.id);
   });
 
+  // Review round (2026-09-12). The assertion above is on the ROW's fields, and
+  // it passed while the deck showed nothing: resolving emitted spinner_start,
+  // the daemon maps that onto gatewaySessionState, the row left
+  // awaiting_permission, sessionTier stopped returning 'attention', and no
+  // surface rendered PERM for the survivor. Assert the STATE the survivor
+  // needs, not only that it is still in the slot.
+  it('resolving the shown one keeps the row in awaiting_permission for the survivor', () => {
+    const { adapter, gw, parser } = harness();
+    gw('plugin.approval.requested', PLUGIN_REQUESTED);
+    gw('exec.approval.requested', { ...EXEC_REQUESTED, createdAtMs: 1_786_940_900_000 });
+    parser.length = 0;
+
+    gw('plugin.approval.resolved', { id: PLUGIN_REQUESTED.id, decision: 'allow-once' });
+
+    const events = parser.map((p) => p.event);
+    expect(events).toContain('permission_prompt');
+    // An allow would otherwise emit spinner_start → 'processing', which is
+    // exactly what drops the row out of attention while a prompt is live.
+    expect(events).not.toContain('spinner_start');
+    expect(events).not.toContain('idle');
+    // The re-broadcast carries the SURVIVOR's question, not the resolved one's.
+    const shown = parser.find((p) => p.event === 'permission_prompt');
+    expect(String(shown?.data?.question ?? '')).toContain(EXEC_REQUESTED.request.command);
+  });
+
+  it('an expiring approval does not idle the row while the other kind is live', () => {
+    const { adapter, gw, parser } = harness();
+    gw('plugin.approval.requested', PLUGIN_REQUESTED);
+    gw('exec.approval.requested', { ...EXEC_REQUESTED, createdAtMs: 1_786_940_900_000 });
+    parser.length = 0;
+
+    (adapter as unknown as { abandonPendingPluginApproval(id: string, why: string): void })
+      .abandonPendingPluginApproval(PLUGIN_REQUESTED.id as string, 'Expired');
+
+    expect(parser.map((p) => p.event)).not.toContain('idle');
+    expect(parser.map((p) => p.event)).toContain('permission_prompt');
+    expect(adapter.getPendingApproval()?.id).toBe(EXEC_REQUESTED.id);
+  });
+
+  it('with nothing left pending, a resolution still settles the activity state', () => {
+    const { gw, parser } = harness();
+    gw('plugin.approval.requested', PLUGIN_REQUESTED);
+    parser.length = 0;
+    gw('plugin.approval.resolved', { id: PLUGIN_REQUESTED.id, decision: 'allow-once' });
+    expect(parser.map((p) => p.event)).toContain('spinner_start');
+  });
+
+  it('a second plugin approval closes the one it supersedes instead of dropping it', () => {
+    const { adapter, gw, rows } = harness();
+    gw('plugin.approval.requested', PLUGIN_REQUESTED);
+    rows.length = 0;
+
+    const SECOND = { ...PLUGIN_REQUESTED, id: 'plugin-approval-2', createdAtMs: 1_786_940_800_000 };
+    gw('plugin.approval.requested', SECOND);
+
+    // Plugin approvals come from independent plugins and cron jobs, so two can
+    // genuinely overlap. The displaced one used to vanish with its tool_request
+    // row stuck at pending and no way to answer it from any surface.
+    const closed = rows.find((r) => r.approvalId === PLUGIN_REQUESTED.id);
+    expect(closed?.status).toBe('abandoned');
+    expect(String(closed?.raw ?? '')).toContain('Superseded');
+    expect(adapter.getPendingApproval()?.id).toBe(SECOND.id);
+  });
+
+  it('a failing exec catch-up does not skip the plugin catch-up', async () => {
+    const { adapter, rpcs } = harness();
+    (adapter as unknown as { rpcCall(m: string, p: Record<string, unknown>): Promise<unknown> })
+      .rpcCall = (method, params) => {
+        rpcs.push({ method, params });
+        // An older Gateway without the method, an error frame, an RPC timeout.
+        if (method === 'exec.approval.list') return Promise.reject(new Error('no such method'));
+        return Promise.resolve({ approvals: [PLUGIN_REQUESTED] });
+      };
+
+    await (adapter as unknown as { adoptPendingApprovals(): Promise<void> }).adoptPendingApprovals();
+
+    expect(rpcs.map((r) => r.method)).toContain('plugin.approval.list');
+    expect(adapter.getPendingApproval()?.id).toBe(PLUGIN_REQUESTED.id);
+  });
+
   it('a press routes to the ACTIVE prompt\'s own resolve method, never the other kind\'s', () => {
     const { adapter, gw, rpcs } = harness();
     gw('plugin.approval.requested', PLUGIN_REQUESTED); // active (older)

--- a/bridge/src/adapters/openclaw.ts
+++ b/bridge/src/adapters/openclaw.ts
@@ -625,6 +625,19 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
    * once the held one is answered.
    */
   private async adoptPendingApprovals(): Promise<void> {
+    // Two INDEPENDENT catch-ups. They used to share one `await` chain, so an
+    // `exec.approval.list` rejection — an RPC timeout, an error frame, an older
+    // Gateway without the method — skipped the plugin half entirely and left
+    // the adapter blocked on an approval that exists on exactly one side: the
+    // precise failure this function was written to prevent. The caller's single
+    // `.catch()` only debug-logs, so it was invisible with debug off.
+    await this.adoptPendingExecApproval()
+      .catch((e) => debug('adapter:openclaw', `exec approval catch-up failed: ${String(e)}`));
+    await this.adoptPendingPluginApprovalOnConnect()
+      .catch((e) => debug('adapter:openclaw', `plugin approval catch-up failed: ${String(e)}`));
+  }
+
+  private async adoptPendingExecApproval(): Promise<void> {
     const pending = approvalListRows(await this.rpcCall('exec.approval.list', {}));
     if (pending && pending.length > 0) {
       const oldest = [...pending].sort(
@@ -644,7 +657,9 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
         this.rebroadcastActivePrompt();
       }
     }
+  }
 
+  private async adoptPendingPluginApprovalOnConnect(): Promise<void> {
     const pendingPlugin = approvalListRows(await this.rpcCall('plugin.approval.list', {}));
     if (pendingPlugin && pendingPlugin.length > 0) {
       const oldest = [...pendingPlugin].sort(
@@ -766,7 +781,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
       // prompt failed to reach a human in time. `raw` names which of the four.
       approvalId, status: 'abandoned',
     });
-    this.emitAdapterEvent({ source: 'parser', event: 'idle' });
+    this.settleApprovalActivity(false);
   }
 
   /** Called from the turn-end paths (`final` / `aborted` / `error`). */
@@ -863,7 +878,22 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
   // expiry, a `plugin.approval.resolved`/`removed` event, or a reconcile miss.
 
   private setPendingPluginApproval(prompt: OpenClawPluginApprovalPrompt): void {
+    // Unlike exec approvals — serialized by the single chat turn that blocks on
+    // them — plugin approvals come from independent plugins and cron jobs and
+    // can genuinely overlap. `adoptPendingApprovals` only runs at handshake and
+    // the reconcile timer follows the NEW id, so a silently dropped predecessor
+    // stays pending on the Gateway, unanswerable from any surface, with its
+    // `tool_request` row stuck at pending forever. Close its row the way every
+    // other path does before taking the slot.
+    const superseded = this.pendingPluginApproval;
     this.clearPendingPluginApproval();
+    if (superseded && superseded.id !== prompt.id) {
+      this.emitTimelineEntry({
+        ts: Date.now(), type: 'tool_resolved',
+        raw: 'Not approved (plugin) · Superseded by a newer plugin approval',
+        approvalId: superseded.id, status: 'abandoned',
+      });
+    }
     this.pendingPluginApproval = prompt.sessionKey || !this.currentSessionKey
       ? prompt
       : { ...prompt, sessionKey: this.currentSessionKey };
@@ -921,7 +951,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
       ts: Date.now(), type: 'tool_resolved', raw: `Not approved (plugin) · ${reason}`,
       approvalId, status: 'abandoned',
     });
-    this.emitAdapterEvent({ source: 'parser', event: 'idle' });
+    this.settleApprovalActivity(false);
   }
 
   private resolvePluginApproval(
@@ -967,6 +997,36 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
 
   /** Re-emit whichever prompt is currently active (exec or plugin). Used after
    *  adopting a catch-up prompt on connect and after a dropped resolve. */
+  /**
+   * The activity state a CLOSING approval leaves behind.
+   *
+   * An approval closing does not mean the Gateway stopped waiting. The two
+   * queues are independent — an exec approval and a plugin approval can be
+   * pending at once — and the deck shows one question at a time, so closing
+   * the shown one can leave a live, answerable prompt behind. Emitting
+   * `spinner_start`/`idle` there flips the Gateway row out of
+   * `awaiting_permission` (`daemon-server.ts` maps these straight onto
+   * `gatewaySessionState`), so `sessionTier` stops returning `attention` and
+   * no surface renders PERM — while `getPendingApproval()` keeps handing the
+   * row a question and options nobody will show. The user sees an idle deck
+   * and the agent stays blocked.
+   *
+   * Re-broadcasting the survivor is what `activePendingApproval`'s doc means
+   * by "surfaces automatically": it restores the state AND swaps the rendered
+   * question in one step.
+   *
+   * This also settles a resolution for an approval we do not track: our own
+   * prompt is still pending, so it is re-shown rather than having its state
+   * stolen by someone else's resolution.
+   */
+  private settleApprovalActivity(allowed: boolean): void {
+    if (this.activePendingApproval()) {
+      this.rebroadcastActivePrompt();
+      return;
+    }
+    this.emitAdapterEvent({ source: 'parser', event: allowed ? 'spinner_start' : 'idle' });
+  }
+
   private rebroadcastActivePrompt(): void {
     const active = this.activePendingApproval();
     if (!active) return;
@@ -1909,7 +1969,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
 
         // Denial does not resume the turn — the tool call fails and the agent
         // either recovers or ends. Only an allow means work continues.
-        this.emitAdapterEvent({ source: 'parser', event: allowed ? 'spinner_start' : 'idle' });
+        this.settleApprovalActivity(allowed);
         break;
       }
 
@@ -1968,7 +2028,7 @@ export class OpenClawAdapter extends EventEmitter implements AgentAdapter {
             status: allowed ? 'approved' : 'denied',
           });
         }
-        this.emitAdapterEvent({ source: 'parser', event: allowed ? 'spinner_start' : 'idle' });
+        this.settleApprovalActivity(allowed);
         break;
       }
 

--- a/bridge/src/daemon-supervisor.ts
+++ b/bridge/src/daemon-supervisor.ts
@@ -180,13 +180,27 @@ export function detectSupervisor(): SupervisorFacts | null {
   return null;
 }
 
-/** The unit's baked posture flags, or [] when the file cannot be read. */
-export function supervisorPosture(f: SupervisorFacts): string[] {
-  if (!f.unitPath) return [];
+/**
+ * The unit's baked posture flags, or `undefined` when they cannot be read.
+ *
+ * The third answer is load-bearing here for the same reason it is in
+ * `supervisorJobRunning`. A Windows scheduled task has no `unitPath` at all —
+ * `windows-service.ts` writes the task XML to a temp file and deletes it after
+ * `schtasks /Create` — so this used to answer `[]`, which reads as "the unit
+ * bakes the default posture". Every `daemon restart` on a machine installed
+ * with `--local` then compared its inherited `--local` against a fabricated
+ * default, took the `posture-mismatch` branch, printed a claim about the task
+ * that was not true, and forked an UNSUPERVISED daemon. `routeDaemonLifecycle`
+ * already treats `undefined` as "no comparison to make" and leaves the
+ * supervisor owning the restart, which is the correct behaviour when we could
+ * not look.
+ */
+export function supervisorPosture(f: SupervisorFacts): string[] | undefined {
+  if (!f.unitPath) return undefined;
   try {
     return parseSupervisorPosture(f.kind, readFileSync(f.unitPath, 'utf-8'));
   } catch {
-    return [];
+    return undefined;
   }
 }
 
@@ -288,6 +302,59 @@ export function routeDaemonLifecycle(args: {
  * `undefined` means the supervisor did not answer, which is not "it died": the
  * caller keeps waiting, bounded by the ceiling.
  */
+/**
+ * `systemctl is-active` → the three answers.
+ *
+ * The transitional states are the reason this is not `=== 'active'`. With
+ * `Restart=on-failure` a unit in restart backoff answers `activating`, which
+ * is "still working on it" — reading it as dead makes the liveness probe
+ * declare the job gone seconds before systemd brings the daemon back, which is
+ * the premature deadline this whole path exists to avoid.
+ */
+export function parseSystemdActive(out: string): boolean | undefined {
+  switch (out.trim()) {
+    case 'active': return true;
+    case 'inactive': case 'failed': return false;
+    // activating / deactivating / reloading — in motion, not an outcome.
+    default: return undefined;
+  }
+}
+
+/**
+ * `schtasks /Query /FO LIST` → the three answers.
+ *
+ * `schtasks` localizes both the field headers and the status VALUES, so a
+ * regex for English `Status: Running` is not a test for "is it running" — on a
+ * non-English Windows it fails to match a running job. Returning `false` there
+ * told `convergeInstalledSupervision` to stop a healthy supervised daemon and
+ * collapsed `waitForRestartedDaemon`'s ceiling to its floor. An output this
+ * cannot read is `undefined`: we could not look, which is not "it died".
+ */
+export function parseSchtasksRunning(out: string): boolean | undefined {
+  const m = /^Status:\s*(.+)$/mi.exec(out);
+  if (!m) return undefined;               // localized header — unreadable
+  switch (m[1].trim().toLowerCase()) {
+    case 'running': return true;
+    case 'ready': case 'disabled': return false;
+    // Queued / Unknown / "Could not start" / any localized value.
+    default: return undefined;
+  }
+}
+
+/**
+ * Did a failed `execFileSync` actually ANSWER, or did it fail to look?
+ *
+ * A command that ran and exited non-zero carries a numeric `status` — that is
+ * an answer (`systemctl is-active` exits 3 and prints the state; `launchctl
+ * print` fails outright once the job is booted out). A timeout (`ETIMEDOUT` /
+ * killed by `SIGTERM`) or a missing binary (`ENOENT`) carries no status: the
+ * probe never got a reading, and saying "dead" there is the false-failure
+ * report this module was rewritten to remove.
+ */
+export function execFailureAnswered(e: unknown): boolean {
+  return typeof (e as { status?: unknown } | null)?.status === 'number';
+}
+
 export function supervisorJobRunning(f: SupervisorFacts): boolean | undefined {
   try {
     switch (f.kind) {
@@ -302,20 +369,20 @@ export function supervisorJobRunning(f: SupervisorFacts): boolean | undefined {
       case 'systemd': {
         const out = execFileSync('systemctl', ['--user', 'is-active', f.label],
           { stdio: 'pipe', encoding: 'utf-8', timeout: 5_000 });
-        return out.trim() === 'active';
+        return parseSystemdActive(out);
       }
       case 'schtasks': {
         const out = execFileSync('schtasks', ['/Query', '/TN', f.label, '/FO', 'LIST'],
           { stdio: 'pipe', encoding: 'utf-8', timeout: 5_000, windowsHide: true });
-        return /^Status:\s+Running/mi.test(out);
+        return parseSchtasksRunning(out);
       }
     }
   } catch (e) {
-    // A non-zero exit is an answer for two of the three: `systemctl is-active`
-    // prints the state and exits 3 when it is not active, and `launchctl print`
-    // fails outright once the job has been booted out.
+    // Only a command that ran and exited non-zero is an answer. A timeout or a
+    // missing binary is not — see `execFailureAnswered`.
+    if (!execFailureAnswered(e)) return undefined;
     const out = ((e as { stdout?: Buffer }).stdout?.toString() ?? '').trim();
-    if (f.kind === 'systemd' && out) return out === 'active';
+    if (f.kind === 'systemd' && out) return parseSystemdActive(out);
     if (f.kind === 'launchd') return false;
     return undefined;
   }


### PR DESCRIPTION
An adversarial review of the 1.3.0 delta (new modules first: `daemon-supervisor.ts`, the plugin-approval path) produced ten findings. Each was verified against the source before anything was changed. These are the ones that were real and worth fixing; the rest are listed at the bottom.

## The supervisor probes could say "dead" without having looked

`supervisorJobRunning`'s own doc comment states the rule — *"`undefined` means the supervisor did not answer, which is not 'it died': the caller keeps waiting"* — and all three probes had a way to break it.

- **schtasks localizes its status VALUES, not just its headers.** `/^Status:\s+Running/` is not a test for "is it running": on a Korean Windows it fails to match a *running* job and the probe answered `false`. That made `convergeInstalledSupervision` stop a healthy supervised daemon to "hand it over", and collapsed `waitForRestartedDaemon`'s 180s ceiling to its 20s floor for a false "daemon did not come back".
- **The launchd `catch` returned `false` for any `execFileSync` failure.** Its comment only justifies the booted-out case, but a 5s timeout under the load of a restart took the same branch. Only a command that ran and exited non-zero carries a numeric `status`; a timeout or a missing binary does not.
- **systemd read anything but `active` as dead, `activating` included.** With `Restart=on-failure`, a unit in backoff answers exactly that, seconds before the daemon returns.
- **`supervisorPosture` answered `[]` when it could not read the unit** — which reads as "the unit bakes the default posture", not "unknown". A Windows scheduled task has no unit file at all (`windows-service.ts` deletes the XML after `schtasks /Create`), so every `daemon restart` on a `--local` machine compared its inherited `--local` against a fabricated default, took the `posture-mismatch` branch, printed a claim about the task that was not true, and forked an **unsupervised** daemon. `routeDaemonLifecycle` already models the third answer, so passing it through is the whole fix.

Parsing is split into three named helpers so the Windows and systemd cases are testable from any desk.

## Closing one approval stopped showing the other one

The two approval queues are independent and the deck shows one question at a time. `activePendingApproval`'s doc promises the queued one "surfaces automatically the moment the shown one resolves". The row fields did; **the state did not**.

Every close path emitted `spinner_start`/`idle` unconditionally, and the daemon maps those straight onto `gatewaySessionState`, so the Gateway row left `awaiting_permission` while a live approval was still waiting — `sessionTier` stopped returning `attention`, no surface rendered PERM, and `getPendingApproval()` kept handing the row a question nobody would show. **The user saw an idle deck and the agent stayed blocked.** The same held for an expiry or abandon of one kind while the other was live, and for a resolution of an approval we do not track, which stole the state from one we do.

Two more from the same area:

- **A second plugin approval silently discarded the first.** Unlike exec approvals — serialized by the one chat turn that blocks on them — plugin approvals come from independent plugins and cron jobs and can genuinely overlap. The displaced one stayed pending on the Gateway, unanswerable from any surface, with its `tool_request` row stuck at `pending`.
- **A failing `exec.approval.list` skipped the plugin catch-up entirely**, because the two shared one `await` chain. That is the exact "blocked on an approval that exists on one side only" failure the function was written to prevent, and the caller's lone `.catch()` only debug-logs it.

**Swift had the same bug and worse:** both resolution paths also set `gatewayPendingApproval = nil`, so the survivor lost its row as well as its state. Fixed in the same shape.

## Verification

Node: full suite **4,477 passed, 1 skipped**; build, typecheck, `generate-protocol` (no drift), tokens, docs, design-system all pass.

Swift: `xcodebuild -scheme AgentDeck_macOS` builds, and the macOS suite runs 853 tests with **the same single failure before and after** — `CollaborationFeedTests.testRenderCollaborationHistoryAtRailWidth` ("InvalidTransition"), which reproduces on an unmodified checkout of `origin/master`. It belongs to the base, not to this change, and is worth its own issue.

Every new test was mutation-checked against the shipped behaviour rather than trusted for being green: reverting each fix turns its tests red. The existing coexistence test asserted only `getPendingApproval()`, which is why the approval bug shipped at all.

## Findings not fixed here

- `launchctl bootout` marked `optional` makes a real failure indistinguishable from "never loaded", and `stopDaemon` then prints neither the success line nor the restart warning.
- `--local`/`--loopback` are treated as unexpressible by the unit even when the unit bakes exactly that posture, so a redundant `--local` on restart leaves the machine unsupervised until next login.

Both are real and both are `daemon stop`/`restart` ergonomics rather than wrong state; they want their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)